### PR TITLE
canvas.paintEvent() bug fix

### DIFF
--- a/PPOCRLabel/libs/canvas.py
+++ b/PPOCRLabel/libs/canvas.py
@@ -611,8 +611,8 @@ class Canvas(QWidget):
 
         if self.drawing() and not self.prevPoint.isNull() and not self.outOfPixmap(self.prevPoint):
             p.setPen(QColor(0, 0, 0))
-            p.drawLine(self.prevPoint.x(), 0, self.prevPoint.x(), self.pixmap.height())
-            p.drawLine(0, self.prevPoint.y(), self.pixmap.width(), self.prevPoint.y())
+            p.drawLine(int(self.prevPoint.x()), 0, int(self.prevPoint.x()), self.pixmap.height())
+            p.drawLine(0, int(self.prevPoint.y()), self.pixmap.width(), int(self.prevPoint.y()))
 
         self.setAutoFillBackground(True)
         if self.verified:


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleOCR/issues/7681  
https://github.com/PaddlePaddle/PaddleOCR/issues/7702  
self.prevPoint存储使用浮点型，p.drawLine只接受整型，触发上述异常。