### PR TITLE
Update native.cpp fix issue 6640

### DIFF
--- a/deploy/android_demo/app/src/main/cpp/native.cpp
+++ b/deploy/android_demo/app/src/main/cpp/native.cpp
@@ -47,7 +47,7 @@ str_to_cpu_mode(const std::string &cpu_mode) {
   std::string upper_key;
   std::transform(cpu_mode.cbegin(), cpu_mode.cend(), upper_key.begin(),
                  ::toupper);
-  auto index = cpu_mode_map.find(upper_key);
+  auto index = cpu_mode_map.find(upper_key.c_str());
   if (index == cpu_mode_map.end()) {
     LOGE("cpu_mode not found %s", upper_key.c_str());
     return paddle::lite_api::LITE_POWER_HIGH;


### PR DESCRIPTION
fix issue 6640
cpu_mode can not change by argument

在 src/main/cpp/native.cpp
的函数` static paddle::lite_api::PowerMode str_to_cpu_mode(const std::string &cpu_mode) `中

第50行
`auto index = cpu_mode_map.find(upper_key);`

无论输入什么 cpu_mode 都会报错 cpu_mode not found

改为
`auto index = cpu_mode_map.find(upper_key.c_str());`

则正常

