### PR TITLE
fix bug when res value is empty

### DIFF
--- a/ppstructure/recovery/recovery_to_doc.py
+++ b/ppstructure/recovery/recovery_to_doc.py
@@ -60,9 +60,10 @@ def convert_info_docx(img, res, save_folder, img_name):
         elif region['type'].lower() == 'title':
             doc.add_heading(region['res'][0]['text'])
         elif region['type'].lower() == 'table':
-            parser = HtmlToDocx()
-            parser.table_style = 'TableGrid'
-            parser.handle_table(region['res']['html'], doc)
+            if region['res']:
+                parser = HtmlToDocx()
+                parser.table_style = 'TableGrid'
+                parser.handle_table(region['res']['html'], doc)
         else:
             paragraph = doc.add_paragraph()
             paragraph_format = paragraph.paragraph_format


### PR DESCRIPTION
#8136 
I checked the output file `output/test_66.txt` and found an empty value like this:  
`{"type": "table", "bbox": [44, 249, 916, 1188], "res": "", "img_idx": 66}`  
This pr should fix the bug.