### PR TITLE
修复错误

### DIFF
--- a/deploy/docker/hubserving/cpu/Dockerfile
+++ b/deploy/docker/hubserving/cpu/Dockerfile
@@ -1,5 +1,5 @@
 # Version: 2.0.0
-FROM registry.baidubce.com/paddlepaddle/paddle:2.0.0
+FROM registry.baidubce.com/paddlepaddle/paddle:2.1.2
 
 # PaddleOCR base on Python3.7
 RUN pip3.7 install --upgrade pip -i https://mirror.baidu.com/pypi/simple
@@ -7,6 +7,8 @@ RUN pip3.7 install --upgrade pip -i https://mirror.baidu.com/pypi/simple
 RUN pip3.7 install paddlehub --upgrade -i https://mirror.baidu.com/pypi/simple
 
 RUN git clone https://github.com/PaddlePaddle/PaddleOCR.git /PaddleOCR
+
+ADD https://raw.githubusercontent.com/python/cpython/3.7/Lib/typing.py /usr/local/lib/python3.7
 
 WORKDIR /PaddleOCR
 


### PR DESCRIPTION
修复 [issues #3565](https://github.com/PaddlePaddle/PaddleOCR/issues/3565) 中提到的错误

做出如下改动:
1. 修改镜像paddle版本 `2.0.0` -> `2.1.2`
1. 第11行加入下载指令替换原有python的typing.py