### PR TITLE
PPOCRLabel标注工具在“重识别此区块功能”“自动识别”等功能时取label的错误

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1177,7 +1177,7 @@ class MainWindow(QMainWindow):
             # print('rm empty label')
             return
         item = self.shapesToItems[shape]
-        item.setText(shape.label)
+        item.setText(shape.label[0])
         self.updateComboBox()
 
         # ADD:

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1411,7 +1411,7 @@ class MainWindow(QMainWindow):
 
     def _get_rgb_by_label(self, label, kie_mode):
         shift_auto_shape_color = 2  # use for random color
-        if kie_mode and label != "None":
+        if kie_mode and label != "None" and label is not None:
             item = self.keyList.findItemsByLabel(label)[0]
             label_id = self.keyList.indexFromItem(item).row() + 1
             label_id += shift_auto_shape_color

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1097,8 +1097,8 @@ class MainWindow(QMainWindow):
     def addLabel(self, shape):
         shape.paintLabel = self.displayLabelOption.isChecked()
         shape.paintIdx = self.displayIndexOption.isChecked()
-
-        item = HashableQListWidgetItem(shape.label)
+        # check shape label tpye, tuple or str
+        item = HashableQListWidgetItem(label2str(shape.label))
         # current difficult checkbox is disenble
         # item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
         # item.setCheckState(Qt.Unchecked) if shape.difficult else item.setCheckState(Qt.Checked)

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2468,6 +2468,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
+                        label = label.replace('null', 'NULL')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []
@@ -2613,6 +2614,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
+                        label = label.replace('null', '\"\"')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []

--- a/PPOCRLabel/libs/autoDialog.py
+++ b/PPOCRLabel/libs/autoDialog.py
@@ -51,7 +51,7 @@ class Worker(QThread):
                         pass
                     else:
                         strs = ''
-                        for res in self.result_dic:
+                        for res in self.result_dic[0]:
                             chars = res[1][0]
                             cond = res[1][1]
                             posi = res[0]

--- a/PPOCRLabel/libs/canvas.py
+++ b/PPOCRLabel/libs/canvas.py
@@ -17,7 +17,7 @@ from PyQt5.QtCore import Qt, pyqtSignal, QPointF, QPoint
 from PyQt5.QtGui import QPainter, QBrush, QColor, QPixmap
 from PyQt5.QtWidgets import QWidget, QMenu, QApplication
 from libs.shape import Shape
-from libs.utils import distance
+from libs.utils import distance, label2str
 
 CURSOR_DEFAULT = Qt.ArrowCursor
 CURSOR_POINT = Qt.PointingHandCursor
@@ -237,7 +237,7 @@ class Canvas(QWidget):
                     self.hShape.highlightClear()
                 self.hVertex, self.hShape = None, shape
                 self.setToolTip(
-                    "Click & drag to move shape '%s'" % shape.label)
+                    "Click & drag to move shape '%s'" % label2str(shape.label))
                 self.setStatusTip(self.toolTip())
                 self.overrideCursor(CURSOR_GRAB)
                 self.update()

--- a/PPOCRLabel/libs/shape.py
+++ b/PPOCRLabel/libs/shape.py
@@ -239,7 +239,7 @@ class Shape(object):
         self._highlightIndex = None
 
     def copy(self):
-        shape = Shape("%s" % self.label)
+        shape = Shape("%s" % self.label[0])
         shape.points = [p for p in self.points]
         shape.center = self.center
         shape.direction = self.direction

--- a/PPOCRLabel/libs/shape.py
+++ b/PPOCRLabel/libs/shape.py
@@ -17,7 +17,7 @@ import sys
 
 from PyQt5.QtCore import QPointF
 from PyQt5.QtGui import QColor, QPen, QPainterPath, QFont
-from libs.utils import distance
+from libs.utils import distance, label2str
 
 DEFAULT_LINE_COLOR = QColor(0, 255, 0, 128)
 DEFAULT_FILL_COLOR = QColor(255, 0, 0, 128)
@@ -239,7 +239,7 @@ class Shape(object):
         self._highlightIndex = None
 
     def copy(self):
-        shape = Shape("%s" % self.label[0])
+        shape = Shape("%s" % label2str(self.label))
         shape.points = [p for p in self.points]
         shape.center = self.center
         shape.direction = self.direction

--- a/PPOCRLabel/libs/utils.py
+++ b/PPOCRLabel/libs/utils.py
@@ -324,3 +324,16 @@ def keysInfo(lang='en'):
               "Notice:For Mac users, use the 'Command' key instead of the 'Ctrl' key"
 
     return msg
+def label2str(label):
+    """
+    convert label to str
+    Args:
+        label:
+
+    Returns:
+
+    """
+    if isinstance(label, str):
+        return label
+    else:
+        return label[0]


### PR DESCRIPTION
首先真的感谢百度团队开源这么好多标注工作，但是我在使用PPOCRLabel标注工具时，遇到了标注信息解析的导致qt闪退的错误（其中一个示例如下），通过排查将此问题修复。

<img width="646" alt="对技术有热情" src="https://user-images.githubusercontent.com/9389138/202831509-854dc7ca-78fc-487d-a3ce-49bf9988f574.png">

```
Gtk-Message: 18:58:06.543: GtkDialog mapped without a transient parent. This is discouraged.
file name in openNext is  /home/clz/Desktop/test2/1111 (copy).png
DirPath in importDirImages is /home/clz/Desktop/test2
initPos PyQt5.QtCore.QPointF(75.26865671641801, 387.8656716417911)
result in reRec is  [[[75, 387], [300, 387], [300, 429], [75, 429]], [('kuangwd@qq.com', 0.9789012670516968)]]
Traceback (most recent call last):
  File "PPOCRLabel.py", line 2281, in singleRerecognition
    self.singleLabel(shape)
  File "PPOCRLabel.py", line 1180, in singleLabel
    item.setText(shape.label)
TypeError: setText(self, str): argument 1 has unexpected type 'tuple'


```

此错误时因为在识别后  shape.label 中的shape.label有时是tuple而非str造成的，取tuple中的第一个字段即可修复此问题，所以在utils中加了一个label2str的function处理此问题，经过测试能够正常使用了。