### PR TITLE
compose preprocess into network

### DIFF
--- a/ppocr/data/imaug/operators.py
+++ b/ppocr/data/imaug/operators.py
@@ -263,7 +263,7 @@ class DetResizeForTest(object):
         else:
             # img, shape = self.resize_image_type1(img)
             img, [ratio_h, ratio_w] = self.resize_image_type1(img)
-        data['image'] = img
+        data['image'] = img.astype(np.float32)
         data['shape'] = np.array([src_h, src_w, ratio_h, ratio_w])
         return data
 

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -45,19 +45,22 @@ class TextDetector(object):
                 'limit_type': args.det_limit_type,
             }
         }, {
-            'NormalizeImage': {
-                'std': [0.229, 0.224, 0.225],
-                'mean': [0.485, 0.456, 0.406],
-                'scale': '1./255.',
-                'order': 'hwc'
-            }
-        }, {
             'ToCHWImage': None
         }, {
             'KeepKeys': {
                 'keep_keys': ['image', 'shape']
             }
         }]
+        if not args.det_normalize_on_net:
+            pre_process_list.insert(1, {
+                'NormalizeImage': {
+                    'std': [0.229, 0.224, 0.225],
+                    'mean': [0.485, 0.456, 0.406],
+                    'scale': '1./255.',
+                    'order': 'hwc'
+                }
+            })
+
         postprocess_params = {}
         if self.det_algorithm == "DB":
             postprocess_params['name'] = 'DBPostProcess'

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -47,6 +47,7 @@ def init_args():
     parser.add_argument("--det_model_dir", type=str)
     parser.add_argument("--det_limit_side_len", type=float, default=960)
     parser.add_argument("--det_limit_type", type=str, default='max')
+    parser.add_argument("--det_normalize_on_net", type=str2bool, default=False)
 
     # DB parmas
     parser.add_argument("--det_db_thresh", type=float, default=0.3)


### PR DESCRIPTION
V100 GPU推理性能如下：预处理耗时大大缩短

```
预处理包含normalize
[2022/06/01 15:23:20] ppocr INFO:  preprocess_time(ms): 8.9351, inference_time(ms): 16.3139, postprocess_time(ms): 10.3171

预处理不包含normalize(放到网络中)
[2022/06/01 15:25:22] ppocr INFO:  preprocess_time(ms): 2.9121, inference_time(ms): 16.755, postprocess_time(ms): 10.4984
```

如果需要获得上述性能优势，你需要
1. 重新导出模型（目前仅支持检测，同时指定`-o Global.det_normalize_on_net=True`
2. 推理的时候，指定`--det_normalize_on_net=True`