### PR TITLE
[TIPC] Fix cmake path bug

### DIFF
--- a/test_tipc/test_inference_cpp.sh
+++ b/test_tipc/test_inference_cpp.sh
@@ -150,7 +150,7 @@ if [ ${use_opencv} = "True" ]; then
 
         make -j
         make install
-        cd ../
+        cd ../..
         echo "################### build opencv finished ###################"
     fi
 fi


### PR DESCRIPTION
解决编译opencv之后，编译ocr inference demo路径错误的问题。
https://github.com/PaddlePaddle/PaddleOCR/blob/c70f769eca3c0a179e745bc8356af942438e0442/test_tipc/test_inference_cpp.sh#L169