### PR TITLE
日志符合benckmark规范

### DIFF
--- a/ppocr/utils/stats.py
+++ b/ppocr/utils/stats.py
@@ -65,5 +65,8 @@ class TrainingStats(object):
 
     def log(self, extras=None):
         d = self.get(extras)
-        strs = ', '.join(str(dict({x: y})).strip('{}') for x, y in d.items())
+        strs = []
+        for k, v in d.items():
+            strs.append('{}: {:x<6f}'.format(k, v))
+        strs = ', '.join(strs)
         return strs

--- a/tools/program.py
+++ b/tools/program.py
@@ -228,7 +228,7 @@ def train(config,
             if dist.get_rank(
             ) == 0 and global_step > 0 and global_step % print_batch_step == 0:
                 logs = train_stats.log()
-                strs = 'epoch: [{}/{}], iter: {}, {}, reader_cost: {:.5f}s, batch_cost: {:.5f}s, samples: {}, ips: {:.5f}'.format(
+                strs = 'epoch: [{}/{}], iter: {}, {}, reader_cost: {:.5f} s, batch_cost: {:.5f} s, samples: {}, ips: {:.5f}'.format(
                     epoch, epoch_num, global_step, logs, train_reader_cost /
                     print_batch_step, train_batch_cost / print_batch_step,
                     batch_sum, batch_sum / train_batch_cost)


### PR DESCRIPTION
样例
```bash
[2020/11/16 11:11:18] root INFO: During the training process, after the 0th iteration, an evaluation is run every 1171 iterations
[2020/11/16 11:11:26] root INFO: epoch: [0/100], iter: 10, lr: 0.001000, acc: 0.507812, loss: 0.698222, reader_cost: 6.01444 s, batch_cost: 6.29982 s, samples: 5632, ips: 89.39943
[2020/11/16 11:11:32] root INFO: epoch: [0/100], iter: 20, lr: 0.001000, acc: 0.500977, loss: 0.696527, reader_cost: 2.33420 s, batch_cost: 2.57432 s, samples: 5120, ips: 198.88761
[2020/11/16 11:11:37] root INFO: epoch: [0/100], iter: 30, lr: 0.001000, acc: 0.500000, loss: 0.695349, reader_cost: 2.34351 s, batch_cost: 2.57905 s, samples: 5120, ips: 198.52250
[2020/11/16 11:11:42] root INFO: epoch: [0/100], iter: 40, lr: 0.001000, acc: 0.500977, loss: 0.693913, reader_cost: 2.36813 s, batch_cost: 2.60749 s, samples: 5120, ips: 196.35729
[2020/11/16 11:11:47] root INFO: epoch: [0/100], iter: 50, lr: 0.001000, acc: 0.503906, loss: 0.693913, reader_cost: 2.37101 s, batch_cost: 2.61313 s, samples: 5120, ips: 195.93392
[2020/11/16 11:11:52] root INFO: epoch: [0/100], iter: 60, lr: 0.001000, acc: 0.501953, loss: 0.694087, reader_cost: 2.32850 s, batch_cost: 2.56124 s, samples: 5120, ips: 199.90301
[2020/11/16 11:11:57] root INFO: epoch: [0/100], iter: 70, lr: 0.001000, acc: 0.504883, loss: 0.694364, reader_cost: 2.35519 s, batch_cost: 2.58811 s, samples: 5120, ips: 197.82808
[2020/11/16 11:12:03] root INFO: epoch: [0/100], iter: 80, lr: 0.001000, acc: 0.501953, loss: 0.694995, reader_cost: 2.35814 s, batch_cost: 2.60395 s, samples: 5120, ips: 196.62465
```