### PR TITLE
Support fixed length TRT prediction

### DIFF
--- a/deploy/cpp_infer/include/preprocess_op.h
+++ b/deploy/cpp_infer/include/preprocess_op.h
@@ -47,18 +47,20 @@ public:
 class ResizeImgType0 {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img, int max_size_len,
-                   float &ratio_h, float &ratio_w);
+                   float &ratio_h, float &ratio_w, bool use_tensorrt);
 };
 
 class CrnnResizeImg {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
+                   bool use_tensorrt = false,
                    const std::vector<int> &rec_image_shape = {3, 32, 320});
 };
 
 class ClsResizeImg {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img,
+                   bool use_tensorrt = false,
                    const std::vector<int> &rec_image_shape = {3, 48, 192});
 };
 

--- a/deploy/cpp_infer/src/main.cpp
+++ b/deploy/cpp_infer/src/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
   auto end = std::chrono::system_clock::now();
   auto duration =
       std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  std::cout << "Cost"
+  std::cout << "Cost  "
             << double(duration.count()) *
                    std::chrono::microseconds::period::num /
                    std::chrono::microseconds::period::den

--- a/deploy/cpp_infer/src/ocr_cls.cpp
+++ b/deploy/cpp_infer/src/ocr_cls.cpp
@@ -25,7 +25,7 @@ cv::Mat Classifier::Run(cv::Mat &img) {
   int index = 0;
   float wh_ratio = float(img.cols) / float(img.rows);
 
-  this->resize_op_.Run(img, resize_img, cls_image_shape);
+  this->resize_op_.Run(img, resize_img, this->use_tensorrt_, cls_image_shape);
 
   this->normalize_op_.Run(&resize_img, this->mean_, this->scale_,
                           this->is_scale_);

--- a/deploy/cpp_infer/src/ocr_det.cpp
+++ b/deploy/cpp_infer/src/ocr_det.cpp
@@ -61,7 +61,8 @@ void DBDetector::Run(cv::Mat &img,
   cv::Mat srcimg;
   cv::Mat resize_img;
   img.copyTo(srcimg);
-  this->resize_op_.Run(img, resize_img, this->max_side_len_, ratio_h, ratio_w);
+  this->resize_op_.Run(img, resize_img, this->max_side_len_, ratio_h, ratio_w,
+                       this->use_tensorrt_);
 
   this->normalize_op_.Run(&resize_img, this->mean_, this->scale_,
                           this->is_scale_);

--- a/deploy/cpp_infer/src/ocr_rec.cpp
+++ b/deploy/cpp_infer/src/ocr_rec.cpp
@@ -33,7 +33,7 @@ void CRNNRecognizer::Run(std::vector<std::vector<std::vector<int>>> boxes,
 
     float wh_ratio = float(crop_img.cols) / float(crop_img.rows);
 
-    this->resize_op_.Run(crop_img, resize_img, wh_ratio);
+    this->resize_op_.Run(crop_img, resize_img, wh_ratio, this->use_tensorrt_);
 
     this->normalize_op_.Run(&resize_img, this->mean_, this->scale_,
                             this->is_scale_);


### PR DESCRIPTION
开启TRT时图像需要resize到固定长度，会影响预测效果
原图：
![image](https://user-images.githubusercontent.com/26592129/103999782-4e195180-51d8-11eb-8b6e-af011dda5b2f.png)

不开启TRT预测结果：
![image](https://user-images.githubusercontent.com/26592129/103999713-3510a080-51d8-11eb-97c3-15fa18c0c4df.png)

开启TRT预测结果：
![image](https://user-images.githubusercontent.com/26592129/103999672-275b1b00-51d8-11eb-9462-ef7eba7b6360.png)
