### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ tqdm
 numpy
 visualdl
 rapidfuzz
-opencv-contrib-python
+opencv-python==4.2.0.32
+opencv-contrib-python==4.2.0.32
 cython
 lxml
 premailer


### PR DESCRIPTION
解决opencv默认版本太高报错
cv._registerMatType(Mat)
AttributeError: module 'cv2' has no attribute '_registerMatType'