### PR TITLE
fix lite crash bug

### DIFF
--- a/deploy/lite/db_post_process.cc
+++ b/deploy/lite/db_post_process.cc
@@ -112,7 +112,7 @@ OrderPointsClockwise(std::vector<std::vector<int>> pts) {
 }
 
 std::vector<std::vector<float>> GetMiniBoxes(cv::RotatedRect box, float &ssid) {
-  ssid = std::max(box.size.width, box.size.height);
+  ssid = std::min(box.size.width, box.size.height);
 
   cv::Mat points;
   cv::boxPoints(box, points);


### PR DESCRIPTION
这个bug会使db_post_process.cc中的Uclip函数中的points为空，从而在使用minAreaRect(points)时发送崩溃