### PR TITLE
export_model support dynamic input shape

### DIFF
--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -51,8 +51,11 @@ def main():
     model.eval()
 
     save_path = '{}/inference'.format(config['Global']['save_inference_dir'])
-    infer_shape = [3, 32, 100] if config['Architecture'][
-        'model_type'] != "det" else [3, 640, 640]
+
+    infer_shape = [3, -1, -1] 
+    if config['Architecture']['model_type'] == "rec":
+         infer_shape = [3, 32, -1]
+
     model = to_static(
         model,
         input_spec=[


### PR DESCRIPTION
动机：由于PaddleOCR模型导出成ONNX之后，在ONNXRunTime运行时会check输入的shape，当模型的输入shape固定时，没办法推理不等于该shape的数据，但实际上模型支持dynamic shape。
修改：在导出det和cls模型时，将输入shape修改为[3,-1,-1]，在导出rec模型时，将输入shape修改为[3,32,-1]。
测试：自测predict_system.py预测结果，可正常预测。

![image](https://user-images.githubusercontent.com/12471701/105841721-0dab3780-6010-11eb-9c59-6c94a054e7f6.png)
![image](https://user-images.githubusercontent.com/12471701/105841742-16037280-6010-11eb-8052-3e06de276e50.png)
