### PR TITLE
修正检测模型转换后效果不一致问题

### DIFF
--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -40,10 +40,7 @@ class TextDetector(object):
         self.det_algorithm = args.det_algorithm
         self.use_onnx = args.use_onnx
         pre_process_list = [{
-            'DetResizeForTest': {
-                'limit_side_len': args.det_limit_side_len,
-                'limit_type': args.det_limit_type,
-            }
+            'DetResizeForTest': None
         }, {
             'NormalizeImage': {
                 'std': [0.229, 0.224, 0.225],


### PR DESCRIPTION
这个问题本来在[这个PR](https://github.com/PaddlePaddle/PaddleOCR/pull/2091)解决了，但是在[这个PR](https://github.com/PaddlePaddle/PaddleOCR/pull/2651)又被改了回去。。