### PR TITLE
add CyclicalCosineDecay

### DIFF
--- a/ppocr/optimizer/lr_scheduler.py
+++ b/ppocr/optimizer/lr_scheduler.py
@@ -1,0 +1,49 @@
+# copyright (c) 2020 PaddlePaddle Authors. All Rights Reserve.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from paddle.optimizer.lr import LRScheduler
+
+
+class CyclicalCosineDecay(LRScheduler):
+    def __init__(self,
+                 learning_rate,
+                 T_max,
+                 cycle=1,
+                 last_epoch=-1,
+                 eta_min=0.0,
+                 verbose=False):
+        """
+        Cyclical cosine learning rate decay
+        A learning rate which can be referred in https://arxiv.org/pdf/2012.12645.pdf
+        Args:
+            learning rate(float): learning rate
+            T_max(int): maximum epoch num
+            cycle(int): period of the cosine decay
+            last_epoch (int, optional):  The index of last epoch. Can be set to restart training. Default: -1, means initial learning rate.
+            eta_min(float): minimum learning rate during training
+            verbose(bool): whether to print learning rate for each epoch
+        """
+        super(CyclicalCosineDecay, self).__init__(learning_rate, last_epoch,
+                                                  verbose)
+        self.cycle = cycle
+        self.eta_min = eta_min
+
+    def get_lr(self):
+        if self.last_epoch == 0:
+            return self.base_lr
+        reletive_epoch = self.last_epoch % self.cycle
+        lr = self.eta_min + 0.5 * (self.base_lr - self.eta_min) * \
+                (1 + math.cos(math.pi * reletive_epoch / self.cycle))
+        return lr

--- a/tools/program.py
+++ b/tools/program.py
@@ -179,9 +179,9 @@ def train(config,
     if 'start_epoch' in best_model_dict:
         start_epoch = best_model_dict['start_epoch']
     else:
-        start_epoch = 0
+        start_epoch = 1
 
-    for epoch in range(start_epoch, epoch_num):
+    for epoch in range(start_epoch, epoch_num + 1):
         if epoch > 0:
             train_dataloader = build_dataloader(config, 'Train', device, logger)
         train_batch_cost = 0.0


### PR DESCRIPTION
1. Add CyclicalCosineDecay. The strategy can be seen in : https://arxiv.org/pdf/2012.12645.pdf. In ocr, without any fine tune on hyper-parameters, it can directly takes a 0.3% accuracy gain for CRNN(with 10% more training epochs).
2. modify the epoch num, because if we want to save models per 5epochs and total epoch is set as 50, then the 50th epoch  model will not be saved for the code before(the last epoch is actually 49).