### PR TITLE
Update ocr_web_server.py

### DIFF
--- a/deploy/pdserving/win/ocr_web_server.py
+++ b/deploy/pdserving/win/ocr_web_server.py
@@ -55,7 +55,7 @@ class OCRService(WebService):
         im = cv2.imdecode(data, cv2.IMREAD_COLOR)
         if(im is None):
             buf = BytesIO()
-            image_decode = base64.b64decode(data["img"].encode())
+            image_decode = base64.b64decode(feed[0]["image"].encode())
             image=BytesIO(image_decode)
             im = Image.open(image)
             rgb = im.convert('RGB')


### PR DESCRIPTION
解决位深度为8的单通道在serving请求时的报错：https://github.com/PaddlePaddle/PaddleOCR/issues/8457