### PR TITLE
使用markdownlint规范Markdown文档

### DIFF
--- a/doc/doc_ch/customize.md
+++ b/doc/doc_ch/customize.md
@@ -5,17 +5,21 @@
 ## step1：训练文本检测模型
 
 PaddleOCR提供了EAST、DB两种文本检测算法，均支持MobileNetV3、ResNet50_vd两种骨干网络，根据需要选择相应的配置文件，启动训练。例如，训练使用MobileNetV3作为骨干网络的DB检测模型（即超轻量模型使用的配置）：
-```
+
+```sh
 python3 tools/train.py -c configs/det/det_mv3_db.yml 2>&1 | tee det_db.log
 ```
+
 更详细的数据准备和训练教程参考文档教程中[文本检测模型训练/评估/预测](./detection.md)。
 
 ## step2：训练文本识别模型
 
 PaddleOCR提供了CRNN、Rosetta、STAR-Net、RARE四种文本识别算法，均支持MobileNetV3、ResNet34_vd两种骨干网络，根据需要选择相应的配置文件，启动训练。例如，训练使用MobileNetV3作为骨干网络的CRNN识别模型（即超轻量模型使用的配置）：
-```
+
+```sh
 python3 tools/train.py -c configs/rec/rec_chinese_lite_train.yml 2>&1 | tee rec_ch_lite.log
 ```
+
 更详细的数据准备和训练教程参考文档教程中[文本识别模型训练/评估/预测](./recognition.md)。
 
 ## step3：模型串联预测
@@ -24,7 +28,8 @@ PaddleOCR提供了检测和识别模型的串联工具，可以将训练好的�
 
 在执行预测时，需要通过参数image_dir指定单张图像或者图像集合的路径、参数det_model_dir指定检测inference模型的路径和参数rec_model_dir指定识别inference模型的路径。可视化识别结果默认保存到 ./inference_results 文件夹里面。
 
-```
+```sh
 python3 tools/infer/predict_system.py --image_dir="./doc/imgs/11.jpg" --det_model_dir="./inference/det/"  --rec_model_dir="./inference/rec/"
 ```
+
 更多的文本检测、识别串联推理使用方式请参考文档教程中的[基于预测引擎推理](./inference.md)。


### PR DESCRIPTION
## 现状

PaddleOCR中几乎所有的Markdown文档都不规范（没有符合markdownlint标准），如下图所示。

![customize.jpg](https://ai-studio-static-online.cdn.bcebos.com/3135ac13e9c34d3b900e6db385abb517b23ceda746a34d1e9e115abcdd246a44)

## 为什么要符合规范

规范的代码对于一个项目的重要性是不言而喻的，同样Markdown文档也需要符合规范。

我坚决不允许这么优秀的开源项目的文档写得不规范！！！

## 解决方法

我这次只把`doc/doc_ch/customize.md`文档规范了，如果贵项目也觉得有必要规范一下文档，那么我们可以一起进行文档的规范化工作。