### PR TITLE
Fixed typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 from io import open
 
-with open('requirments.txt', encoding="utf-8-sig") as f:
+with open('requirements.txt', encoding="utf-8-sig") as f:
     requirements = f.readlines()
     requirements.append('tqdm')
 


### PR DESCRIPTION
requirements.txt was misspelled which caused an error when installing the python package.  Fixed it. 