### PR TITLE
specify simultaneous jobs when compiling OpenCV

### DIFF
--- a/deploy/cpp_infer/readme.md
+++ b/deploy/cpp_infer/readme.md
@@ -52,7 +52,7 @@ cmake .. \
     -DWITH_TIFF=ON \
     -DBUILD_TIFF=ON
 
-make -j
+make -j4
 make install
 ```
 


### PR DESCRIPTION
When compiling OpenCV, `make -j` will sometimes cause server out of memory and high usage of CPU. Use `make -j4` to limit jobs to 4 can avoid this.