### PR TITLE
[KIE] add configurable ignore classes for KIEMetric

### DIFF
--- a/configs/kie/kie_unet_sdmgr.yml
+++ b/configs/kie/kie_unet_sdmgr.yml
@@ -54,6 +54,8 @@ PostProcess:
 Metric:
   name: KIEMetric
   main_indicator: hmean
+  # Classes that will be ignored while computing F1 score.
+  ignore_classes: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 25]
 
 Train:
   dataset:

--- a/ppocr/metrics/kie_metric.py
+++ b/ppocr/metrics/kie_metric.py
@@ -24,8 +24,12 @@ __all__ = ['KIEMetric']
 
 
 class KIEMetric(object):
-    def __init__(self, main_indicator='hmean', **kwargs):
+    def __init__(self,
+                 main_indicator='hmean',
+                 ignore_classes=[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 25],
+                 **kwargs):
         self.main_indicator = main_indicator
+        self.ignore_classes = ignore_classes
         self.reset()
         self.node = []
         self.gt = []
@@ -40,7 +44,7 @@ class KIEMetric(object):
         # self.results.append(result)
 
     def compute_f1_score(self, preds, gts):
-        ignores = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 25]
+        ignores = self.ignore_classes
         C = preds.shape[1]
         classes = np.array(sorted(set(range(C)) - set(ignores)))
         hist = np.bincount(


### PR DESCRIPTION
There's a hard-coded ignores list for computing the F1 score while evaluating the model. If the class list of data is modified, the ignore list should be modified as well, otherwise, the F1 score could not reflect the actual performance of the model.

Instead of changing the hidden and hard-coded ignore class list, this change makes it configurable via the model config YAML file.
