### PR TITLE
fix log print twice error

### DIFF
--- a/ppocr/utils/logging.py
+++ b/ppocr/utils/logging.py
@@ -26,7 +26,7 @@ logger_initialized = {}
 
 
 @functools.lru_cache()
-def get_logger(name='root', log_file=None, log_level=logging.DEBUG):
+def get_logger(name='ppocr', log_file=None, log_level=logging.DEBUG):
     """Initialize and get a logger by name.
     If the logger has not been initialized, this method will initialize the
     logger by adding one or two handlers, otherwise the initialized logger will
@@ -67,4 +67,5 @@ def get_logger(name='root', log_file=None, log_level=logging.DEBUG):
     else:
         logger.setLevel(logging.ERROR)
     logger_initialized[name] = True
+    logger.propagate = False
     return logger

--- a/test_tipc/supplementary/config.py
+++ b/test_tipc/supplementary/config.py
@@ -122,7 +122,7 @@ def preprocess(is_train=False):
         log_file = '{}/train.log'.format(save_model_dir)
     else:
         log_file = None
-    logger = get_logger(name='root', log_file=log_file)
+    logger = get_logger(log_file=log_file)
 
     # check if set use_gpu=True in paddlepaddle cpu version
     use_gpu = config['use_gpu']

--- a/tools/infer_vqa_token_ser_re.py
+++ b/tools/infer_vqa_token_ser_re.py
@@ -151,7 +151,7 @@ def preprocess():
     ser_config = load_config(FLAGS.config_ser)
     ser_config = merge_config(ser_config, FLAGS.opt_ser)
 
-    logger = get_logger(name='root')
+    logger = get_logger()
 
     # check if set use_gpu=True in paddlepaddle cpu version
     use_gpu = config['Global']['use_gpu']

--- a/tools/program.py
+++ b/tools/program.py
@@ -525,7 +525,7 @@ def preprocess(is_train=False):
         log_file = '{}/train.log'.format(save_model_dir)
     else:
         log_file = None
-    logger = get_logger(name='root', log_file=log_file)
+    logger = get_logger(log_file=log_file)
 
     # check if set use_gpu=True in paddlepaddle cpu version
     use_gpu = config['Global']['use_gpu']


### PR DESCRIPTION
某些情况下，当其他程序配置了root logger后，会造成当前logger重复打印两次，这是因为所有logger都是继承自root logger，因此会打印两次。将logger.propagate设置False可避免这种情况 ，设置之后不能使用root logger，需要使用自定义的logger