### PR TITLE
Update requirements.txt

### DIFF
--- a/ppstructure/recovery/requirements.txt
+++ b/ppstructure/recovery/requirements.txt
@@ -1,4 +1,4 @@
 python-docx
 docx2pdf
-PyMuPDF
+"PyMuPDF==1.18.7"
 beautifulsoup4


### PR DESCRIPTION
🐛 fix: AttributeError: 'Document' object has no attribute 'pageCount'

我在识别PDF的过程中，发现了这个问题，自动安装的PyMuPDF版本是 `1.20.2`
运行后会报一个错误
```
'Document' object has no attribute 'pageCount'
```
升级到 `1.18.7` 即可解决这个问题
问题链接：[PyMuPDF/issues/877](https://github.com/pymupdf/PyMuPDF/issues/877)