### PR TITLE
Update pipeline_http_client.py

### DIFF
--- a/deploy/pdserving/pipeline_http_client.py
+++ b/deploy/pdserving/pipeline_http_client.py
@@ -36,5 +36,4 @@ for idx, img_file in enumerate(os.listdir(test_img_dir)):
         r = requests.post(url=url, data=json.dumps(data))
         print(r.json())
 
-test_img_dir = "../../doc/imgs/"
 print("==> total number of test imgs: ", len(os.listdir(test_img_dir)))


### PR DESCRIPTION
the second test_img_dir assignment is not necessary:
after it is defined,  it's not modified. We can use it anyway.