### PR TITLE
Fix bug

### DIFF
--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from ppocr.utils.utility import enable_static_mode
+
 
 import os
 import sys
@@ -39,6 +39,7 @@ set_paddle_flags(
 
 import program
 from paddle import fluid
+from ppocr.utils.utility import enable_static_mode
 from ppocr.utils.utility import initial_logger
 logger = initial_logger()
 from ppocr.utils.save_load import init_model


### PR DESCRIPTION
Move https://github.com/PaddlePaddle/PaddleOCR/blob/23942cf7bce004eb9152fd191a8a5e0d13c9e513/tools/export_model.py#L18
after https://github.com/PaddlePaddle/PaddleOCR/blob/23942cf7bce004eb9152fd191a8a5e0d13c9e513/tools/export_model.py#L24
to avoid ModuleNotFoundError: No module named 'ppocr'