### PR TITLE
Fix copy_paste no texts augment.

### DIFF
--- a/ppocr/data/imaug/copy_paste.py
+++ b/ppocr/data/imaug/copy_paste.py
@@ -35,10 +35,12 @@ class CopyPaste(object):
         point_num = data['polys'].shape[1]
         src_img = data['image']
         src_polys = data['polys'].tolist()
+        src_texts = data['texts']
         src_ignores = data['ignore_tags'].tolist()
         ext_data = data['ext_data'][0]
         ext_image = ext_data['image']
         ext_polys = ext_data['polys']
+        ext_texts = ext_data['texts']
         ext_ignores = ext_data['ignore_tags']
 
         indexs = [i for i in range(len(ext_ignores)) if not ext_ignores[i]]
@@ -53,7 +55,7 @@ class CopyPaste(object):
         src_img = cv2.cvtColor(src_img, cv2.COLOR_BGR2RGB)
         ext_image = cv2.cvtColor(ext_image, cv2.COLOR_BGR2RGB)
         src_img = Image.fromarray(src_img).convert('RGBA')
-        for poly, tag in zip(select_polys, select_ignores):
+        for idx, poly, tag in zip(select_idxs, select_polys, select_ignores):
             box_img = get_rotate_crop_image(ext_image, poly)
 
             src_img, box = self.paste_img(src_img, box_img, src_polys)
@@ -62,6 +64,7 @@ class CopyPaste(object):
                 for _ in range(len(box), point_num):
                     box.append(box[-1])
                 src_polys.append(box)
+                src_texts.append(ext_texts[idx])
                 src_ignores.append(tag)
         src_img = cv2.cvtColor(np.array(src_img), cv2.COLOR_RGB2BGR)
         h, w = src_img.shape[:2]
@@ -70,6 +73,7 @@ class CopyPaste(object):
         src_polys[:, :, 1] = np.clip(src_polys[:, :, 1], 0, h)
         data['image'] = src_img
         data['polys'] = src_polys
+        data['texts'] = src_texts
         data['ignore_tags'] = np.array(src_ignores)
         return data
 


### PR DESCRIPTION
If you train data with CopyPaste and EastRandomCropData such as [ch_PP-OCRv3_det_cml.yml](https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.5/configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml).

The original copy_paste only appends the new polys and new ignore_tags to data, but no new texts value to data.  In EastRandomCropData, the texts value is an important key in below https://github.com/PaddlePaddle/PaddleOCR/blob/473a811667adcc2706c8cfa6d04a66f9fbce02d7/ppocr/data/imaug/random_crop_data.py#L170-L179

If you tranform the train data with no new texts, you will get a wrong label. So append the texts to CopyPaste.
