### PR TITLE
更新 PPOCRLabel 导出 JSON 文件的错误，更新了配置文件 SLANet_ch.yml 中 Eval - datadir 前多余的空格。

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2531,7 +2531,7 @@ class MainWindow(QMainWindow):
                 split = 'test'
 
             #  save dict
-            html = {'structure': {'tokens': token_list}, 'cell': cells}
+            html = {'structure': {'tokens': token_list}, 'cells': cells}
             json_results.append({'filename': os.path.basename(image_path), 'split': split, 'imgid': imgid, 'html': html})
             imgid += 1
 

--- a/configs/table/SLANet_ch.yml
+++ b/configs/table/SLANet_ch.yml
@@ -107,7 +107,7 @@ Train:
 Eval:
   dataset:
     name: PubTabDataSet
-     data_dir: train_data/table/val/
+    data_dir: train_data/table/val/
     label_file_list: [train_data/table/val.txt]
     transforms:
       - DecodeImage:


### PR DESCRIPTION
解决了导出 JSON 文件时，L2534 将 "cells" 写成 "cell" 的问题。因如下代码取的是cells，否则在训练载入数据时会报 keyerror 的错误。
https://github.com/PaddlePaddle/PaddleOCR/blob/282eebbd660886c38d4ae91bcbcd70b5cdc03f75/ppocr/data/pubtab_dataset.py#L102