### PR TITLE
Support new profiler

### DIFF
--- a/ppocr/utils/profiler.py
+++ b/ppocr/utils/profiler.py
@@ -51,7 +51,6 @@ class ProfilerOptions(object):
                 self._parse_from_string(options_str)
 
     def _parse_from_string(self, options_str):
-        self._options['timer_only'] = False
         for kv in options_str.replace(' ', '').split(';'):
             key, value = kv.split('=')
             if key == 'batch_range':
@@ -65,7 +64,7 @@ class ProfilerOptions(object):
                     continue
                 elif value.lower() == 'cpu':
                     del self._options[key][1]
-                elif value.lower == 'gpu':
+                elif value.lower() == 'gpu':
                     del self._options[key][0]
                 else:
                     raise ValueError(

--- a/ppocr/utils/profiler.py
+++ b/ppocr/utils/profiler.py
@@ -37,7 +37,7 @@ class ProfilerOptions(object):
 
     def __init__(self, options_str):
         self._options = {
-            'batch_range': [10, 20],
+            'batch_range': [50, 60],
             'targets': [profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.GPU],
             'sorted_key': profiler.SortedKeys['CPUTotal'],
             'profile_path': "",
@@ -45,10 +45,12 @@ class ProfilerOptions(object):
             'timer_only': True
         }
         if options_str != None:
-            self._parse_from_string(options_str)
+            assert isinstance(options_str, str)
+            self._options['timer_only'] = False
+            if '=' in options_str:
+                self._parse_from_string(options_str)
 
     def _parse_from_string(self, options_str):
-        assert isinstance(options_str, str)
         self._options['timer_only'] = False
         for kv in options_str.replace(' ', '').split(';'):
             key, value = kv.split('=')
@@ -59,11 +61,11 @@ class ProfilerOptions(object):
                         1] > value_list[0]:
                     self._options[key] = value_list
             elif key == 'targets':
-                if value == 'All' or value == 'ALL':
+                if value.lower() == 'all':
                     continue
-                elif value == 'CPU':
+                elif value.lower() == 'cpu':
                     del self._options[key][1]
-                elif value == 'GPU':
+                elif value.lower == 'gpu':
                     del self._options[key][0]
                 else:
                     raise ValueError(


### PR DESCRIPTION
支持三种使用方式：
* 测试脚本中不加-p或--profiler_options参数选项，仅默认使用profiler的计时功能
* 测试脚本中加-p或--profiler_options参数选项，参数设置为`default`（其实可以设置为任意非空字符串，为准确达意用`default`表示），使用默认配置进行profiler的分析功能
* 测试脚本中加-p或--profiler_options参数选项，参数设置为正确的配置选项，如`state=ALL;batch_range=[20,60]`使用指定配置选项进行profiler分析功能