### PR TITLE
[tipc] set benchmark_train dynamic epoch

### DIFF
--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -29,8 +29,6 @@ function set_dynamic_epoch(){
     arr=(${_str})
     M=${arr[0]}
     P=${arr[1]}
-    gn=`expr $P - 1`
-    gpu_num=`expr $gn / $M`
     ep=`expr $num \* $M \* $P`
     echo $ep
 }

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -156,6 +156,7 @@ else
     if [ ${precision} = "fp16" ];then
         precision="amp"
     fi
+
     epoch=$(set_dynamic_epoch $device_num $epoch)
     fp_items_list=($precision)
     batch_size_list=($batch_size)

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -21,6 +21,20 @@ function func_parser_params(){
     echo ${tmp}
 }
 
+function set_dynamic_epoch(){
+    string=$1
+    num=$2
+    _str=${string:1:6}
+    IFS="C"
+    arr=(${_str})
+    M=${arr[0]}
+    P=${arr[1]}
+    gn=`expr $P - 1`
+    gpu_num=`expr $gn / $M`
+    ep=`expr $num \* $M \* $P`
+    echo $ep
+}
+
 function func_sed_params(){
     filename=$1
     line=$2
@@ -142,7 +156,7 @@ else
     if [ ${precision} = "fp16" ];then
         precision="amp"
     fi
-
+    epoch=$(set_dynamic_epoch $device_num $epoch)
     fp_items_list=($precision)
     batch_size_list=($batch_size)
     device_num_list=($device_num)


### PR DESCRIPTION
Default epoch: 8
The benchmark epoch is `8*1*1`  for N1C1.
The benchmark epoch is `8*1*4`  for N1C4.
The benchmark epoch is `8*4*8`  for N4C8.