### PR TITLE
add PolygonScoreAcc to improve polygon detect

### DIFF
--- a/deploy/cpp_infer/include/postprocess_op.h
+++ b/deploy/cpp_infer/include/postprocess_op.h
@@ -51,6 +51,7 @@ public:
                                                float &ssid);
 
   float BoxScoreFast(std::vector<std::vector<float>> box_array, cv::Mat pred);
+  float PolygonScoreAcc(std::vector<cv::Point> contour, cv::Mat pred);
 
   std::vector<std::vector<std::vector<int>>>
   BoxesFromBitmap(const cv::Mat pred, const cv::Mat bitmap,

--- a/deploy/cpp_infer/src/postprocess_op.cpp
+++ b/deploy/cpp_infer/src/postprocess_op.cpp
@@ -170,10 +170,10 @@ float PostProcessor::PolygonScoreAcc(std::vector<cv::Point> contour,
     box_y.push_back(contour[i].y);
   }
 
-  int xmin = std::clamp(int(std::floor(*(std::min_element(box_x.begin(), box_x.end())))), 0, width - 1);
-  int xmax = std::clamp(int(std::ceil(*(std::max_element(box_x.begin(), box_x.end())))), 0, width - 1);
-  int ymin = std::clamp(int(std::floor(*(std::min_element(box_y.begin(), box_y.end())))), 0, height - 1);
-  int ymax = std::clamp(int(std::ceil(*(std::max_element(box_y.begin(), box_y.end())))), 0, height - 1);
+  int xmin = clamp(int(std::floor(*(std::min_element(box_x.begin(), box_x.end())))), 0, width - 1);
+  int xmax = clamp(int(std::ceil(*(std::max_element(box_x.begin(), box_x.end())))), 0, width - 1);
+  int ymin = clamp(int(std::floor(*(std::min_element(box_y.begin(), box_y.end())))), 0, height - 1);
+  int ymax = clamp(int(std::ceil(*(std::max_element(box_y.begin(), box_y.end())))), 0, height - 1);
 
   cv::Mat mask;
   mask = cv::Mat::zeros(ymax - ymin + 1, xmax - xmin + 1, CV_8UC1);

--- a/deploy/cpp_infer/src/postprocess_op.cpp
+++ b/deploy/cpp_infer/src/postprocess_op.cpp
@@ -159,6 +159,39 @@ std::vector<std::vector<float>> PostProcessor::GetMiniBoxes(cv::RotatedRect box,
   return array;
 }
 
+float PostProcessor::PolygonScoreAcc(std::vector<cv::Point> contour,
+		                  cv::Mat pred){
+  int width = pred.cols;
+  int height = pred.rows;
+  std::vector<float> box_x;
+  std::vector<float> box_y;
+  for(int i=0; i<contour.size(); ++i){
+    box_x.push_back(contour[i].x);
+    box_y.push_back(contour[i].y);
+  }
+
+  int xmin = std::clamp(int(std::floor(*(std::min_element(box_x.begin(), box_x.end())))), 0, width - 1);
+  int xmax = std::clamp(int(std::ceil(*(std::max_element(box_x.begin(), box_x.end())))), 0, width - 1);
+  int ymin = std::clamp(int(std::floor(*(std::min_element(box_y.begin(), box_y.end())))), 0, height - 1);
+  int ymax = std::clamp(int(std::ceil(*(std::max_element(box_y.begin(), box_y.end())))), 0, height - 1);
+
+  cv::Mat mask;
+  mask = cv::Mat::zeros(ymax - ymin + 1, xmax - xmin + 1, CV_8UC1);
+
+  cv::Point rook_point[contour.size()];
+  for(int i=0; i<contour.size(); ++i){
+    rook_point[i] = cv::Point(int(box_x[i]) - xmin, int(box_y[i]) - ymin);
+  }
+  const cv::Point *ppt[1] = {rook_point};
+  int npt[] = {int(contour.size())};
+  cv::fillPoly(mask, ppt, npt, 1, cv::Scalar(1));
+
+  cv::Mat croppedImg;
+  pred(cv::Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1)).copyTo(croppedImg);
+  float score = cv::mean(croppedImg, mask)[0];
+  return score;
+}
+
 float PostProcessor::BoxScoreFast(std::vector<std::vector<float>> box_array,
                                   cv::Mat pred) {
   auto array = box_array;
@@ -235,6 +268,8 @@ PostProcessor::BoxesFromBitmap(const cv::Mat pred, const cv::Mat bitmap,
 
     float score;
     score = BoxScoreFast(array, pred);
+    /* compute using polygon*/ 
+    // score = PolygonScoreAcc(contours[_i], pred);
     if (score < box_thresh)
       continue;
 


### PR DESCRIPTION
求rectangle区域的平均分数，容易造成弯曲文本漏检。 求polygon区域的平均分数会更准确，但速度有所降低。 可按需选择