### PR TITLE
fix the default value of predictor inputStd in android example

### DIFF
--- a/deploy/android_demo/app/src/main/java/com/baidu/paddle/lite/demo/ocr/Predictor.java
+++ b/deploy/android_demo/app/src/main/java/com/baidu/paddle/lite/demo/ocr/Predictor.java
@@ -34,7 +34,7 @@ public class Predictor {
     protected String inputColorFormat = "BGR";
     protected long[] inputShape = new long[]{1, 3, 960};
     protected float[] inputMean = new float[]{0.485f, 0.456f, 0.406f};
-    protected float[] inputStd = new float[]{1.0f / 0.229f, 1.0f / 0.224f, 1.0f / 0.225f};
+    protected float[] inputStd = new float[]{0.229f, 0.224f, 0.225f};
     protected float scoreThreshold = 0.1f;
     protected Bitmap inputImage = null;
     protected Bitmap outputImage = null;


### PR DESCRIPTION
In the Predictor class of the Android sample code, the default value of the inputStd variable is wrong, because the default value read from strings.xml is 0.485, 0.456, 0.406. Since the variable has been reassigned, this bug is not easy to find.