### PR TITLE
add parameter enable_mkldnn for deploy

### DIFF
--- a/deploy/hubserving/ocr_det/params.py
+++ b/deploy/hubserving/ocr_det/params.py
@@ -10,7 +10,8 @@ class Config(object):
 
 def read_params():
     cfg = Config()
-    
+
+    cfg.enable_mkldnn = False
     #params for text detector
     cfg.det_algorithm = "DB"
     cfg.det_model_dir = "./inference/ch_det_mv3_db/"

--- a/deploy/hubserving/ocr_rec/params.py
+++ b/deploy/hubserving/ocr_rec/params.py
@@ -10,7 +10,8 @@ class Config(object):
 
 def read_params():
     cfg = Config()
-    
+
+    cfg.enable_mkldnn = False
     # #params for text detector
     # cfg.det_algorithm = "DB"
     # cfg.det_model_dir = "./inference/ch_det_mv3_db/"

--- a/deploy/hubserving/ocr_system/params.py
+++ b/deploy/hubserving/ocr_system/params.py
@@ -10,7 +10,8 @@ class Config(object):
 
 def read_params():
     cfg = Config()
-    
+
+    cfg.enable_mkldnn = False
     #params for text detector
     cfg.det_algorithm = "DB"
     cfg.det_model_dir = "./inference/ch_det_mv3_db/"


### PR DESCRIPTION
hub 部署由于缺少参数报错, 需要添加 enable_mkldnn 参数:
AttributeError: 'Config' object has no attribute 'enable_mkldnn'