### PR TITLE
[TIPC] add scripts for NPU and XPU, test=develop

### DIFF
--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != 'x86_64' ]; then
+    sed -i 's/--enable_mkldnn:True|False/--enable_mkldnn:False/g' $FILENAME
+    sed -i 's/--enable_mkldnn:True/--enable_mkldnn:False/g' $FILENAME
+fi
+
+# change gpu to npu in tipc txt configs
+sed -i 's/use_gpu/use_npu/g' $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i 's/--benchmark:True/--benchmark:False/g' $FILENAME
+dataline=`cat $FILENAME`
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace training config file
+grep -n 'tools/.*yml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# change gpu to npu in execution script
+sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd='bash test_tipc/test_train_inference_python.sh ${FILENAME} $2'
+echo -e '\033[1;32m Started to run command: ${cmd}!  \033[0m'
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != 'x86_64' ]; then
+    sed -i 's/--enable_mkldnn:True|False/--enable_mkldnn:False/g' $FILENAME
+    sed -i 's/--enable_mkldnn:True/--enable_mkldnn:False/g' $FILENAME
+fi
+
+# change gpu to xpu in tipc txt configs
+sed -i 's/use_gpu/use_xpu/g' $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i 's/--benchmark:True/--benchmark:False/g' $FILENAME
+dataline=`cat $FILENAME`
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace training config file
+grep -n 'tools/.*yml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    sed -i 's/use_gpu/use_xpu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# change gpu to xpu in execution script
+sed -i 's/\"gpu\"/\"xpu\"/g' test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd='bash test_tipc/test_train_inference_python.sh ${FILENAME} $2'
+echo -e '\033[1;32m Started to run command: ${cmd}!  \033[0m'
+eval $cmd


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本

```bash
# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/configs/ch_PP-OCRv2_det/train_infer_python.txt 'lite_train_lite_infer'


# GPU上运行单测模型，脚本保持不变
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ch_PP-OCRv2_det/train_infer_python.txt 'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
     test_tipc/configs/ch_PP-OCRv2_det/train_infer_python.txt 'lite_train_lite_infer'

# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
     test_tipc/configs/ch_PP-OCRv2_det/train_infer_python.txt 'lite_train_lite_infer'
```

昆仑运行结果如下：

![image](https://user-images.githubusercontent.com/16605440/189829532-101c659c-6c9e-4099-b7ee-84b6cfde6fe0.png)


