### PR TITLE
因字典是无序的而造成的逻辑错误

### DIFF
--- a/ppocr/modeling/architectures/rec_model.py
+++ b/ppocr/modeling/architectures/rec_model.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from collections import OrderedDict
+
 from paddle import fluid
 
 from ppocr.utils.utility import create_module
@@ -215,16 +217,15 @@ class RecModel(object):
                 label = labels['label']
             if self.loss_type == 'srn':
                 total_loss, img_loss, word_loss = self.loss(predicts, labels)
-                outputs = {
-                    'total_loss': total_loss,
-                    'img_loss': img_loss,
-                    'word_loss': word_loss,
-                    'decoded_out': decoded_out,
-                    'label': label
-                }
+                outputs = OrderedDict([('total_loss', total_loss), 
+                                       ('img_loss', img_loss), 
+                                       ('word_loss', word_loss), 
+                                       ('decoded_out', decoded_out),
+                                       ('label', label)])
             else:
-                outputs = {'total_loss':loss, 'decoded_out':\
-                    decoded_out, 'label':label}
+                outputs = OrderedDict([('total_loss', total_loss), 
+                                       ('decoded_out', decoded_out),
+                                       ('label', label)])
             return loader, outputs
         # export_model
         elif mode == "export":
@@ -233,16 +234,15 @@ class RecModel(object):
                 predict = fluid.layers.softmax(predict)
             if self.loss_type == "srn":
                 return [
-                    image, labels, {
-                        'decoded_out': decoded_out,
-                        'predicts': predict
-                    }
-                ]
+                    image, labels, OrderedDict([('decoded_out', decoded_out), 
+                                                ('predicts', predict)])]
 
-            return [image, {'decoded_out': decoded_out, 'predicts': predict}]
+            return [image, OrderedDict([('decoded_out', decoded_out), 
+                                        ('predicts', predict)])]
         # eval or test
         else:
             predict = predicts['predict']
             if self.loss_type == "ctc":
                 predict = fluid.layers.softmax(predict)
-            return loader, {'decoded_out': decoded_out, 'predicts': predict}
+            return loader, OrderedDict([('decoded_out', decoded_out), 
+                                        ('predicts', predict)])


### PR DESCRIPTION
环境: docker hub上的paddlepaddle/paddle:latest-gpu-cuda10.1-cudnn7镜像（注意: 该镜像是python3.5）
问题: python3.6之前的dict类是无序的，导致tools/program.py文件中build函数里的fetch_name_list是无序的
造成现象: 出现验证准确率可能是正确的，可能是直接为0，因为验证时取得的preds可能是softmax后的分布结果，而不是decode后的结果。

我只使用了字符识别的代码，所以其他部分在python3.6以下的版本可能也会出现相关的问题，需要开发者审核一下。

建议: 使用OrderedDict代替dict。