### PR TITLE
fix compile bug

### DIFF
--- a/deploy/lite/crnn_process.cc
+++ b/deploy/lite/crnn_process.cc
@@ -35,11 +35,13 @@ cv::Mat CrnnResizeImg(cv::Mat img, float wh_ratio, int rec_image_height) {
   else
     resize_w = int(ceilf(imgH * ratio));
 
+  cv::Mat resize_img;
   cv::resize(img, resize_img, cv::Size(resize_w, imgH), 0.f, 0.f,
              cv::INTER_LINEAR);
   cv::copyMakeBorder(resize_img, resize_img, 0, 0, 0,
                      int(imgW - resize_img.cols), cv::BORDER_CONSTANT,
                      {127, 127, 127});
+  return resize_img;
 }
 
 std::vector<std::string> ReadDict(std::string path) {

--- a/deploy/lite/ocr_db_crnn.cc
+++ b/deploy/lite/ocr_db_crnn.cc
@@ -474,7 +474,7 @@ void system(char **argv){
   
     std::vector<double> rec_times;
     RunRecModel(boxes, srcimg, rec_predictor, rec_text, rec_text_score,
-                charactor_dict, cls_predictor, use_direction_classify, &rec_times);
+                charactor_dict, cls_predictor, use_direction_classify, &rec_times, rec_image_height);
   
     //// visualization
     auto img_vis = Visualization(srcimg, boxes);


### PR DESCRIPTION
1. crnn_process.cc文件的CrnnResizeImg方法没有定义resize_img变量，并且没有返回值；
2. ocr_db_crnn.cc文件中调用RunRecModel方法时缺少参数
