### PR TITLE
优化可视化方法，使得倾斜的文本框文字不画在框外

### DIFF
--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -35,6 +35,7 @@ import tools.infer.predict_cls as predict_cls
 from ppocr.utils.utility import get_image_file_list, check_and_read
 from ppocr.utils.logging import get_logger
 from tools.infer.utility import draw_ocr_box_txt, get_rotate_crop_image
+from tools.infer.utility import draw_ocr_box_txt2
 logger = get_logger()
 
 
@@ -189,7 +190,7 @@ def main(args):
             txts = [rec_res[i][0] for i in range(len(rec_res))]
             scores = [rec_res[i][1] for i in range(len(rec_res))]
 
-            draw_img = draw_ocr_box_txt(
+            draw_img = draw_ocr_box_txt2(
                 image,
                 boxes,
                 txts,

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -16,6 +16,8 @@ import argparse
 import os
 import sys
 import platform
+
+import PIL.Image
 import cv2
 import numpy as np
 import paddle
@@ -449,7 +451,7 @@ def draw_ocr_box_txt(image,
 
 def draw_ocr_box_txt2(image,
                       boxes,
-                      txts,
+                      txts=None,
                       scores=None,
                       drop_score=0.5,
                       font_path="./doc/fonts/simfang.ttf"):
@@ -457,14 +459,15 @@ def draw_ocr_box_txt2(image,
     img_left = image.copy()
     img_right = np.ones((h, w, 3), dtype=np.uint8) * 255
     import random
-
     random.seed(0)
+
     draw_left = ImageDraw.Draw(img_left)
+    if txts is None or len(txts) != len(boxes):
+        txts = [None] * len(boxes)
     for idx, (box, txt) in enumerate(zip(boxes, txts)):
         if scores is not None and scores[idx] < drop_score:
             continue
-        color = (random.randint(0, 255), random.randint(0, 255),
-                 random.randint(0, 255))
+        color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
         draw_left.polygon(box, fill=color)
         img_right_text = draw_box_txt_fine((w, h), box, txt, font_path)
         pts = np.array(box, np.int32).reshape((-1, 1, 2))
@@ -477,22 +480,23 @@ def draw_ocr_box_txt2(image,
     return np.array(img_show)
 
 
-def draw_box_txt_fine(img_size, box, txt, font_path):
+def draw_box_txt_fine(img_size, box, txt, font_path="./doc/fonts/simfang.ttf"):
     box_height = int(math.sqrt((box[0][0] - box[3][0])**2 + (box[0][1] - box[3][1])**2))
     box_width = int(math.sqrt((box[0][0] - box[1][0])**2 + (box[0][1] - box[1][1])**2))
-    img_text = Image.new('RGB', (box_width, box_height), (255, 255, 255))
-    draw_text = ImageDraw.Draw(img_text)
+
     if box_height > 2 * box_width and box_height > 30:
-        font_size = max(int(box_width * 0.9), 10)
-        font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
-        cur_y = 0
-        for c in txt:
-            draw_text.text((0, cur_y), c, fill=(0, 0, 0), font=font)
-            cur_y += font.getsize(c)[1]
+        img_text = Image.new('RGB', (box_height, box_width), (255, 255, 255))
+        draw_text = ImageDraw.Draw(img_text)
+        if txt:
+            font = create_font(txt, (box_height, box_width), font_path)
+            draw_text.text([0, 0], txt, fill=(0, 0, 0), font=font)
+        img_text = img_text.transpose(PIL.Image.ROTATE_270)
     else:
-        font_size = max(int(box_height * 0.8), 10)
-        font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
-        draw_text.text([0, 0], txt, fill=(0, 0, 0), font=font)
+        img_text = Image.new('RGB', (box_width, box_height), (255, 255, 255))
+        draw_text = ImageDraw.Draw(img_text)
+        if txt:
+            font = create_font(txt, (box_width, box_height), font_path)
+            draw_text.text([0, 0], txt, fill=(0, 0, 0), font=font)
 
     pts1 = np.float32([[0, 0], [box_width, 0], [box_width, box_height], [0, box_height]])
     pts2 = np.array(box, dtype=np.float32)
@@ -504,6 +508,16 @@ def draw_box_txt_fine(img_size, box, txt, font_path):
                                          borderMode=cv2.BORDER_CONSTANT,
                                          borderValue=(255, 255, 255))
     return img_right_text
+
+
+def create_font(txt, sz, font_path="./doc/fonts/simfang.ttf"):
+    font_size = int(sz[1] * 0.99)
+    font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
+    length = font.getsize(txt)[0]
+    if length > sz[0]:
+        font_size = int(font_size * sz[0] / length)
+        font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
+    return font
 
 
 def str_count(s):

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -447,6 +447,65 @@ def draw_ocr_box_txt(image,
     return np.array(img_show)
 
 
+def draw_ocr_box_txt2(image,
+                      boxes,
+                      txts,
+                      scores=None,
+                      drop_score=0.5,
+                      font_path="./doc/fonts/simfang.ttf"):
+    h, w = image.height, image.width
+    img_left = image.copy()
+    img_right = np.ones((h, w, 3), dtype=np.uint8) * 255
+    import random
+
+    random.seed(0)
+    draw_left = ImageDraw.Draw(img_left)
+    for idx, (box, txt) in enumerate(zip(boxes, txts)):
+        if scores is not None and scores[idx] < drop_score:
+            continue
+        color = (random.randint(0, 255), random.randint(0, 255),
+                 random.randint(0, 255))
+        draw_left.polygon(box, fill=color)
+        img_right_text = draw_box_txt_fine((w, h), box, txt, font_path)
+        pts = np.array(box, np.int32).reshape((-1, 1, 2))
+        cv2.polylines(img_right_text, [pts], True, color, 1)
+        img_right = cv2.bitwise_and(img_right, img_right_text)
+    img_left = Image.blend(image, img_left, 0.5)
+    img_show = Image.new('RGB', (w * 2, h), (255, 255, 255))
+    img_show.paste(img_left, (0, 0, w, h))
+    img_show.paste(Image.fromarray(img_right), (w, 0, w * 2, h))
+    return np.array(img_show)
+
+
+def draw_box_txt_fine(img_size, box, txt, font_path):
+    box_height = int(math.sqrt((box[0][0] - box[3][0])**2 + (box[0][1] - box[3][1])**2))
+    box_width = int(math.sqrt((box[0][0] - box[1][0])**2 + (box[0][1] - box[1][1])**2))
+    img_text = Image.new('RGB', (box_width, box_height), (255, 255, 255))
+    draw_text = ImageDraw.Draw(img_text)
+    if box_height > 2 * box_width and box_height > 30:
+        font_size = max(int(box_width * 0.9), 10)
+        font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
+        cur_y = 0
+        for c in txt:
+            draw_text.text((0, cur_y), c, fill=(0, 0, 0), font=font)
+            cur_y += font.getsize(c)[1]
+    else:
+        font_size = max(int(box_height * 0.8), 10)
+        font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
+        draw_text.text([0, 0], txt, fill=(0, 0, 0), font=font)
+
+    pts1 = np.float32([[0, 0], [box_width, 0], [box_width, box_height], [0, box_height]])
+    pts2 = np.array(box, dtype=np.float32)
+    M = cv2.getPerspectiveTransform(pts1, pts2)
+
+    img_text = np.array(img_text, dtype=np.uint8)
+    img_right_text = cv2.warpPerspective(img_text, M, img_size,
+                                         flags=cv2.INTER_NEAREST,
+                                         borderMode=cv2.BORDER_CONSTANT,
+                                         borderValue=(255, 255, 255))
+    return img_right_text
+
+
 def str_count(s):
     """
     Count the number of Chinese characters,


### PR DESCRIPTION
上次重写了OCR结果可视化后，对于倾斜的文本框，可视化时文本会画在框外，看着非常不 舒服，这次我先把文字画好，然后再贴到图中，虽然麻烦点，看是看着舒服多了。

