### PR TITLE
Fixed Imghdr missing some cases

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -16,7 +16,7 @@ import logging
 import os
 import imghdr
 import cv2
-
+from PIL import Image
 
 def print_dict(d, logger, delimiter=0):
     """
@@ -45,14 +45,13 @@ def get_check_global_params(mode):
         check_params = check_params + ['test_batch_size_per_card']
     return check_params
 
-
 def get_image_file_list(img_file):
     imgs_lists = []
     if img_file is None or not os.path.exists(img_file):
         raise Exception("not found any img file in {}".format(img_file))
 
     img_end = {'jpg', 'bmp', 'png', 'jpeg', 'rgb', 'tif', 'tiff', 'gif', 'GIF'}
-    if os.path.isfile(img_file) and imghdr.what(img_file) in img_end:
+    if os.path.isfile(img_file) and Image.open(img_file).format in img_end:
         imgs_lists.append(img_file)
     elif os.path.isdir(img_file):
         for single_file in os.listdir(img_file):

--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -51,7 +51,12 @@ def get_image_file_list(img_file):
         raise Exception("not found any img file in {}".format(img_file))
 
     img_end = {'jpg', 'bmp', 'png', 'jpeg', 'rgb', 'tif', 'tiff', 'gif', 'GIF'}
-    if os.path.isfile(img_file) and Image.open(img_file).format in img_end:
+    PIL_Checker=False
+    try:
+        PIL_Checker=(Image.open(img_file).format.lower() in [img_end_lower.lower() for img_end_lower in img_end])
+    except:
+        pass
+    if os.path.isfile(img_file) and (PIL_Checker or (imghdr.what(img_file) in img_end)):
         imgs_lists.append(img_file)
     elif os.path.isdir(img_file):
         for single_file in os.listdir(img_file):


### PR DESCRIPTION
`imghdr.what` method fail in checking some JPG images.
`imghdr.what` use the following command to check for JPG by checking the header: `[6:10] in (b'JFIF', b'Exif')`
However, its not always the case as some - quantized JPG - can start with `b'\xff\xd8\xff\xdb' `headers and not including `(b'JFIF', b'Exif')` as described in the references [here](https://www.digicamsoft.com/itu/itu-t81-36.html) and [here](https://web.archive.org/web/20120403212223/http://class.ee.iastate.edu/ee528/Reading%20material/JPEG_File_Format.pdf).
`\xdb` defining the Quantization Table.

PIL can be an alternative for that issue until imghdr bug is fixed [issue](https://github.com/python/cpython/pull/26964#issue-680660918)

