### PR TITLE
【PPOCRLabel】: Improve User Experience and Efficiency

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -180,7 +180,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
         fileListContainer = QWidget()
         fileListContainer.setLayout(filelistLayout)
-        self.filedock = QDockWidget(getStr('fileList'), self)
+        self.fileListName = getStr('fileList')
+        self.filedock = QDockWidget(self.fileListName, self)
         self.filedock.setObjectName(getStr('files'))
         self.filedock.setWidget(fileListContainer)
         self.addDockWidget(Qt.LeftDockWidgetArea, self.filedock)
@@ -1378,6 +1379,12 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.labelList.setCurrentItem(self.labelList.item(self.labelList.count() - 1))
                 self.labelList.item(self.labelList.count() - 1).setSelected(True)
 
+            # show file list image count
+            select_indexes = self.fileListWidget.selectedIndexes()
+            if len(select_indexes) > 0:
+                self.filedock.setWindowTitle(self.fileListName + f" ({select_indexes[0].row()}"
+                                                                 f"/{self.fileListWidget.count()})")
+
             self.canvas.setFocus(True)
             return True
         return False
@@ -1578,7 +1585,8 @@ class MainWindow(QMainWindow, WindowMixin):
         self.actions.rotateLeft.setEnabled(True)
         self.actions.rotateRight.setEnabled(True)
 
-
+        self.fileListWidget.setCurrentRow(0)  # set list index to first
+        self.filedock.setWindowTitle(self.fileListName + f" (1/{self.fileListWidget.count()})")  # show image count
 
     def openPrevImg(self, _value=False):
         if len(self.mImgList) <= 0:

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1740,7 +1740,10 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def discardChangesDialog(self):
         yes, no, cancel = QMessageBox.Yes, QMessageBox.No, QMessageBox.Cancel
-        msg = u'You have unsaved changes, would you like to save them and proceed?\nClick "No" to undo all changes.'
+        if self.lang == 'ch':
+            msg = u'您有未保存的变更, 您想保存再继续吗?\n点击 "No" 丢弃所有未保存的变更.'
+        else:
+            msg = u'You have unsaved changes, would you like to save them and proceed?\nClick "No" to undo all changes.'
         return QMessageBox.warning(self, u'Attention', msg, yes | no | cancel)
 
     def errorMessage(self, title, message):

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -101,6 +101,8 @@ class MainWindow(QMainWindow, WindowMixin):
     def __init__(self, lang="ch", gpu=False, defaultFilename=None, defaultPrefdefClassFile=None, defaultSaveDir=None):
         super(MainWindow, self).__init__()
         self.setWindowTitle(__appname__)
+        self.setWindowState(Qt.WindowMaximized)  # set window max
+        self.activateWindow()  # label tool go to the front when activate
 
         # Load setting in the main thread
         self.settings = Settings()

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -397,7 +397,7 @@ class MainWindow(QMainWindow, WindowMixin):
                         'w', 'objects', getStr('crtBoxDetail'), enabled=False)
 
         delete = action(getStr('delBox'), self.deleteSelectedShape,
-                        'backspace', 'delete', getStr('delBoxDetail'), enabled=False)
+                        'Ctrl+T', 'delete', getStr('delBoxDetail'), enabled=False)
         copy = action(getStr('dupBox'), self.copySelectedShape,
                       'Ctrl+C', 'copy', getStr('dupBoxDetail'),
                       enabled=False)

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1382,7 +1382,7 @@ class MainWindow(QMainWindow, WindowMixin):
             # show file list image count
             select_indexes = self.fileListWidget.selectedIndexes()
             if len(select_indexes) > 0:
