### PR TITLE
Fix #2013

### DIFF
--- a/ppocr/data/imaug/make_shrink_map.py
+++ b/ppocr/data/imaug/make_shrink_map.py
@@ -44,20 +44,33 @@ class MakeShrinkMap(object):
                 ignore_tags[i] = True
             else:
                 polygon_shape = Polygon(polygon)
-                distance = polygon_shape.area * (
-                    1 - np.power(self.shrink_ratio, 2)) / polygon_shape.length
-                subject = [tuple(l) for l in text_polys[i]]
+                subject = [tuple(l) for l in polygon]
                 padding = pyclipper.PyclipperOffset()
                 padding.AddPath(subject, pyclipper.JT_ROUND,
                                 pyclipper.ET_CLOSEDPOLYGON)
-                shrinked = padding.Execute(-distance)
+                shrinked = []
+
+                # Increase the shrink ratio every time we get multiple polygon returned back 
+                possible_ratios = np.arange(self.shrink_ratio, 1, self.shrink_ratio)
+                np.append(possible_ratios, 1)
+                # print(possible_ratios)
+                for ratio in possible_ratios:
+                    # print(f"Change shrink ratio to {ratio}")
+                    distance = polygon_shape.area * (
+                        1 - np.power(ratio, 2)) / polygon_shape.length
+                    shrinked = padding.Execute(-distance)
+                    if len(shrinked) == 1:
+                        break
+
                 if shrinked == []:
                     cv2.fillPoly(mask,
                                  polygon.astype(np.int32)[np.newaxis, :, :], 0)
                     ignore_tags[i] = True
                     continue
-                shrinked = np.array(shrinked[0]).reshape(-1, 2)
-                cv2.fillPoly(gt, [shrinked.astype(np.int32)], 1)
+
+                for each_shirnk in shrinked:
+                    shirnk = np.array(each_shirnk).reshape(-1, 2)
+                    cv2.fillPoly(gt, [shirnk.astype(np.int32)], 1)
                 # cv2.fillPoly(gt[0], [shrinked.astype(np.int32)], 1)
 
         data['shrink_map'] = gt


### PR DESCRIPTION
Hi. Thanks for the great works.

After trying the DB training code, I've found out that the current shrink map generation at training for DB is wrong for some polygon.

The problem is that the polygon shrinking process uses Vatti's clipping algorithm, which can create multiple polygons for some polygon with thin part (see example in issue #2013) 

To fix this, we can increase the shrink ratio every time we get multiple polygons returned back after clipping. I had found that double the shrink ratio for each try give a really good result, also since the shrink ratio is limited by `1`, we only need to redo the clipping step a few times (2 for the default `0.4`), this doesn't slow down anything much at all.

Since this will greatly affect the accuracy of the trained model. I hope you guys can have a look and merge this to fix #2013 soon ;)