### PR TITLE
PaddleOCR中Slim 模型导出 export_prune_model

### DIFF
--- a/deploy/slim/prune/export_prune_model.py
+++ b/deploy/slim/prune/export_prune_model.py
@@ -62,9 +62,11 @@ def main(config, device, logger, vdl_writer):
     # build metric
     eval_class = build_metric(config['Metric'])
 
+    # eval 缺少参数 model_type
+    model_type = config['Architecture']['model_type']
     def eval_fn():
         metric = program.eval(model, valid_dataloader, post_process_class,
-                              eval_class)
+                              eval_class,model_type)
         logger.info(f"metric['hmean']: {metric['hmean']}")
         return metric['hmean']
 


### PR DESCRIPTION
PaddleOCR **识别模型**在裁剪后，模型导出报错
```bash
<class 'paddle.nn.layer.pooling.AvgPool2D'>'s flops has been counted
<class 'paddle.nn.layer.conv.Conv2D'>'s flops has been counted
<class 'paddle.fluid.dygraph.nn.BatchNorm'>'s flops has been counted
Cannot find suitable count function for <class 'paddle.nn.layer.pooling.MaxPool2D'>. Treat it as zero FLOPs.
Cannot find suitable count function for <class 'ppocr.modeling.necks.rnn.Im2Seq'>. Treat it as zero FLOPs.
Cannot find suitable count function for <class 'paddle.nn.layer.rnn.LSTMCell'>. Treat it as zero FLOPs.
<class 'paddle.nn.layer.common.Linear'>'s flops has been counted
Total Flops: 651971400     Total Params: 2767820
[2021/11/28 08:24:21] root INFO: FLOPs after pruning: 651971400
[2021/11/28 08:24:21] root INFO: load pretrained model from ['./output/prune_model_ccpd/best_accuracy']
Traceback (most recent call last):
  File "deploy/slim/prune/export_prune_model.py", line 128, in <module>
    main(config, device, logger, vdl_writer)
  File "deploy/slim/prune/export_prune_model.py", line 96, in main
    eval_class)
TypeError: eval() missing 1 required positional argument: 'model_type'
PaddleOCR 中deploy/slim/prune/export_prune_model.py 中，eval 缺少参数model_type
```
```python
# 修改前
def eval_fn():
    metric = program.eval(model, valid_dataloader, post_process_class,
                             eval_class)
# 修改后
def eval_fn():
    metric = program.eval(model, valid_dataloader, post_process_class,
                           eval_class,model_type)
```
**program.py**中
```python
def eval(model,
         valid_dataloader,
         post_process_class,
         eval_class,
         model_type,
         use_srn=False):
    model.eval()
```