### PR TITLE
update paddle2onnx readme and fix a bug for onnx（issue:5055)

### DIFF
--- a/deploy/paddle2onnx/readme.md
+++ b/deploy/paddle2onnx/readme.md
@@ -18,8 +18,8 @@ python3.7 -m pip install paddle2onnx
 
 - 安装 ONNX
 ```
-# 建议安装 1.4.0 版本，可根据环境更换版本号
-python3.7 -m pip install onnxruntime==1.4.0
+# 建议安装 1.9.0 版本，可根据环境更换版本号
+python3.7 -m pip install onnxruntime==1.9.0
 ```
 
 ## 2. 模型转换
@@ -47,13 +47,15 @@ paddle2onnx --model_dir=./inference/ch_ppocr_mobile_v2.0_det_infer/ \
 --params_filename=inference.pdiparams \
 --save_file=./inference/det_mobile_onnx/model.onnx \
 --opset_version=10 \
+--input_shape_dict="{'x': [-1, 3, -1, -1]}" \
 --enable_onnx_checker=True
 ```
 
 执行完毕后，ONNX 模型会被保存在 `./inference/det_mobile_onnx/` 路径下
 
-* 注意：以下几个模型暂不支持转换为 ONNX 模型：
-NRTR、SAR、RARE、SRN
+* 注意：对于OCR模型，转化过程中必须采用动态shape的形式，即加入选项--input_shape_dict="{'x': [-1, 3, -1, -1]}"，否则预测结果可能与直接使用Paddle预测有细微不同。
+  另外，以下几个模型暂不支持转换为 ONNX 模型：
+  NRTR、SAR、RARE、SRN
 
 ## 3. onnx 预测
 
@@ -72,5 +74,3 @@ root INFO: 1.jpg  [[[291, 295], [334, 292], [348, 844], [305, 847]], [[344, 296]
 The predict time of ../../doc/imgs/1.jpg: 0.06162881851196289
 The visualized image saved in ./inference_results/det_res_1.jpg
 ```
-
-* 注意：ONNX暂时不支持变长预测，需要将输入resize到固定输入，预测结果可能与直接使用Paddle预测有细微不同。

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -101,16 +101,21 @@ class TextDetector(object):
         else:
             logger.info("unknown det_algorithm:{}".format(self.det_algorithm))
             sys.exit(0)
-        if self.use_onnx:
-            pre_process_list[0] = {
-                'DetResizeForTest': {
-                    'image_shape': [640, 640]
-                }
-            }
+
         self.preprocess_op = create_operators(pre_process_list)
         self.postprocess_op = build_post_process(postprocess_params)
         self.predictor, self.input_tensor, self.output_tensors, self.config = utility.create_predictor(
             args, 'det', logger)
+
+        if self.use_onnx:
+            img_h, img_w = self.input_tensor.shape[2:]
+            if img_h is not None and img_w is not None and img_h > 0 and img_w > 0:
+                pre_process_list[0] = {
+                    'DetResizeForTest': {
+                        'image_shape': [img_h, img_w]
+                    }
+                }
+        self.preprocess_op = create_operators(pre_process_list)
 
         if args.benchmark:
             import auto_log

--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -109,7 +109,10 @@ class TextRecognizer(object):
         assert imgC == img.shape[2]
         imgW = int((32 * max_wh_ratio))
         if self.use_onnx:
-            imgW = 100
+            w = self.input_tensor.shape[3:][0]
+            if w is not None and w > 0:
+                imgW = w
+
         h, w = img.shape[:2]
         ratio = w / float(h)
         if math.ceil(imgH * ratio) > imgW:


### PR DESCRIPTION
更新paddle2onnx 部署文档，支持OCR动态shape的转换
修复当采用固定shape转换onnx时，输入数据应该和onnx的输入大小保持一致
解决issue: PaddleOCR的模型转成onnx后的推理结果与原版不一致，精度差很多。 [Paddle2ONNX#451](https://github.com/PaddlePaddle/Paddle2ONNX/issues/451)
解决issue: PaddleOCR的模型转成onnx后的推理结果与原版不一致，精度差很多 #5055