### PR TITLE
replace python-Levenshtein

### DIFF
--- a/ppocr/metrics/rec_metric.py
+++ b/ppocr/metrics/rec_metric.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import Levenshtein
+from rapidfuzz import string_metric
 
 
 class RecMetric(object):
@@ -28,7 +28,7 @@ class RecMetric(object):
         for (pred, pred_conf), (target, _) in zip(preds, labels):
             pred = pred.replace(" ", "")
             target = target.replace(" ", "")
-            norm_edit_dis += Levenshtein.distance(pred, target) / max(
+            norm_edit_dis += string_metric.levenshtein(pred, target) / max(
                 len(pred), len(target), 1)
             if pred == target:
                 correct_num += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ opencv-python==4.2.0.32
 tqdm
 numpy
 visualdl
-python-Levenshtein
+rapidfuzz


### PR DESCRIPTION
Python-Levenshtein is GPL licensed, which is not compatible with the Apache license. This PR replaces python-levenshtein with the MIT licensed library rapidfuzz.