### PR TITLE
修复多进程下ModuleNotFoundError: No module named 'paddleocr.ppstructure'的问题

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .paddleocr import *
+from .paddle_ocr import *
 
-__version__ = paddleocr.VERSION
+__version__ = paddle_ocr.VERSION
 __all__ = [
     'PaddleOCR', 'PPStructure', 'draw_ocr', 'draw_structure_result',
     'save_structure_res', 'download_with_progressbar', 'sorted_layout_boxes',

--- a/paddle_ocr.py
+++ b/paddle_ocr.py
@@ -47,7 +47,7 @@ __all__ = [
 ]
 
 SUPPORT_DET_MODEL = ['DB']
-VERSION = '2.6.1.0'
+VERSION = '2.6.1.1'
 SUPPORT_REC_MODEL = ['CRNN', 'SVTR_LCNet']
 BASE_DIR = os.path.expanduser("~/.paddleocr/")
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 from io import open
-from paddleocr import VERSION
+from paddle_ocr import VERSION
 
 def load_requirements(file_list=None):
     if file_list is None:
@@ -39,7 +39,7 @@ setup(
     packages=['paddleocr'],
     package_dir={'paddleocr': ''},
     include_package_data=True,
-    entry_points={"console_scripts": ["paddleocr= paddleocr.paddleocr:main"]},
+    entry_points={"console_scripts": ["paddleocr= paddleocr.paddle_ocr:main"]},
     version=VERSION,
     install_requires=load_requirements(['requirements.txt', 'ppstructure/recovery/requirements.txt']),
     license='Apache License 2.0',


### PR DESCRIPTION
原有实现中，同名Module（paddleocr）下使用同名的Python主入口脚本（paddleocr.py），使用spawn多进程，在Python3.8触发ModuleNotFoundError的bug，该bug在测试环境（Python3.8.15 Paddle2.2.2 PaddleOCR2.6.0.1）可以稳定复现

CASE代码：
```python
from paddleocr.ppstructure.predict_system import StructureSystem
import multiprocessing

def func(
    pid,
):
    print(f"[{pid}] Start")
    [_ for _ in range(int(1e6))]
    print(f"[{pid}] Finished")


if __name__ == '__main__':
    with multiprocessing.Manager() as manager:
        procs = []
        for i in range(2):
            p = multiprocessing.get_context("spawn").Process(
                target=func,
                args=(f"pid_{i}",)
            )
            p.start()
            procs.append(p)

        for p in procs:
            p.join()
```

修复前：
![image](https://user-images.githubusercontent.com/31271515/196724165-4311bedd-5feb-404a-8560-9a99b1d32068.png)

修复后：
![image](https://user-images.githubusercontent.com/31271515/196723997-71d91038-ca77-40b7-82b8-5a23781c779e.png)

