### PR TITLE
大角度倾斜旋转校正——基于文本检测模型

### DIFF
--- a/tools/infer/calibrate_image.py
+++ b/tools/infer/calibrate_image.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(__dir__)
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
+
+import cv2
+import copy
+import numpy as np
+import math
+import time
+import sys
+
+import paddle.fluid as fluid
+
+import tools.infer.utility as utility
+from ppocr.utils.utility import initial_logger
+logger = initial_logger()
+from ppocr.utils.utility import get_image_file_list, check_and_read_gif
+from ppocr.data.det.sast_process import SASTProcessTest
+from ppocr.data.det.east_process import EASTProcessTest
+from ppocr.data.det.db_process import DBProcessTest
+from ppocr.postprocess.db_postprocess import DBPostProcess
+from ppocr.postprocess.east_postprocess import EASTPostPocess
+from ppocr.postprocess.sast_postprocess import SASTPostProcess
+
+import tools.infer.predict_det as predict_det
+
+
+# from urs/transform
+def get_rotated_size(w, h, theta):
+    # 以中心为原心为旋转
+    half_w = int(w // 2 + 1)
+    half_h = int(h // 2 + 1)
+    # 对右下顶点进行旋转，最大的宽度和高度
+    new_w1 = (math.cos(theta) * half_w - math.sin(theta) * half_h) * 2
+    new_h1 = (math.sin(theta) * half_w + math.cos(theta) * half_h) * 2
+    # print("image shape : {}, (new_w, new_h) : {},{}".format((w, h), new_w1, new_h1))
+
+    # 对右上顶点进行旋转，最大的宽度和高度
+    new_w2 = (math.cos(theta) * half_w - math.sin(theta) * -half_h) * 2
+    new_h2 = (math.sin(theta) * half_w + math.cos(theta) * -half_h) * 2
+    # print("image shape : {}, (new_w, new_h) : {},{}".format((w, h), new_w2, new_h2))
+
+    # 求出最大的宽度和高度
+    new_w = int(max(abs(new_w1), abs(new_w2)))
+    new_h = int(max(abs(new_h1), abs(new_h2)))
+    # print(new_w, new_h)
+    return new_w, new_h
+
+
+# from urs/transform
+def rotate_image(img, theta):
+    h, w = img.shape[:2]
+    M = cv2.getRotationMatrix2D((w // 2, h // 2), math.degrees(theta), 1.0)
+    new_w, new_h = get_rotated_size(w, h, theta)
+    # return cv2.warpAffine(img, M, (new_w, new_h), flags=cv2.INTER_CUBIC)
+    M[0, 2] += (new_w - w) // 2
+    M[1, 2] += (new_h - h) // 2
+    return cv2.warpAffine(img, M, (new_w, new_h))
+
+
+# from urs/transform
+# 假设最长的5个文本条的方向就是图像的方向
+def get_rotated_radian(text_boxes):
+    long_side_list = []
+    theta_list = []
+    for box in text_boxes:
+        d12 = math.sqrt((box[0] - box[2]) ** 2 + (box[1] - box[3]) ** 2)
+        d14 = math.sqrt((box[0] - box[6]) ** 2 + (box[1] - box[7]) ** 2)
+        if d12 >= d14:
+            long_side_list.append(d12)
+            theta = (box[3] - box[1]) / (box[2] - box[0] + 0.001)
+        else:
+            long_side_list.append(d14)
+            theta = (box[7] - box[1]) / (box[6] - box[0] + 0.001)
+        theta_list.append(math.atan(theta))
+    indies = np.argsort(long_side_list)[::-1][:5]
+    top_theta_list = [theta_list[i] for i in indies]
+    top_theta_indies = np.argsort(top_theta_list)
+    return top_theta_list[top_theta_indies[len(top_theta_list)//2]]
+
+
+def length(x1, y1, x2, y2):
+    return math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
+
+
+def get_box_length(box):
+    t = length(box[0, 0], box[0, 1], box[1, 0], box[1, 1])
+    r = length(box[1, 0], box[1, 1], box[2, 0], box[2, 1])
+    b = length(box[2, 0], box[2, 1], box[3, 0], box[3, 1])
+    l = length(box[3, 0], box[3, 1], box[0, 0], box[0, 1])
+    return t, r, b, l
+
+
+def check_box_num(boxes, ratio=3.0):
+    num = 0
+    for box in boxes:
+        # print(type(box), box)
+        t, r, b, l = get_box_length(box)
+        if (t + b) / (l + r) >= ratio or (l + r) / (t + b) >= ratio:
+            num += 1
+    return num
+
+
+# 假设获取的文本框越长，检测的效果越好。
+def check_box_score(boxes, ratio=2.0):
+    score = 0
+    for box in boxes:
+        # print(type(box), box)
+        t, r, b, l = get_box_length(box)
+        if (t + b) / (l + r) >= ratio:
+            score += (t + b) / (l + r)
+        elif (l + r) / (t + b) >= ratio:
+            score += (l + r) / (t + b)
+    return score
+
+
+def calibrate_img(text_detector, img, image_file, out_dir):
+    total_time = 0
+    # 添加4个旋转后图像
+    imgs = [img]
+    for theta in [math.pi / 8, math.pi / 4, math.pi * 3 / 8, math.pi / 2]:
+        imgs.append(rotate_image(img, theta))
+
+    # 对5个图像分别检测文本框，并以长文本框数量第一次计算最佳旋转角度
+    dt_boxes_list = []
+    max_valid_score = 0
+    score_list = []
+    for i in range(len(imgs)):
+        dt_boxes, elapse = text_detector(imgs[i])
+        total_time += elapse
+        dt_boxes_list.append(dt_boxes)
+        # elapse_list.append(elapse)
+        score = check_box_score(dt_boxes, 3)
+        if score > max_valid_score:
+            max_valid_score = score
+        print("Predict time of:{}-{}， boxes:{}-{}，time:{}".format(image_file, i, len(dt_boxes), int(score), elapse))
+        score_list.append(score)
+        '''
+        src_im = utility.draw_text_det_res2(dt_boxes_list[i], imgs[i])
+        new_filename = "det_res_{}-{}-{}.png".format(img_name_pure, i, int(score_list[i]))
+        cv2.imwrite(os.path.join(draw_img_save, new_filename), src_im)
+        '''
+
+    index = score_list.index(max_valid_score)
+    if len(dt_boxes_list[index]) < 1:
+        return img, None, 0
+    theta = get_rotated_radian(dt_boxes_list[index].reshape((-1, 8)).tolist())
+    print("get_rotated_radian : {}".format(theta))
+    theta += index * math.pi / 8
+    rotate_angle = math.degrees(theta)
+    print("判断图像的旋转方向 {} {}".format(theta, rotate_angle))
+
+    h, w = img.shape[:2]
+    # h, w = imgs[index].shape[:2]
+    M = cv2.getRotationMatrix2D((w / 2, h / 2), rotate_angle, 1.0)
+    print("M : {}".format(M))
+    new_w, new_h = get_rotated_size(w, h, theta)
+    M[0, 2] += (new_w - w) // 2
+    M[1, 2] += (new_h - h) // 2
+    print("image shape : {}, (new_w, new_h) : {},{}".format((h, w), new_w, new_h))
+    # image = cv2.warpAffine(image, M, (new_w, new_h), flags=cv2.INTER_CUBIC)
+    image = cv2.warpAffine(img, M, (new_w, new_h))
+    # image = cv2.warpAffine(imgs[index], M, (new_w, new_h))
+    dt_boxes, elapse = text_detector(image)
+    print("Predict time of:{}， boxes:{}，time:{}".format(image_file, len(dt_boxes), elapse))
+    return image, dt_boxes, rotate_angle
+
+
+if __name__ == "__main__":
+    args = utility.parse_args()
+    image_file_list = get_image_file_list(args.image_dir)
+    text_detector = predict_det.TextDetector(args)
+    count = 0
+    total_time = 0
+    draw_img_save = "./inference_results"
+    if not os.path.exists(draw_img_save):
+        os.makedirs(draw_img_save)
+    for image_file in image_file_list:
+        img, flag = check_and_read_gif(image_file)
+        if not flag:
+            img = cv2.imread(image_file)
+        if img is None:
+            logger.info("error in loading image:{}".format(image_file))
+            continue
+        count += 1
+        image, dt_boxes, rotate_angle = calibrate_img(text_detector, img, image_file, draw_img_save)
+        if dt_boxes is not None and len(dt_boxes) > 0:
+            image = utility.draw_text_det_res2(dt_boxes, image)
+        img_name_pure = os.path.basename(image_file)
+        new_filename = "res_{}-{}.png".format(img_name_pure, int(rotate_angle))
+        cv2.imwrite(os.path.join(draw_img_save, new_filename), image)
+        # break
+    if count > 1:
+        print("Avg Time:", total_time / (count - 1))

--- a/tools/infer/calibrate_image.py
+++ b/tools/infer/calibrate_image.py
@@ -149,6 +149,7 @@ def calibrate_img(text_detector, img, image_file, out_dir):
         score_list.append(score)
         '''
         src_im = utility.draw_text_det_res2(dt_boxes_list[i], imgs[i])
+        img_name_pure = os.path.basename(image_file)
         new_filename = "det_res_{}-{}-{}.png".format(img_name_pure, i, int(score_list[i]))
         cv2.imwrite(os.path.join(draw_img_save, new_filename), src_im)
         '''

--- a/tools/infer/calibrate_image.py
+++ b/tools/infer/calibrate_image.py
@@ -51,8 +51,9 @@ logger = initial_logger()
 
 def get_rotated_size(w, h, theta):
     # 以中心为原心为旋转
-    half_w = int(w // 2 + 1)
-    half_h = int(h // 2 + 1)
+    # half_w = int(w // 2 + 1)
+    # half_h = int(h // 2 + 1)
+    half_w, half_h = w / 2, h / 2
     # 对右下顶点进行旋转，最大的宽度和高度
     new_w1 = (math.cos(theta) * half_w - math.sin(theta) * half_h) * 2
     new_h1 = (math.sin(theta) * half_w + math.cos(theta) * half_h) * 2
@@ -64,8 +65,8 @@ def get_rotated_size(w, h, theta):
     # print("image shape : {}, (new_w, new_h) : {},{}".format((w, h), new_w2, new_h2))
 
     # 求出最大的宽度和高度
-    new_w = int(max(abs(new_w1), abs(new_w2)))
-    new_h = int(max(abs(new_h1), abs(new_h2)))
+    new_w = round(max(abs(new_w1), abs(new_w2)))
+    new_h = round(max(abs(new_h1), abs(new_h2)))
     # print(new_w, new_h)
     return new_w, new_h
 

--- a/tools/infer/calibrate_image.py
+++ b/tools/infer/calibrate_image.py
@@ -40,7 +40,6 @@ from ppocr.postprocess.sast_postprocess import SASTPostProcess
 import tools.infer.predict_det as predict_det
 
 
-# from urs/transform
 def get_rotated_size(w, h, theta):
     # 以中心为原心为旋转
     half_w = int(w // 2 + 1)
@@ -62,7 +61,6 @@ def get_rotated_size(w, h, theta):
     return new_w, new_h
 
 
-# from urs/transform
 def rotate_image(img, theta):
     h, w = img.shape[:2]
     M = cv2.getRotationMatrix2D((w // 2, h // 2), math.degrees(theta), 1.0)
@@ -73,7 +71,6 @@ def rotate_image(img, theta):
     return cv2.warpAffine(img, M, (new_w, new_h))
 
 
-# from urs/transform
 # 假设最长的5个文本条的方向就是图像的方向
 def get_rotated_radian(text_boxes):
     long_side_list = []

--- a/tools/infer/calibrate_image.py
+++ b/tools/infer/calibrate_image.py
@@ -267,7 +267,7 @@ def calibrate_img(text_detector, img, image_file, out_dir, debug=False):
         rotate_angle1 = math.degrees(theta1)
         logger.debug("第一次旋转：文本框数量1：{}，旋转角度1：{}, score1: {}".format(len(boxes1), rotate_angle1, score1))
         img_name_pure = os.path.basename(image_file)
-        new_filename = "{}.1-rotate.{}.{}.png".format(img_name_pure, int(rotate_angle1), int(score1))
+        new_filename = "{}.1-rotate.{}.{}.jpg".format(img_name_pure, int(rotate_angle1), int(score1))
         cv2.imwrite(os.path.join(out_dir, new_filename), utility.draw_text_det_res2(boxes1, img1))
 
     # 2 计算文本框旋转角度
@@ -282,7 +282,7 @@ def calibrate_img(text_detector, img, image_file, out_dir, debug=False):
     score2 = check_box_score(boxes2)
     if debug:
         logger.debug("第二次旋转:boxes2:{}, 旋转角度2：{}， score2:{}".format(len(boxes2), rotate_angle2, score2))
-        new_filename = "{}.2-rotate.{}.{}.png".format(img_name_pure, int(rotate_angle2), int(score2))
+        new_filename = "{}.2-rotate.{}.{}.jpg".format(img_name_pure, int(rotate_angle2), int(score2))
         cv2.imwrite(os.path.join(draw_img_save, new_filename), utility.draw_text_det_res2(boxes2, img2))
 
     # 3 找到文本区域的四边形顶点
@@ -309,8 +309,10 @@ def calibrate_img(text_detector, img, image_file, out_dir, debug=False):
     if debug:
         img3_show = img3.copy()
         cv2.polylines(img3_show, [pts1.astype(np.int)], True, color=(255, 0, 0), thickness=4)
-        cv2.imwrite(os.path.join(draw_img_save, "{}.3-rectify.png".format(img_name_pure)), img3_show)
-        cv2.imwrite(os.path.join(draw_img_save, "{}.4-rectify.png".format(img_name_pure)), img4)
+        cv2.imwrite(os.path.join(draw_img_save, "{}.3-rectify.jpg".format(img_name_pure)), img3_show)
+        boxes4, elapse4 = text_detector(img4)
+        cv2.imwrite(os.path.join(draw_img_save, "{}.4-rectify.jpg".format(img_name_pure)),
+                    utility.draw_text_det_res2(boxes4, img4))
     return img2, boxes2, theta2
 
 
@@ -331,6 +333,13 @@ if __name__ == "__main__":
             logger.info("error in loading image:{}".format(image_file))
             continue
         count += 1
+        h, w = img.shape[:2]
+        print(image_file, img.shape)
+        if w > 2000 and w >= h:
+            img = cv2.resize(img, (2000, round(2000 * h / w)))
+        elif h > 2000 and h >= w:
+            img = cv2.resize(img, (round(2000 * w / h), 2000))
+        print(img.shape)
         image, dt_boxes, rotate_angle = calibrate_img(text_detector, img, image_file, draw_img_save, debug=True)
         # if dt_boxes is not None and len(dt_boxes) > 0:
         #     image = utility.draw_text_det_res2(dt_boxes, image)

--- a/tools/infer/calibrate_image2.py
+++ b/tools/infer/calibrate_image2.py
@@ -1,0 +1,140 @@
+import os
+import sys
+__dir__ = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(__dir__)
+sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
+
+import cv2
+import copy
+import numpy as np
+import math
+import time
+import sys
+
+import paddle.fluid as fluid
+
+import tools.infer.utility as utility
+from ppocr.utils.utility import initial_logger
+logger = initial_logger()
+from ppocr.utils.utility import get_image_file_list, check_and_read_gif
+from ppocr.data.det.sast_process import SASTProcessTest
+from ppocr.data.det.east_process import EASTProcessTest
+from ppocr.data.det.db_process import DBProcessTest
+from ppocr.postprocess.db_postprocess import DBPostProcess
+from ppocr.postprocess.east_postprocess import EASTPostPocess
+from ppocr.postprocess.sast_postprocess import SASTPostProcess
+
+import tools.infer.predict_det as predict_det
+from calibrate_image import get_rotated_size, check_box_score
+# from calibrate_image import rotate_image, rotate_first
+
+
+def rotate_image2(img, theta):
+    h, w = img.shape[:2]
+    M = cv2.getRotationMatrix2D((w / 2, h / 2), math.degrees(theta), 1.0)
+    new_w, new_h = get_rotated_size(w, h, theta)
+    # return cv2.warpAffine(img, M, (new_w, new_h), flags=cv2.INTER_CUBIC)
+    M[0, 2] += (new_w - w) / 2
+    M[1, 2] += (new_h - h) / 2
+
+    center = (w / 2, h / 2)
+    lt = np.array([new_w/2, new_h/2]) + M[0:2, 0:2].dot(np.array((0, 0)) - np.array(center))
+    rt = np.array([new_w/2, new_h/2]) + M[0:2, 0:2].dot(np.array((w - 1, 0)) - np.array(center))
+    rb = np.array([new_w/2, new_h/2]) + M[0:2, 0:2].dot(np.array((w - 1, h - 1)) - np.array(center))
+    lb = np.array([new_w/2, new_h/2]) + M[0:2, 0:2].dot(np.array((0, h - 1)) - np.array(center))
+    # img_box = [round(x) for x in np.array([lt, rt, rb, lb]).reshape((8,)).tolist()]
+    img_box = np.array([lt, rt, rb, lb]).astype(int)
+    # print(theta, img_box)
+    return cv2.warpAffine(img, M, (new_w, new_h)), img_box
+
+
+def rotate_first2(text_detector, img):
+    # 添加4个旋转后图像
+    imgs = [img]
+    h, w = img.shape[:2]
+    img_box_list = [np.array([[0, 0], [w-1, 0], [w-1, h-1], [0, h-1]])]
+    for theta in [math.pi / 8, math.pi / 4, math.pi * 3 / 8, math.pi / 2]:
+        new_img, new_box = rotate_image2(img, theta)
+        imgs.append(new_img)
+        img_box_list.append(new_box)
+    print(img_box_list)
+
+    # 对5个图像分别检测文本框，并以长文本框数量第一次计算最佳旋转角度
+    dt_boxes_list = []
+    max_valid_score = 0
+    score_list = []
+    for i in range(len(imgs)):
+        dt_boxes, elapse = text_detector(imgs[i])
+        dt_boxes_list.append(dt_boxes)
+        score = check_box_score(dt_boxes, 3)
+        if score > max_valid_score:
+            max_valid_score = score
+        logger.debug("Predict time of:{}-{}， boxes:{}-{}".format(i, elapse, len(dt_boxes), int(score)))
+        score_list.append(score)
+    index = score_list.index(max_valid_score)
+    if len(dt_boxes_list[index]) < 1:
+        return img, None, 0
+    return imgs[index], dt_boxes_list[index], index * math.pi / 8, max_valid_score, img_box_list[index]
+
+
+def calibrate_img2(text_detector, img, image_file, out_dir, debug=False):
+    # 1 通过多次旋转图片，初步找到旋转角度
+    img1, boxes1, theta1, score1, img_box1 = rotate_first2(text_detector, img)
+    if debug:
+        print('img_box1 : ', img_box1)
+        rotate_angle1 = math.degrees(theta1)
+        logger.debug("第一次旋转：文本框数量1：{}，旋转角度1：{}, score1: {}".format(len(boxes1), rotate_angle1, score1))
+        new_filename = "{}.1-rotate.{}.{}.jpg".format(os.path.basename(image_file), int(rotate_angle1), int(score1))
+        cv2.imwrite(os.path.join(out_dir, new_filename), utility.draw_text_det_res2(boxes1, img1))
+
+    img_mask = np.zeros(img1.shape[:2], dtype=np.uint8)
+    cv2.fillConvexPoly(img_mask, img_box1, (255, ))
+
+    img_gray = cv2.cvtColor(img1, cv2.COLOR_BGR2GRAY)
+    img_gaus = cv2.GaussianBlur(img_gray, (5, 5), 0)
+    # Implementation has been removed due original code license issues in function 'LineSegmentDetectorImpl'
+    # LSD = cv2.createLineSegmentDetector(0, _scale=1)
+    # lines = LSD.detect(img_gray)
+    fld = cv2.ximgproc.createFastLineDetector()
+    lines = fld.detect(img_gaus)
+    drawn_img = fld.drawSegments(img1, lines)
+    print(lines)
+    # image, dt_boxes, rotate_angle = calibrate_img(text_detector, img, image_file, draw_img_save, debug=True)
+    # if dt_boxes is not None and len(dt_boxes) > 0:
+    #     image = utility.draw_text_det_res2(dt_boxes, image)
+    if debug:
+        new_filename = "{}-mask.png".format(os.path.basename(image_file))
+        cv2.imwrite(os.path.join(draw_img_save, new_filename), img_mask)
+
+        new_filename = "{}-{}.png".format(os.path.basename(image_file), len(lines))
+        cv2.imwrite(os.path.join(draw_img_save, new_filename), drawn_img)
+
+
+if __name__ == "__main__":
+    args = utility.parse_args()
+    image_file_list = get_image_file_list(args.image_dir)
+    text_detector = predict_det.TextDetector(args)
+    count = 0
+    total_time = 0
+    draw_img_save = "./inference_results"
+    if not os.path.exists(draw_img_save):
+        os.makedirs(draw_img_save)
+    for image_file in image_file_list:
+        img, flag = check_and_read_gif(image_file)
+        if not flag:
+            img = cv2.imread(image_file)
+        if img is None:
+            logger.info("error in loading image:{}".format(image_file))
+            continue
+        count += 1
+        h, w = img.shape[:2]
+        print(image_file, img.shape)
+        if w > 2000 and w >= h:
+            img = cv2.resize(img, (2000, round(2000 * h / w)))
+        elif h > 2000 and h >= w:
+            img = cv2.resize(img, (round(2000 * w / h), 2000))
+        print(img.shape)
+        calibrate_img2(text_detector, img, image_file, draw_img_save, debug=True)
+        break
+    if count > 1:
+        print("Avg Time:", total_time / (count - 1))

--- a/tools/infer/calibrate_image2.py
+++ b/tools/infer/calibrate_image2.py
@@ -2,6 +2,7 @@ import os
 import sys
 __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
+from line_seg import LineSeg
 sys.path.append(os.path.abspath(os.path.join(__dir__, '../..')))
 
 import cv2
@@ -25,8 +26,11 @@ from ppocr.postprocess.east_postprocess import EASTPostPocess
 from ppocr.postprocess.sast_postprocess import SASTPostProcess
 
 import tools.infer.predict_det as predict_det
-from calibrate_image import get_rotated_size, check_box_score
+from calibrate_image import get_rotated_size, check_box_score, get_box_length, length
 # from calibrate_image import rotate_image, rotate_first
+_debug = True
+_out_dir = './inference_results'
+_img_base_name = ''
 
 
 def rotate_image2(img, theta):
@@ -49,10 +53,18 @@ def rotate_image2(img, theta):
 
 
 def rotate_first2(text_detector, img):
+    '''
+    return :
+        旋转后图像
+        文本框列表
+        旋转角度
+        评价分数
+        有效区域
+    '''
     # 添加4个旋转后图像
     imgs = [img]
     h, w = img.shape[:2]
-    img_box_list = [np.array([[0, 0], [w-1, 0], [w-1, h-1], [0, h-1]])]
+    img_box_list = [np.array([[0, 0], [w, 0], [w, h], [0, h]])]
     for theta in [math.pi / 8, math.pi / 4, math.pi * 3 / 8, math.pi / 2]:
         new_img, new_box = rotate_image2(img, theta)
         imgs.append(new_img)
@@ -73,41 +85,240 @@ def rotate_first2(text_detector, img):
         score_list.append(score)
     index = score_list.index(max_valid_score)
     if len(dt_boxes_list[index]) < 1:
-        return img, None, 0
+        return img, None, 0, 0, img_box_list[0]
     return imgs[index], dt_boxes_list[index], index * math.pi / 8, max_valid_score, img_box_list[index]
 
 
-def calibrate_img2(text_detector, img, image_file, out_dir, debug=False):
-    # 1 通过多次旋转图片，初步找到旋转角度
-    img1, boxes1, theta1, score1, img_box1 = rotate_first2(text_detector, img)
-    if debug:
-        print('img_box1 : ', img_box1)
-        rotate_angle1 = math.degrees(theta1)
-        logger.debug("第一次旋转：文本框数量1：{}，旋转角度1：{}, score1: {}".format(len(boxes1), rotate_angle1, score1))
-        new_filename = "{}.1-rotate.{}.{}.jpg".format(os.path.basename(image_file), int(rotate_angle1), int(score1))
-        cv2.imwrite(os.path.join(out_dir, new_filename), utility.draw_text_det_res2(boxes1, img1))
+def get_img_mask(img, box, boxes):
+    '''
+    有效区域为box
+    文本框区域为无效区域
+    '''
+    img_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+    center, size, angle = cv2.minAreaRect(box)
+    size = (size[0] - 10, size[1] - 10)
+    print(center, size, angle)
+    img_box = cv2.boxPoints((center, size, angle))
+    print(img_box, type(img_box))
+    cv2.fillConvexPoly(img_mask, img_box.astype(int), (255,))
+    for box in boxes:
+        cv2.fillConvexPoly(img_mask, box.astype(np.int), (0,))
+    if _debug:
+        new_filename = "{}.11-mask.png".format(_img_base_name)
+        cv2.imwrite(os.path.join(_out_dir, new_filename), img_mask)
+    return img_mask
 
-    img_mask = np.zeros(img1.shape[:2], dtype=np.uint8)
-    cv2.fillConvexPoly(img_mask, img_box1, (255, ))
 
-    img_gray = cv2.cvtColor(img1, cv2.COLOR_BGR2GRAY)
+def get_lines_by_box(boxes):
+    box_height_list = []
+    lines_valid_text_box = []
+    for box in boxes:
+        # print(box, type(box))
+        t, r, b, l = get_box_length(box)
+        box_width = (t + b) / 2
+        box_height = (l + r) / 2
+        # box_height_list.append(min(box_width, box_height))
+        # 大于文本框宽高比大于2倍的才算作有效直线
+        if box_width > box_height * 2:
+            lines_valid_text_box.append([[box[0, 0], box[0, 1], box[1, 0], box[1, 1]]])
+            lines_valid_text_box.append([[box[3, 0], box[3, 1], box[2, 0], box[2, 1]]])
+            box_height_list.append(box_height)
+        elif box_height > box_width * 2:
+            lines_valid_text_box.append([[box[0, 0], box[0, 1], box[3, 0], box[3, 1]]])
+            lines_valid_text_box.append([[box[1, 0], box[1, 1], box[2, 0], box[2, 1]]])
+            box_height_list.append(box_width)
+    # img_mask = cv2.erode(img_mask, np.ones((9, 9), np.uint8), iterations=1)
+    box_height_avg = np.median(box_height_list)
+    print('box_height_avg:', box_height_avg)
+    print('lines-valid-textbox:', lines_valid_text_box, type(lines_valid_text_box))
+    return lines_valid_text_box, box_height_avg
+
+
+def get_lines_by_ld(img, img_mask, box_height_avg):
+    # 找出非文本有效区域内检测到的线段
+    img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     img_gaus = cv2.GaussianBlur(img_gray, (5, 5), 0)
     # Implementation has been removed due original code license issues in function 'LineSegmentDetectorImpl'
     # LSD = cv2.createLineSegmentDetector(0, _scale=1)
     # lines = LSD.detect(img_gray)
     fld = cv2.ximgproc.createFastLineDetector()
     lines = fld.detect(img_gaus)
-    drawn_img = fld.drawSegments(img1, lines)
-    print(lines)
-    # image, dt_boxes, rotate_angle = calibrate_img(text_detector, img, image_file, draw_img_save, debug=True)
-    # if dt_boxes is not None and len(dt_boxes) > 0:
-    #     image = utility.draw_text_det_res2(dt_boxes, image)
-    if debug:
-        new_filename = "{}-mask.png".format(os.path.basename(image_file))
-        cv2.imwrite(os.path.join(draw_img_save, new_filename), img_mask)
+    lines_valid = []
+    for i, line in enumerate(lines):
+        line = line[0].astype(np.int)
+        x1, y1, x2, y2 = line[0], line[1], line[2], line[3]
+        # 大于文本高度1.5倍的才算有效的直线
+        if img_mask[y1, x1] > 0 and img_mask[y2, x2] > 0 and length(x1, y1, x2, y2) > box_height_avg * 1.5:
+            lines_valid.append(lines[i])
+    lines_valid = np.array(lines_valid)
+    print('lines(fld):')
+    print(lines, type(lines), lines.shape)
+    print('lines(fld-valid):')
+    print(lines_valid, type(lines_valid), lines_valid.shape)
+    if _debug:
+        '''
+        drawn_img = img.copy()
+        for line in lines:
+            x1, y1, x2, y2 = line[0]
+            cv2.line(drawn_img, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        new_filename = "{}.22-lines_fld.png".format(_img_base_name)
+        cv2.imwrite(os.path.join(_out_dir, new_filename), drawn_img)
+        '''
+        drawn_img = img.copy()
+        for line in lines_valid:
+            x1, y1, x2, y2 = line[0]
+            cv2.line(drawn_img, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        new_filename = "{}.22-lines_fld_valid.png".format(_img_base_name)
+        cv2.imwrite(os.path.join(_out_dir, new_filename), drawn_img)
+    return lines_valid
 
-        new_filename = "{}-{}.png".format(os.path.basename(image_file), len(lines))
-        cv2.imwrite(os.path.join(draw_img_save, new_filename), drawn_img)
+
+def lines_split_by_direction(lines, lines_valid_hor, lines_valid_ver):
+    for line in lines:
+        x1, y1, x2, y2 = line[0]
+        if abs(x1 - x2) > abs(y1 - y2) * 2:
+            lines_valid_hor.append([[x1, y1, x2, y2]])
+        elif abs(y1 - y2) > abs(x1 - x2) * 2:
+            lines_valid_ver.append([[x1, y1, x2, y2]])
+    return lines_valid_hor, lines_valid_ver
+
+
+def line_infer(line, x):
+    vx = line[0][0]
+    vy = line[1][0]
+    x0 = line[2][0]
+    y0 = line[3][0]
+    y = vy * (x - x0) / vx + y0
+    return round(y)
+
+
+def calibrate_img2(text_detector, img):
+    """
+    """
+    # 1 通过多次旋转图片，初步找到旋转角度
+    img1, boxes1, theta1, score1, img_box1 = rotate_first2(text_detector, img)
+    if _debug:
+        print('img_box1 : ', img_box1, type(img_box1))
+        rotate_angle1 = math.degrees(theta1)
+        logger.debug("第一次旋转：文本框数量1：{}，旋转角度1：{}, score1: {}".format(len(boxes1), rotate_angle1, score1))
+        new_filename = "{}.10-rotate.{}.{}.jpg".format(_img_base_name, int(rotate_angle1), int(score1))
+        cv2.imwrite(os.path.join(_out_dir, new_filename), utility.draw_text_det_res2(boxes1, img1))
+    if len(boxes1) < 4:
+        return img1, boxes1, theta1, score1, img_box1
+
+    # 2 找出非文本有效区域
+    img_mask = get_img_mask(img1, img_box1, boxes1)
+    # 找出文本框的有效直线
+    lines_valid_text_box, box_height_avg = get_lines_by_box(boxes1)
+    if _debug:
+        drawn_img = img1.copy()
+        for line in lines_valid_text_box:
+            print(line, type(line))
+            cv2.line(drawn_img, tuple(line[0][:2]), tuple(line[0][2:4]), (255, 0, 0), 2)
+        new_filename = "{}.21-lines_text-box.png".format(_img_base_name)
+        cv2.imwrite(os.path.join(_out_dir, new_filename), drawn_img)
+    # 找出fld的有效直线
+    lines_valid_fld = get_lines_by_ld(img1, img_mask, box_height_avg)
+    # 有效的横线、有效的竖线
+    lines_valid_hor, lines_valid_ver = [], []
+    lines_valid_hor, lines_valid_ver = lines_split_by_direction(lines_valid_fld, lines_valid_hor, lines_valid_ver)
+    lines_valid_hor, lines_valid_ver = lines_split_by_direction(lines_valid_text_box, lines_valid_hor, lines_valid_ver)
+    if _debug:
+        print("lines_valid_hor : ", lines_valid_hor)
+        print("lines_valid_ver : ", lines_valid_ver)
+        drawn_img = img1.copy()
+        for line in lines_valid_hor:
+            cv2.line(drawn_img, tuple(line[0][:2]), tuple(line[0][2:4]), (255, 0, 0), 2)
+        for line in lines_valid_ver:
+            cv2.line(drawn_img, tuple(line[0][:2]), tuple(line[0][2:4]), (0, 255, 0), 2)
+        cv2.imwrite(os.path.join(_out_dir, _img_base_name + '.23.lines_hor_ver.png'), drawn_img)
+
+    h, w = img1.shape[:2]
+    lineseg_center_cross_x_min = w - 1
+    lineseg_center_cross_x_max = 0
+    lineseg_center_cross_y_min = h - 1
+    lineseg_center_cross_y_max = 0
+    slope_hor_list, slope_ver_list = [], []
+
+    for line in lines_valid_hor:
+        x1, y1, x2, y2 = line[0]
+        # 横线与中竖线交点
+        line_seg = LineSeg(x1, y1, x2, y2)
+        cross_pt_hor = line_seg.get_cross_point(LineSeg(w / 2, 0, w / 2, h - 1))
+        # theta_hor.append([cross_pt_hor[1], 100 * math.degrees(math.atan((y1 - y2) / (x1 - x2)))])
+        slope_hor_list.append([cross_pt_hor[1], 10000 * (y2 - y1) / (x2 - x1)])
+        if cross_pt_hor[1] > lineseg_center_cross_y_max:
+            lineseg_center_cross_y_max = cross_pt_hor[1]
+        if cross_pt_hor[1] < lineseg_center_cross_y_min:
+            lineseg_center_cross_y_min = cross_pt_hor[1]
+    for line in lines_valid_ver:
+        x1, y1, x2, y2 = line[0]
+        # 竖线与中横线交点
+        cross_pt_ver = LineSeg(0, h / 2, w - 1, h / 2).get_cross_point(LineSeg(x1, y1, x2, y2))
+        # theta_ver.append([cross_pt_ver[0], 100 * math.degrees(math.atan((x1 - x2) / (y1 - y2)))])
+        slope_ver_list.append([cross_pt_ver[0], 10000 * (x2 - x1) / (y2 - y1)])
+        if cross_pt_ver[0] > lineseg_center_cross_x_max:
+            lineseg_center_cross_x_max = cross_pt_ver[0]
+        if cross_pt_ver[0] < lineseg_center_cross_x_min:
+            lineseg_center_cross_x_min = cross_pt_ver[0]
+    print("斜率统计结果：")
+    print(slope_hor_list)
+    print(slope_ver_list)
+
+    line_top, line_bottom, line_left, line_right = None, None, None, None
+    line_top_left, line_top_right = None, None
+    line_bot_left, line_bot_right = None, None
+    line_left_top, line_left_bot = None, None
+    line_right_top, line_right_bot = None, None
+    if len(slope_hor_list) > 2:
+        # theta_hor_line = cv2.fitLine(np.array(theta_hor), cv2.DIST_L1, 0, 0.01, 0.01)
+        slope_hor_line = cv2.fitLine(np.array(slope_hor_list), cv2.DIST_L2, 0, 0.01, 0.01)
+        # print('theta_hor_line:', theta_hor_line)
+        print('slope_hor_line : ', slope_hor_line)
+        line_top_pt = (w / 2, lineseg_center_cross_y_min)
+        line_bottom_pt = (w / 2, lineseg_center_cross_y_max)
+        print(line_top_pt, line_bottom_pt)
+        # print(theta_top, theta_bot)
+        slope_top = line_infer(slope_hor_line, line_top_pt[1]) / 10000
+        slope_bot = line_infer(slope_hor_line, line_bottom_pt[1]) / 10000
+        line_top = (-1.0 * slope_top, 1.0, w / 2 * slope_top - line_top_pt[1])
+        line_bottom = (-1.0 * slope_bot, 1.0, w / 2 * slope_bot - line_bottom_pt[1])
+        line_top_left = LineSeg(0, 0, 0, h - 1).get_cross_point_by_param(*line_top)
+        line_top_right = LineSeg(w-1, 0, w-1, h-1).get_cross_point_by_param(*line_top)
+        line_bot_left = LineSeg(0, 0, 0, h - 1).get_cross_point_by_param(*line_bottom)
+        line_bot_right = LineSeg(w-1, 0, w-1, h-1).get_cross_point_by_param(*line_bottom)
+    if len(slope_ver_list) > 2:
+        # theta_ver_line = cv2.fitLine(np.array(theta_ver), cv2.DIST_L1, 0, 0.01, 0.01)
+        slope_ver_line = cv2.fitLine(np.array(slope_ver_list), cv2.DIST_L2, 0, 0.01, 0.01)
+        print('slope_ver_line : ', slope_ver_line)
+        # print('theta_ver_line:', theta_ver_line)
+        line_left_pt = (lineseg_center_cross_x_min, h / 2)
+        line_right_pt = (lineseg_center_cross_x_max, h / 2)
+        print(line_left_pt, line_right_pt)
+        slope_left = line_infer(slope_ver_line, line_left_pt[0]) / 10000
+        slope_right = line_infer(slope_ver_line, line_right_pt[0]) / 10000
+        print(slope_left, slope_right)
+
+        line_left = (1.0, -1.0 * slope_left, h / 2 * slope_left - line_left_pt[0])
+        line_right = (1.0, -1.0 * slope_right, h / 2 * slope_right - line_right_pt[0])
+        line_left_top = LineSeg(0, 0, w-1, 0).get_cross_point_by_param(*line_left)
+        line_left_bot = LineSeg(0, h-1, w - 1, h - 1).get_cross_point_by_param(*line_left)
+        line_right_top = LineSeg(0, 0, w-1, 0).get_cross_point_by_param(*line_right)
+        line_right_bot = LineSeg(0, h-1, w-1, h - 1).get_cross_point_by_param(*line_right)
+    if _debug:
+        drawn_img = img1.copy()
+        print('slope_top, slope_bot : ')
+        print(slope_top, slope_bot)
+        if line_top_left is not None and line_top_right is not None:
+            cv2.line(drawn_img, line_top_left, line_top_right, (255, 0, 0), 2)
+        if line_bot_left is not None and line_bot_right is not None:
+            cv2.line(drawn_img, line_bot_left, line_bot_right, (0, 255, 0), 2)
+        if line_left_top is not None and line_left_bot is not None:
+            cv2.line(drawn_img, line_left_top, line_left_bot, (0, 0, 255), 2)
+        if line_right_top is not None and line_right_bot is not None:
+            cv2.line(drawn_img, line_right_top, line_right_bot, (0, 255, 255), 2)
+        cv2.imwrite(os.path.join(_out_dir, "{}.31.top_bot.png".format(_img_base_name)),
+                    drawn_img)
 
 
 if __name__ == "__main__":
@@ -116,10 +327,11 @@ if __name__ == "__main__":
     text_detector = predict_det.TextDetector(args)
     count = 0
     total_time = 0
-    draw_img_save = "./inference_results"
-    if not os.path.exists(draw_img_save):
-        os.makedirs(draw_img_save)
+    if _debug and not os.path.exists(_out_dir):
+        os.makedirs(_out_dir)
     for image_file in image_file_list:
+        if _debug:
+            _img_base_name = os.path.basename(image_file)
         img, flag = check_and_read_gif(image_file)
         if not flag:
             img = cv2.imread(image_file)
@@ -134,7 +346,7 @@ if __name__ == "__main__":
         elif h > 2000 and h >= w:
             img = cv2.resize(img, (round(2000 * w / h), 2000))
         print(img.shape)
-        calibrate_img2(text_detector, img, image_file, draw_img_save, debug=True)
-        break
+        calibrate_img2(text_detector, img)
+        # break
     if count > 1:
         print("Avg Time:", total_time / (count - 1))

--- a/tools/infer/line_seg.py
+++ b/tools/infer/line_seg.py
@@ -1,0 +1,73 @@
+
+import math
+
+
+def get_line_para(x1, y1, x2, y2):
+    A = y1 - y2
+    B = x2 - x1
+    C = x1 * y2 - x2 * y1
+    return A, B, C
+
+
+def line_length(x1, y1, x2, y2):
+    return math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
+
+
+def get_cross_point(a1, b1, c1, a2, b2, c2):
+    x = (b1 * c2 - b2 * c1) / (a1 * b2 - a2 * b1)
+    y = (a2 * c1 - a1 * c2) / (a1 * b2 - a2 * b1)
+    return round(x), round(y)
+
+
+class LineSeg:
+    def __init__(self, x1, y1, x2, y2):
+        self.x1, self.y1 = x1, y1
+        self.x2, self.y2 = x2, y2
+        self.A, self.B, self.C = get_line_para(x1, y1, x2, y2)
+        self.length = line_length(x1, y1, x2, y2)
+
+    def get_cross_point(self, line):
+        a1, b1, c1 = self.A, self.B, self.C
+        a2, b2, c2 = line.A, line.B, line.C
+        x = (b1 * c2 - b2 * c1) / (a1 * b2 - a2 * b1)
+        y = (a2 * c1 - a1 * c2) / (a1 * b2 - a2 * b1)
+        return round(x), round(y)
+
+    def get_line_vertical(self, pt):
+        px, py = pt[0], pt[1]
+        AA, BB, CC = 0, 0, 0
+        if self.A == 0:
+            BB = 0
+            AA = -1 * self.B
+            CC = self.B * px
+        elif self.B == 0:
+            AA = 0
+            BB = -1 * self.A
+            CC = self.A * py
+        else:
+            AA, BB = -1 * self.B, self.A
+            CC = -1 * (AA * px + BB * py)
+        return AA, BB, CC
+
+    def left(self):
+        if self.x1 > self.x2:
+            return self.x2, self.y2
+        return self.x1, self.y1
+
+    def right(self):
+        if self.x1 > self.x2:
+            return self.x1, self.y1
+        return self.x2, self.y2
+
+    def top(self):
+        if self.y1 > self.y2:
+            return self.x2, self.y2
+        return self.x1, self.y1
+
+    def bottom(self):
+        if self.y1 > self.y2:
+            return self.x1, self.y1
+        return self.x2, self.y2
+
+
+

--- a/tools/infer/line_seg.py
+++ b/tools/infer/line_seg.py
@@ -33,6 +33,12 @@ class LineSeg:
         y = (a2 * c1 - a1 * c2) / (a1 * b2 - a2 * b1)
         return round(x), round(y)
 
+    def get_cross_point_by_param(self, a2, b2, c2):
+        a1, b1, c1 = self.A, self.B, self.C
+        x = (b1 * c2 - b2 * c1) / (a1 * b2 - a2 * b1)
+        y = (a2 * c1 - a1 * c2) / (a1 * b2 - a2 * b1)
+        return int(round(x)), int(round(y))
+
     def get_line_vertical(self, pt):
         px, py = pt[0], pt[1]
         AA, BB, CC = 0, 0, 0

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -151,6 +151,18 @@ def draw_text_det_res(dt_boxes, img_path):
     return src_im
 
 
+import random
+def draw_text_det_res2(dt_boxes, img):
+    # src_im = cv2.imread(img_path)
+    src_im = img.copy()
+    for box in dt_boxes:
+        box = np.array(box).astype(np.int32).reshape(-1, 2)
+        color = [random.randint(0, 255) for _ in range(3)]
+        # cv2.polylines(src_im, [box], True, color=color, thickness=2)
+        cv2.fillConvexPoly(src_im, box, color)
+    return cv2.addWeighted(src_im, 0.5, img, 0.5, 0)
+
+
 def resize_img(img, input_size=600):
     """
     resize img and limit the longest side of the image to input_size


### PR DESCRIPTION
1. 分别对图像旋转0度、22.5度、45度、67.5度，90度，并保存这5张图片。
2. 使用（轻量）文本检测模型对这5张图片进行文本检测。
3. 然后挑选长文本框最多、宽高比最大的角度，作为大致的旋转角度判断，得到角度$\theta1 \in (0, 22.5, 45, 67.5, 90)$。
4. 使用上一步得到的文本框，统计最大的几个文本框长边倾斜角度得到角度$\theta2$。
5. 通过$\theta1$ 和$\theta2$来对原图进行旋转。

![](https://img-blog.csdnimg.cn/20201024154545275.png?x-oss-process=image/watermark,type_ZmFuZ3poZW5naGVpdGk,shadow_10,text_aHR0cHM6Ly9ibG9nLmNzZG4ubmV0L3NkbHlweXpx,size_16,color_FFFFFF,t_70#pic_center)



![](https://img-blog.csdnimg.cn/20201024154707696.png?x-oss-process=image/watermark,type_ZmFuZ3poZW5naGVpdGk,shadow_10,text_aHR0cHM6Ly9ibG9nLmNzZG4ubmV0L3NkbHlweXpx,size_16,color_FFFFFF,t_70#pic_center)