### PR TITLE
bug fix

### DIFF
--- a/ppocr/data/imaug/label_ops.py
+++ b/ppocr/data/imaug/label_ops.py
@@ -283,7 +283,7 @@ class AttnLabelEncode(BaseRecLabelEncode):
         text = self.encode(text)
         if text is None:
             return None
-        if len(text) >= self.max_text_len:
+        if len(text) >= self.max_text_len - 1:
             return None
         data['length'] = np.array(len(text))
         text = [0] + text + [len(self.character) - 1] + [0] * (self.max_text_len


### PR DESCRIPTION
训练数据中可能出现标签较长的情况，因为 [0] + text + [len(self.character) - 1]    一定会增加前后两个填充的index，使用max_text_len - 1 来判断可以避免这种情况