### PR TITLE
修改PPOCRLabel，避免程序运行速度越来越慢

### DIFF
--- a/PPOCRLabel/libs/autoDialog.py
+++ b/PPOCRLabel/libs/autoDialog.py
@@ -48,7 +48,7 @@ class Worker(QThread):
                             posi = res[0]
                             strs += "Transcription: " + chars + " Probability: " + str(cond) + " Location: " + json.dumps(posi)
                         # Sending large amounts of data repeatedly through pyqtSignal may affect the program efficiency
-                        self.listValue.emit(strs)  # It is better to remove this line
+                        # self.listValue.emit(strs)  # It is better to remove this line
                         self.mainThread.result_dic = self.result_dic
                         self.mainThread.filePath = Imgpath
                         # 保存

--- a/PPOCRLabel/libs/autoDialog.py
+++ b/PPOCRLabel/libs/autoDialog.py
@@ -41,11 +41,14 @@ class Worker(QThread):
                         print('Can not recognise file  is :  ', Imgpath)
                         pass
                     else:
+                        strs = ''
                         for res in self.result_dic:
                             chars = res[1][0]
                             cond = res[1][1]
                             posi = res[0]
-                            self.listValue.emit("Transcription: " + chars + " Probability: " + str(cond) + " Location: " + json.dumps(posi))
+                            strs += "Transcription: " + chars + " Probability: " + str(cond) + " Location: " + json.dumps(posi)
+                        # Sending large amounts of data repeatedly through pyqtSignal may affect the program efficiency
+                        self.listValue.emit(strs)  # It is better to remove this line
                         self.mainThread.result_dic = self.result_dic
                         self.mainThread.filePath = Imgpath
                         # 保存


### PR DESCRIPTION
通过信号反复发送大量数据可能影响程序运行效率，最好不要发送识别结果到界面滚动显示