### PR TITLE
Fix the difference between C + + and python preprocessing in rec

### DIFF
--- a/deploy/cpp_infer/src/preprocess_op.cpp
+++ b/deploy/cpp_infer/src/preprocess_op.cpp
@@ -90,8 +90,9 @@ void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
   imgC = rec_image_shape[0];
   imgH = rec_image_shape[1];
   imgW = rec_image_shape[2];
-
-  imgW = int(32 * wh_ratio);
+  float max_wh_radio=imgW * 1.0 / imgH;
+  max_wh_radio = std::max(max_wh_radio,wh_ratio);
+  imgW = int(32 * max_wh_radio);
 
   int resize_w, resize_h;
   if (ceilf(imgH * wh_ratio) > imgW)

--- a/deploy/cpp_infer/src/preprocess_op.cpp
+++ b/deploy/cpp_infer/src/preprocess_op.cpp
@@ -93,12 +93,11 @@ void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
 
   imgW = int(32 * wh_ratio);
 
-  float ratio = float(img.cols) / float(img.rows);
   int resize_w, resize_h;
-  if (ceilf(imgH * ratio) > imgW)
+  if (ceilf(imgH * wh_ratio) > imgW)
     resize_w = imgW;
   else
-    resize_w = int(ceilf(imgH * ratio));
+    resize_w = int(ceilf(imgH * wh_ratio));
 
   cv::resize(img, resize_img, cv::Size(resize_w, imgH), 0.f, 0.f,
              cv::INTER_LINEAR);


### PR DESCRIPTION
The results of c++ and python are different for the same picture,I found that the preprocessing of c++ is different from that of Python.