### PR TITLE
Fix the incompatibility of gif saving

### DIFF
--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -176,6 +176,8 @@ def main(args):
             draw_img_save = "./inference_results/"
             if not os.path.exists(draw_img_save):
                 os.makedirs(draw_img_save)
+            if flag:
+               image_file = image_file[:-3] + "png" 
             cv2.imwrite(
                 os.path.join(draw_img_save, os.path.basename(image_file)),
                 draw_img[:, :, ::-1])


### PR DESCRIPTION
When cv2.imwirte() saves ".gif", it will cause _error: (-2:Unspecified error) could not find a writer for the specified extension in function 'cv::imwrite_'. We add an _if_ statement to check whether the saving file format is ".gif" and covert the format to ".png" instead so as to avoid the error.

Now, it can work with ".gif" correctly.

Example:

![2](https://user-images.githubusercontent.com/37281330/112681699-5d22ae00-8e6f-11eb-987a-878294969c97.gif)

![2](https://user-images.githubusercontent.com/37281330/112681870-922f0080-8e6f-11eb-8755-2986ca44b287.png)

