### PR TITLE
fix cls type

### DIFF
--- a/ppocr/losses/cls_loss.py
+++ b/ppocr/losses/cls_loss.py
@@ -25,6 +25,6 @@ class ClsLoss(nn.Layer):
         self.loss_func = nn.CrossEntropyLoss(reduction='mean')
 
     def forward(self, predicts, batch):
-        label = batch[1]
+        label = batch[1].astype("int64")
         loss = self.loss_func(input=predicts, label=label)
         return {'loss': loss}


### PR DESCRIPTION
att

部分windows环境中，int为int32，会导致celoss计算类型错误
linux中，int为int64，这里强制做了类型转换
