### PR TITLE
fix plt.imshow BGR image

### DIFF
--- a/notebook/notebook_ch/2.text_detection/文本检测实践篇.ipynb
+++ b/notebook/notebook_ch/2.text_detection/文本检测实践篇.ipynb
@@ -218,7 +218,7 @@
     "\n",
     "# 画出读取的图片\n",
     "plt.figure(figsize=(10, 10))\n",
-    "plt.imshow(image)\n"
+    "plt.imshow(image[:, :, ::-1])\n"
    ]
   },
   {

--- a/notebook/notebook_ch/3.text_recognition/文本识别实践部分.ipynb
+++ b/notebook/notebook_ch/3.text_recognition/文本识别实践部分.ipynb
@@ -445,12 +445,12 @@
     "plt.figure()\n",
     "plt.subplot(2,1,1)\n",
     "# 可视化原图\n",
-    "plt.imshow(raw_img)\n",
+    "plt.imshow(raw_img[:, :, ::-1])\n",
     "# 缩放并归一化\n",
     "padding_im, draw_img = resize_norm_img(raw_img)\n",
     "plt.subplot(2,1,2)\n",
     "# 可视化网络输入图\n",
-    "plt.imshow(draw_img)\n",
+    "plt.imshow(draw_img[:, :, ::-1])\n",
     "plt.show()"
    ]
   },
@@ -1475,12 +1475,12 @@
     "plt.figure()\n",
     "plt.subplot(2,1,1)\n",
     "# 可视化原图\n",
-    "plt.imshow(raw_img)\n",
+    "plt.imshow(raw_img[:, :, ::-1])\n",
     "# 随机切割\n",
     "crop_img = get_crop(raw_img)\n",
     "plt.subplot(2,1,2)\n",
     "# 可视化增广图\n",
-    "plt.imshow(crop_img)\n",
+    "plt.imshow(crop_img[:, :, ::-1])\n",
     "plt.show()"
    ]
   },

--- a/notebook/notebook_ch/6.document_analysis/文档分析实战-VQA.ipynb
+++ b/notebook/notebook_ch/6.document_analysis/文档分析实战-VQA.ipynb
@@ -313,7 +313,7 @@
     "\n",
     "img = cv2.imread('output/res_e2e/zh_val_42_ser.jpg')\n",
     "plt.figure(figsize=(48,24))\n",
-    "plt.imshow(img)"
+    "plt.imshow(img[:, :, ::-1])"
    ]
   },
   {

--- a/notebook/notebook_ch/6.document_analysis/文档分析实战-表格识别.ipynb
+++ b/notebook/notebook_ch/6.document_analysis/文档分析实战-表格识别.ipynb
@@ -255,7 +255,7 @@
     "\n",
     "# 读取表格图像并显示\n",
     "img = cv2.imread('/home/aistudio/1.jpg')\n",
-    "plt.imshow(img)"
+    "plt.imshow(img[:, :, ::-1])"
    ]
   },
   {
@@ -478,7 +478,7 @@
     "# 显示输入图像\n",
     "plt.subplot(1,3,1)\n",
     "plt.title('src, shape:{}'.format(img.shape))\n",
-    "plt.imshow(img)\n",
+    "plt.imshow(img[:, :, ::-1])\n",
     "\n",
     "# 执行 ResizeTableImage\n",
     "# https://github.com/PaddlePaddle/PaddleOCR/blob/dygraph/ppocr/data/imaug/gen_table_mask.py#L182\n",
@@ -491,7 +491,7 @@
     "# 显示 ResizeTableImage 后的图像\n",
     "plt.subplot(1,3,2)\n",
     "plt.title('ResizeTableImage, shape:{}'.format(data['image'].shape))\n",
-    "plt.imshow(data['image'])\n",
+    "plt.imshow(data['image'][:, :, ::-1])\n",
     "\n",
     "# 执行 PaddingTableImage\n",
     "# https://github.com/PaddlePaddle/PaddleOCR/blob/dygraph/ppocr/data/imaug/gen_table_mask.py#L232\n",
@@ -504,7 +504,7 @@
     "# 显示 PaddingTableImage 后的图像\n",
     "plt.subplot(1,3,3)\n",
     "plt.title('PaddingTableImage, shape:{}'.format(data['image'].shape))\n",
-    "plt.imshow(data['image']/255)\n",
+    "plt.imshow(data['image'][:, :, ::-1]/255)\n",
     "plt.show()\n",
     "\n",
     "# 定义完整的处理op列表\n",
@@ -902,7 +902,7 @@
     "img_show = img.copy()\n",
     "for box in res_loc_final:\n",
     "    cv2.rectangle(img_show, (box[0], box[1]), (box[2], box[3]), (0, 255, 0), 2)\n",
-    "plt.imshow(img_show)"
+    "plt.imshow(img_show[:, :, ::-1])"
    ]
   },
   {


### PR DESCRIPTION
文档中有多处使用opencv读取图片，然后直接使用plt.imshow的方式进行可视化，中间漏了一步将BGR转RGB的过程。例如：
```python
# 4. 可视化检测结果
image = cv2.imread(img_path)
boxes = [line[0] for line in result]
for box in result:
    box = np.reshape(np.array(box), [-1, 1, 2]).astype(np.int64)
    image = cv2.polylines(np.array(image), [box], True, (255, 0, 0), 2)

# 画出读取的图片
plt.figure(figsize=(10, 10))
plt.imshow(image)
```


![image](https://user-images.githubusercontent.com/31005897/147652335-050bbaef-5e77-43c1-8962-d0a58230b51a.png)
