### PR TITLE
Fix TensorRT failed due to some TRT inputs dynamic shape info not set

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -276,6 +276,7 @@ def create_predictor(args, mode, logger):
                 min_input_shape = {"x": [1, 3, imgH, 10]}
                 max_input_shape = {"x": [args.rec_batch_num, 3, imgH, 2304]}
                 opt_input_shape = {"x": [args.rec_batch_num, 3, imgH, 320]}
+                config.exp_disable_tensorrt_ops(["transpose2"])
             elif mode == "cls":
                 min_input_shape = {"x": [1, 3, 48, 10]}
                 max_input_shape = {"x": [args.rec_batch_num, 3, 48, 1024]}


### PR DESCRIPTION
After updating the paddleocr base code from version 2.4 to 2.5, TensorRT execution failed in the new version due to some TRT inputs dynamic shape info not set. By adding the following line the TensorRT should execute normally. Tested on 3 different machines :)