### PR TITLE
fix are calc for polygon

### DIFF
--- a/ppocr/data/imaug/make_shrink_map.py
+++ b/ppocr/data/imaug/make_shrink_map.py
@@ -84,11 +84,12 @@ class MakeShrinkMap(object):
         return polygons, ignore_tags
 
     def polygon_area(self, polygon):
-        # return cv2.contourArea(polygon.astype(np.float32))
-        edge = 0
-        for i in range(polygon.shape[0]):
-            next_index = (i + 1) % polygon.shape[0]
-            edge += (polygon[next_index, 0] - polygon[i, 0]) * (
-                polygon[next_index, 1] - polygon[i, 1])
-
-        return edge / 2.
+        """
+        compute polygon area
+        """
+        area = 0
+        q = polygon[-1]
+        for p in polygon:
+            area += p[0] * q[1] - p[1] * q[0]
+            q = p
+        return area / 2.0


### PR DESCRIPTION
fix the issue of  #1967 
refer to https://www.cnblogs.com/zzcpy/p/10524348.html
```
case1:
polygon = np.array([[1, 3], [5, 3], [5, 1], [1, 1]]).astype("float32")
area before the pr: 0.0
area before the pr: 8.0

case2:
polygon = np.array([[0, 0], [-1, 1], [0, 2], [1, 1]]).astype("float32")
area before the pr: 0.0
area before the pr: 2.0
```
