### PR TITLE
removed singleton comparison pitfall from the code

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -318,7 +318,7 @@ class PaddleOCR(predict_system.TextSystem):
         if isinstance(img, list) and det == True:
             logger.error('When input a list of images, det must be false')
             exit(0)
-        if cls == True and self.use_angle_cls == False:
+        if cls and not self.use_angle_cls:
             logger.warning(
                 'Since the angle classifier is not initialized, the angle classifier will not be uesd during the forward process'
             )


### PR DESCRIPTION
**The problem**
The code had a case of the singleton comparison pitfall, which happens when one compares a singleton value, usually True, False and None, with the operator '=='.
In Python its advised to use the operator 'is' when dealing with singletons. In some cases, when the singleton is a boolean, it is also advised to not use an operator at all.
This pitfall was detected using Pylint under the code  C0121, which may be checked here https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0121.html

**The solution**
Removed the '==' operator on the if