### PR TITLE
bugfix: unable to save Korean to the specified file: system_results.txt

### DIFF
--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -195,7 +195,7 @@ def main(args):
         text_sys.text_detector.autolog.report()
         text_sys.text_recognizer.autolog.report()
 
-    with open(os.path.join(draw_img_save_dir, "system_results.txt"), 'w') as f:
+    with open(os.path.join(draw_img_save_dir, "system_results.txt"), 'w', encoding='utf-8') as f:
         f.writelines(save_results)
 
 


### PR DESCRIPTION
在使用tools/infer/predict_system.py对韩文进行预测时，无法保存韩文到用于存放识别结果的system_results.txt文件，并报错：
![I2(Y)G%DB8OT2__(A((GPT0](https://user-images.githubusercontent.com/33342388/161070083-7611fb57-6d0f-4add-82ce-5e9996115372.png)
修改之后能够正常保存：
![WV{I~83)EYOBN79@W~}BB`X](https://user-images.githubusercontent.com/33342388/161070168-0c27dbe1-ea68-43fc-8843-6e4f6d24b600.png)
