### PR TITLE
rename PaddleOCR to PPOCR

### DIFF
--- a/deploy/cpp_infer/include/paddleocr.h
+++ b/deploy/cpp_infer/include/paddleocr.h
@@ -39,10 +39,10 @@ using namespace paddle_infer;
 
 namespace PaddleOCR {
 
-class PaddleOCR {
+class PPOCR {
 public:
-  explicit PaddleOCR();
-  ~PaddleOCR();
+  explicit PPOCR();
+  ~PPOCR();
   std::vector<std::vector<OCRPredictResult>>
   ocr(std::vector<cv::String> cv_all_img_names, bool det = true,
       bool rec = true, bool cls = true);

--- a/deploy/cpp_infer/include/utility.h
+++ b/deploy/cpp_infer/include/utility.h
@@ -65,6 +65,8 @@ public:
 
   static bool PathExists(const std::string &path);
 
+  static void CreateDir(const std::string &path);
+
   static void print_result(const std::vector<OCRPredictResult> &ocr_result);
 };
 

--- a/deploy/cpp_infer/src/main.cpp
+++ b/deploy/cpp_infer/src/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   cv::glob(FLAGS_image_dir, cv_all_img_names);
   std::cout << "total images num: " << cv_all_img_names.size() << endl;
 
-  PaddleOCR::PaddleOCR ocr = PaddleOCR::PaddleOCR();
+  PPOCR ocr = PPOCR();
 
   std::vector<std::vector<OCRPredictResult>> ocr_results =
       ocr.ocr(cv_all_img_names, FLAGS_det, FLAGS_rec, FLAGS_cls);

--- a/deploy/cpp_infer/src/paddleocr.cpp
+++ b/deploy/cpp_infer/src/paddleocr.cpp
@@ -21,7 +21,7 @@
 
 namespace PaddleOCR {
 
-PaddleOCR::PaddleOCR() {
+PPOCR::PPOCR() {
   if (FLAGS_det) {
     this->detector_ = new DBDetector(
         FLAGS_det_model_dir, FLAGS_use_gpu, FLAGS_gpu_id, FLAGS_gpu_mem,
@@ -45,8 +45,8 @@ PaddleOCR::PaddleOCR() {
   }
 };
 
-void PaddleOCR::det(cv::Mat img, std::vector<OCRPredictResult> &ocr_results,
-                    std::vector<double> &times) {
+void PPOCR::det(cv::Mat img, std::vector<OCRPredictResult> &ocr_results,
+                std::vector<double> &times) {
   std::vector<std::vector<std::vector<int>>> boxes;
   std::vector<double> det_times;
 
@@ -63,9 +63,9 @@ void PaddleOCR::det(cv::Mat img, std::vector<OCRPredictResult> &ocr_results,
   times[2] += det_times[2];
 }
 
-void PaddleOCR::rec(std::vector<cv::Mat> img_list,
-                    std::vector<OCRPredictResult> &ocr_results,
-                    std::vector<double> &times) {
+void PPOCR::rec(std::vector<cv::Mat> img_list,
+                std::vector<OCRPredictResult> &ocr_results,
+                std::vector<double> &times) {
   std::vector<std::string> rec_texts(img_list.size(), "");
   std::vector<float> rec_text_scores(img_list.size(), 0);
   std::vector<double> rec_times;
@@ -80,9 +80,9 @@ void PaddleOCR::rec(std::vector<cv::Mat> img_list,
   times[2] += rec_times[2];
 }
 
-void PaddleOCR::cls(std::vector<cv::Mat> img_list,
-                    std::vector<OCRPredictResult> &ocr_results,
-                    std::vector<double> &times) {
+void PPOCR::cls(std::vector<cv::Mat> img_list,
+                std::vector<OCRPredictResult> &ocr_results,
+                std::vector<double> &times) {
   std::vector<int> cls_labels(img_list.size(), 0);
   std::vector<float> cls_scores(img_list.size(), 0);
   std::vector<double> cls_times;
@@ -98,8 +98,8 @@ void PaddleOCR::cls(std::vector<cv::Mat> img_list,
 }
 
 std::vector<std::vector<OCRPredictResult>>
-PaddleOCR::ocr(std::vector<cv::String> cv_all_img_names, bool det, bool rec,
-               bool cls) {
+PPOCR::ocr(std::vector<cv::String> cv_all_img_names, bool det, bool rec,
+           bool cls) {
   std::vector<double> time_info_det = {0, 0, 0};
   std::vector<double> time_info_rec = {0, 0, 0};
   std::vector<double> time_info_cls = {0, 0, 0};
@@ -188,9 +188,8 @@ PaddleOCR::ocr(std::vector<cv::String> cv_all_img_names, bool det, bool rec,
   return ocr_results;
 } // namespace PaddleOCR
 
-void PaddleOCR::log(std::vector<double> &det_times,
-                    std::vector<double> &rec_times,
-                    std::vector<double> &cls_times, int img_num) {
+void PPOCR::log(std::vector<double> &det_times, std::vector<double> &rec_times,
+                std::vector<double> &cls_times, int img_num) {
   if (det_times[0] + det_times[1] + det_times[2] > 0) {
     AutoLogger autolog_det("ocr_det", FLAGS_use_gpu, FLAGS_use_tensorrt,
                            FLAGS_enable_mkldnn, FLAGS_cpu_threads, 1, "dynamic",
@@ -212,7 +211,7 @@ void PaddleOCR::log(std::vector<double> &det_times,
     autolog_cls.report();
   }
 }
-PaddleOCR::~PaddleOCR() {
+PPOCR::~PPOCR() {
   if (this->detector_ != nullptr) {
     delete this->detector_;
   }

--- a/deploy/cpp_infer/src/paddleocr.cpp
+++ b/deploy/cpp_infer/src/paddleocr.cpp
@@ -17,8 +17,6 @@
 
 #include "auto_log/autolog.h"
 #include <numeric>
-#include <sys/stat.h>
-
 namespace PaddleOCR {
 
 PPOCR::PPOCR() {
@@ -139,7 +137,7 @@ PPOCR::ocr(std::vector<cv::String> cv_all_img_names, bool det, bool rec,
     }
   } else {
     if (!Utility::PathExists(FLAGS_output) && FLAGS_det) {
-      mkdir(FLAGS_output.c_str(), 0777);
+      Utility::CreateDir(FLAGS_output);
     }
 
     for (int i = 0; i < cv_all_img_names.size(); ++i) {

--- a/deploy/cpp_infer/src/utility.cpp
+++ b/deploy/cpp_infer/src/utility.cpp
@@ -16,9 +16,14 @@
 #include <include/utility.h>
 #include <iostream>
 #include <ostream>
-#include <sys/stat.h>
-#include <sys/types.h>
+
 #include <vector>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
 
 namespace PaddleOCR {
 
@@ -203,6 +208,14 @@ bool Utility::PathExists(const std::string &path) {
 #else
   struct stat buffer;
   return (stat(path.c_str(), &buffer) == 0);
+#endif // !_WIN32
+}
+
+void Utility::CreateDir(const std::string &path) {
+#ifdef _WIN32
+  _mkdir(path.c_str());
+#else
+  mkdir(path.c_str(), 0777);
 #endif // !_WIN32
 }
 


### PR DESCRIPTION
1. fix mkdir error in win
2. Rename PaddleOCR to PPOCR to avoid name conflict with namespace