### PR TITLE
limit maximum resizing ratio

### DIFF
--- a/ppocr/data/imaug/rec_img_aug.py
+++ b/ppocr/data/imaug/rec_img_aug.py
@@ -502,7 +502,7 @@ def resize_norm_img_chinese(img, image_shape):
     max_wh_ratio = imgW * 1.0 / imgH
     h, w = img.shape[0], img.shape[1]
     ratio = w * 1.0 / h
-    max_wh_ratio = max(max_wh_ratio, ratio)
+    max_wh_ratio = min(max(max_wh_ratio, ratio), max_wh_ratio)
     imgW = int(imgH * max_wh_ratio)
     if math.ceil(imgH * ratio) > imgW:
         resized_w = imgW


### PR DESCRIPTION
limit max_wh_ratio as the ratio can be higher than max_wh_ratio.

```
resize_shape = (3,32, 320)
wrong = np.zeros((32, 325, 3))
y= resize_norm_img_chinese(wrong, resize_shape)[0]

y.shape = (3, 32, 325)
```

reference: #7108 @andyjpaddle 