### PR TITLE
Update utility.py

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -51,7 +51,7 @@ def get_image_file_list(img_file):
     if img_file is None or not os.path.exists(img_file):
         raise Exception("not found any img file in {}".format(img_file))
 
-    img_end = {'jpg', 'bmp', 'png', 'jpeg', 'rgb', 'tif', 'tiff', 'gif', 'GIF'}
+    img_end = {'jpg', 'bmp', 'png', 'jpeg', 'rgb', 'tif', 'tiff', 'gif', 'GIF','webp','ppm'}
     if os.path.isfile(img_file) and imghdr.what(img_file) in img_end:
         imgs_lists.append(img_file)
     elif os.path.isdir(img_file):


### PR DESCRIPTION
Added missing image formats by checking the [cpython imghdr class](https://github.com/python/cpython/blob/86dfb55d2e091cf633dbd7aabcd49d96fb1f9d81/Lib/imghdr.py). 

(Not sure if `pgm` should be added as well.)


[Issue](https://github.com/PaddlePaddle/PaddleOCR/issues/4422#issuecomment-949586591)

I've also generated different [file formats](https://github.com/mohamadmansourX/PaddleOCR_IMG_Type_Test) for the same picture for testing purposes.