### PR TITLE
修复 端到端算法调用inference模型时与训练模型结果不一致的问题，由rgb3个通道的顺序不一致引起

### DIFF
--- a/tools/infer/predict_e2e.py
+++ b/tools/infer/predict_e2e.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
         img, flag = check_and_read_gif(image_file)
         if not flag:
             img = cv2.imread(image_file)
+            img = img[:, :, ::-1]
         if img is None:
             logger.info("error in loading image:{}".format(image_file))
             continue


### PR DESCRIPTION
调用训练模型时（infer_e2e.py）比调用inference模型时多一个预处理类：DecodeImage，在这里通过调用cv将字节数据转成图像数据以后又进行了红蓝通道交换，但是在调用inference模型时（predict_e2e.py）是直接通过cv读取的文件，并没有交换红蓝通道，导致最终的识别结果不一致。