### PR TITLE
fix dataset sample

### DIFF
--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -57,8 +57,9 @@ class SimpleDataSet(Dataset):
             with open(file, "rb") as f:
                 lines = f.readlines()
                 random.seed(self.seed)
-                lines = random.sample(lines,
-                                      round(len(lines) * ratio_list[idx]))
+                if int(ratio_list[idx]) != 1:
+	                lines = random.sample(lines,
+	                                      round(len(lines) * ratio_list[idx]))
                 data_lines.extend(lines)
         return data_lines
 

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -57,9 +57,9 @@ class SimpleDataSet(Dataset):
             with open(file, "rb") as f:
                 lines = f.readlines()
                 random.seed(self.seed)
-                if int(ratio_list[idx]) != 1:
-	                lines = random.sample(lines,
-	                                      round(len(lines) * ratio_list[idx]))
+                data_sample_num = round(len(lines) * ratio_list[idx])
+                sample_idx_list = sorted(random.sample(range(len(lines)), data_sample_num))
+                lines = [lines[i] for i in sample_idx_list]
                 data_lines.extend(lines)
         return data_lines
 


### PR DESCRIPTION
random.sample会始原始数据乱序，当ratio设置为1时，即使shuffle=False，验证的顺序也与验证集不一致。在网上有搜索说random.sample不乱序，但是查看3.5-3.8的文档并没有明确说明，在python3.8.8环境下测试sample会引起乱序。