### PR TITLE
fix ips info and reduce interval of metric calc

### DIFF
--- a/ppocr/losses/rec_ctc_loss.py
+++ b/ppocr/losses/rec_ctc_loss.py
@@ -31,7 +31,8 @@ class CTCLoss(nn.Layer):
             predicts = predicts[-1]
         predicts = predicts.transpose((1, 0, 2))
         N, B, _ = predicts.shape
-        preds_lengths = paddle.to_tensor([N] * B, dtype='int64')
+        preds_lengths = paddle.to_tensor(
+            [N] * B, dtype='int64', place=paddle.CPUPlace())
         labels = batch[1].astype("int32")
         label_lengths = batch[2].astype('int64')
         loss = self.loss_func(predicts, labels, preds_lengths, label_lengths)


### PR DESCRIPTION
### 1. 背景
ips与log打印的日志无法对应（按照ips计算得出的训练耗时与实际log的时间戳不同）

###  2. 优化项
* 修复ips信息可视化结果
* 添加训练时计算metric的时间间隔控制，加速训练
* 将ctc loss的pred_length生成在cpu上（本身ctc loss计算，也要求数据在cpu上），防止cloud上v100训练hang住的问题，同时减少个gpu->cpu拷贝

### 3. 结果

#### 3.1 默认代码的信息打印（每个iter是0.5s，但是根据ips计算的话，只需要0.2s左右）
* 命令：`python tools/train.py -c configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml`
* 可视化结果：

![641db53961c36d0410c7e74ee9d7dabb](https://user-images.githubusercontent.com/14270174/152787156-ae6b29cc-7e7e-451f-b0b0-0fd808b757e0.png)

#### 3.2 修复ips信息

* 命令：`python tools/train.py -c configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml`
* 可视化结果：

![aa5507876f2a9c6eee84157000bfc7cc](https://user-images.githubusercontent.com/14270174/152787657-b482f657-1a20-4161-8e17-e4e083ea43c7.png)

#### 3.3 metric的时间间隔控制，加速训练
* 命令：`python tools/train.py -c configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml -o Global.calc_epoch_interval=10`
* 可视化结果（ips 255 -> ~330）：

![fb61713b71a2a204157149479427d422](https://user-images.githubusercontent.com/14270174/152787777-0daff89b-bf2a-42cd-be6f-f678eaab10be.png)


#### 3.4 pred length在cpu上生成

* 命令：`python tools/train.py -c configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml -o Global.calc_epoch_interval=10`
* 可视化结果(eta 7d18h -> 7d6h)：

![1eeed9230dfa62f8729ef39497129b1e](https://user-images.githubusercontent.com/14270174/152787866-94f3e1a3-7430-4b21-b80d-2e0b207b3696.png)


