### PR TITLE
feat: add support to process https

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -22,6 +22,7 @@ import cv2
 import logging
 import numpy as np
 from pathlib import Path
+from urllib.parse import urlparse
 
 from tools.infer import predict_system
 from ppocr.utils.logging import get_logger
@@ -325,7 +326,7 @@ class PaddleOCR(predict_system.TextSystem):
 
         if isinstance(img, str):
             # download net image
-            if img.startswith('http'):
+            if urlparse(img).scheme in {'http', 'https'}:
                 download_with_progressbar(img, 'tmp.jpg')
                 img = 'tmp.jpg'
             image_file = img

--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -33,7 +33,7 @@ def download_with_progressbar(url, save_path):
             file.write(data)
     progress_bar.close()
     if total_size_in_bytes == 0 or progress_bar.n != total_size_in_bytes:
-        logger.error("Something went wrong while downloading models")
+        logger.error(f"Something went wrong while downloading from {url}")
         sys.exit(0)
 
 


### PR DESCRIPTION
- resolve #4644 with the python built-in [`urllib.parse()`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse)
- fix the misleading logging message