### PR TITLE
update read image function

### DIFF
--- a/ppocr/data/imaug/operators.py
+++ b/ppocr/data/imaug/operators.py
@@ -45,10 +45,20 @@ class DecodeImage(object):
                     img) > 0, "invalid input 'img' in DecodeImage"
             img = np.frombuffer(img, dtype='uint8')
             img = cv2.imdecode(img, 1)
+            if img is None:
+                return None
+            if self.img_mode == 'GRAY':
+                img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            elif self.img_mode == 'RGB':
+                assert img.shape[2] == 3, 'invalid shape of image[%s]' % (
+                    img.shape)
+                img = img[:, :, ::-1]
         else:
             img_path = data['img_path']
             img = Image.open(img_path).convert('RGB')
             img = cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)
+            if img is None:
+                return None
 
         if img is None:
             return None

--- a/ppocr/data/pgnet_dataset.py
+++ b/ppocr/data/pgnet_dataset.py
@@ -87,9 +87,6 @@ class PGDataSet(Dataset):
             data = {'img_path': img_path, 'label': label, 'img_id': img_id}
             if not os.path.exists(img_path):
                 raise Exception("{} does not exist!".format(img_path))
-            with open(data['img_path'], 'rb') as f:
-                img = f.read()
-                data['image'] = img
             outs = transform(data, self.ops)
         except Exception as e:
             self.logger.error(

--- a/ppocr/data/pubtab_dataset.py
+++ b/ppocr/data/pubtab_dataset.py
@@ -70,7 +70,7 @@ class PubTabDataSet(Dataset):
                 prob = self.img_select_prob[file_name]
                 if prob < random.uniform(0, 1):
                     select_flag = False
-            
+
             if self.table_select_type:
                 structure = info['html']['structure']['tokens'].copy()
                 structure_str = ''.join(structure)
@@ -79,18 +79,19 @@ class PubTabDataSet(Dataset):
                     table_type = "complex"
                 if table_type == "complex":
                     if self.table_select_prob < random.uniform(0, 1):
-                        select_flag = False                    
-            
+                        select_flag = False
+
             if select_flag:
                 cells = info['html']['cells'].copy()
                 structure = info['html']['structure'].copy()
                 img_path = os.path.join(self.data_dir, file_name)
-                data = {'img_path': img_path, 'cells': cells, 'structure':structure}
+                data = {
+                    'img_path': img_path,
+                    'cells': cells,
+                    'structure': structure
+                }
                 if not os.path.exists(img_path):
                     raise Exception("{} does not exist!".format(img_path))
-                with open(data['img_path'], 'rb') as f:
-                    img = f.read()
-                    data['image'] = img
                 outs = transform(data, self.ops)
             else:
                 outs = None

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -95,7 +95,7 @@ class SimpleDataSet(Dataset):
                 data['image'] = img
             data = transform(data, load_data_ops)
 
-            if data is None or data['polys'].shape[1]!=4:
+            if data is None or data['polys'].shape[1] != 4:
                 continue
             ext_data.append(data)
         return ext_data
@@ -112,9 +112,7 @@ class SimpleDataSet(Dataset):
             data = {'img_path': img_path, 'label': label}
             if not os.path.exists(img_path):
                 raise Exception("{} does not exist!".format(img_path))
-            with open(data['img_path'], 'rb') as f:
-                img = f.read()
-                data['image'] = img
+
             data['ext_data'] = self.get_ext_data()
             outs = transform(data, self.ops)
         except:


### PR DESCRIPTION
在参加OCR十讲课程中，有使用到[官方指定的数据集det_data_lesson_demo](https://paddleocr.bj.bcebos.com/dataset/det_data_lesson_demo.tar)。在使用过程中发现，其中有很多是gif格式的图片（但后缀是```.jpg```），通过PaddleOCR官方的代码读取这些数据后全部为None（例如：```mtwi/train/TB1Zj7Un4rI8KJjy0FpXXb5hVXa_!!1-item_pic.gif.jpg```），还有些数据opencv会报```Corrupt JPEG data```看着很难受（例如：```xfun/train/zh_train_43.jpg```）。详情可以查看 [#5092](https://github.com/PaddlePaddle/PaddleOCR/issues/5029)。

PaddleOCR官方读取图片方式精简如下：
```python
with open(img_path, 'rb') as f:
    img = f.read()
img = np.frombuffer(img, dtype='uint8')
img = cv2.imdecode(img, 1)
```

我将图片读取的方式修改成：
```python
img = Image.open(img_path).convert('RGB')
img = cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)
```
通过我提供的方式读取gif图片时能够正常读取不会为None，并且也解决了opencv报```Corrupt JPEG data```警告的问题。