-                self.filedock.setWindowTitle(self.fileListName + f" ({select_indexes[0].row()}"
+                self.filedock.setWindowTitle(self.fileListName + f" ({select_indexes[0].row() + 1}"
                                                                  f"/{self.fileListWidget.count()})")
 
             self.canvas.setFocus(True)

--- a/PPOCRLabel/README.md
+++ b/PPOCRLabel/README.md
@@ -151,7 +151,7 @@ python PPOCRLabel.py
 | Ctrl + R                 | Re-recognize the selected box                    |
 | Ctrl + C                 | Copy and paste the selected box                  |
 | Ctrl + Left Mouse Button | Multi select the label box                       |
-| Backspace                | Delete the selected box                          |
+| Ctrl+T                   | Delete the selected box                          |
 | Ctrl + V                 | Check image                                      |
 | Ctrl + Shift + d         | Delete image                                     |
 | D                        | Next image                                       |

--- a/PPOCRLabel/README_ch.md
+++ b/PPOCRLabel/README_ch.md
@@ -139,8 +139,8 @@ python PPOCRLabel.py --lang ch
 | Ctrl + E         | 编辑所选框标签               |
 | Ctrl + R         | 重新识别所选标记             |
 | Ctrl + C         | 复制并粘贴选中的标记框       |
-| Ctrl + 鼠标左键  | 多选标记框                   |
-| Backspace        | 删除所选框                   |
+| Ctrl + 鼠标左键   | 多选标记框                   |
+| Ctrl+T           | 删除所选框                   |
 | Ctrl + V         | 确认本张图片标记             |
 | Ctrl + Shift + d | 删除本张图片                 |
 | D                | 下一张图片                   |

--- a/PPOCRLabel/libs/autoDialog.py
+++ b/PPOCRLabel/libs/autoDialog.py
@@ -6,6 +6,8 @@ except ImportError:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
+import time
+import datetime
 import json
 import cv2
 import numpy as np
@@ -76,12 +78,13 @@ class AutoDialog(QDialog):
 
     def __init__(self, text="Enter object label", parent=None, ocr=None, mImgList=None, lenbar=0):
         super(AutoDialog, self).__init__(parent)
+        self.lender = lenbar
         self.setFixedWidth(1000)
         self.parent = parent
         self.ocr = ocr
         self.mImgList = mImgList
         self.pb = QProgressBar()
-        self.pb.setRange(0, lenbar)
+        self.pb.setRange(0, self.lender)
         self.pb.setValue(0)
 
         layout = QVBoxLayout()
@@ -108,9 +111,15 @@ class AutoDialog(QDialog):
         self.thread_1.progressBarValue.connect(self.handleProgressBarSingal)
         self.thread_1.listValue.connect(self.handleListWidgetSingal)
         self.thread_1.endsignal.connect(self.handleEndsignalSignal)
+        self.time_start = time.time()
 
     def handleProgressBarSingal(self, i):
         self.pb.setValue(i)
+
+        # calculate time left of auto labeling
+        avg_time = (time.time() - self.time_start) / i  # Use average time to prevent time fluctuations
+        time_left = str(datetime.timedelta(seconds=avg_time * (self.lender - i)))
+        self.setWindowTitle("PPOCRLabel  --  " + f"Time Left: {time_left}")  # show
 
     def handleListWidgetSingal(self, i):
         self.listWidget.addItem(i)


### PR DESCRIPTION
感谢 PPOCRLabel 这款非常优秀的打标签工具 🚀  ，这里我从使用者的角度提交了`5`点改进，请审核😄：  

1、**当使用中文作为语言时，优化丢弃更改对话框注意信息**。（提交：`519e77f43bcde4ca9cdbf4b2a475e6bd0e4eb60f`）
![image](https://user-images.githubusercontent.com/25873202/149936782-090fab44-f4c5-4c58-92b2-5333131fba66.png)

2、**当软件打开的时候，将窗口设置为最大化，并将窗口转到前面。** 因为我自己第一次用的时候，我等了好久都不见软件启动，低头看状态栏的时候才发现已经启动了，故提出这点改进。（提交：`855bc0f7b819513890200e47e073fa0581755585`）

3、**在【文件列表】加入图片张数和目前在第几张的显示**，因为在打标签的时候不知道第几张了，用于评估时间等，有利于打标签er更好的体验（下方有图）（提交：`3d0ad4f5de6a0232e7f2efa089a19b1e5d2c28d7`、`27f08ab0fd239f23ea94bc6c54b47f51c39db26b`）
![image](https://user-images.githubusercontent.com/25873202/149935736-9452bca3-1e38-43ed-b313-2dc171c8db93.png)

4、**在【自动标注】的时候加上时间显示**，以便使用者更好地去掌握剩余时间（下方有图）（提交：`d007e9d9d58afd9293d2daa52029cdffab5eb061`）
![image](https://user-images.githubusercontent.com/25873202/149935610-62bb5860-ede6-41eb-99c9-d5dd82dfc140.png)

5、**更改删除快捷键为【Ctrl+T】**，因为如果使用 backspace 实在太远了，右手拿着鼠标如果去按效率很低，左手去按同样的体验不好，效率下来了，我考虑到大佬是因为 backspace 比较远是因为怕误触，所以这里使用了一个稍微远一点的【T】 而且加了【Ctrl】，可以左手不用移动就可以操作，而且误触概率基本为零，一举两得（提交：`009575161563a0ecbd8a682d79a37d7e3cd224f3`）
