### PR TITLE
hubserving部署方式，在config.json增加开启mkldnn的的参数设置

### DIFF
--- a/deploy/hubserving/ocr_cls/config.json
+++ b/deploy/hubserving/ocr_cls/config.json
@@ -3,7 +3,8 @@
         "ocr_cls": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }

--- a/deploy/hubserving/ocr_det/config.json
+++ b/deploy/hubserving/ocr_det/config.json
@@ -3,7 +3,8 @@
         "ocr_det": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }

--- a/deploy/hubserving/ocr_rec/config.json
+++ b/deploy/hubserving/ocr_rec/config.json
@@ -3,7 +3,8 @@
         "ocr_rec": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }

--- a/deploy/hubserving/ocr_system/config.json
+++ b/deploy/hubserving/ocr_system/config.json
@@ -3,7 +3,8 @@
         "ocr_system": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -170,7 +170,8 @@ $ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
         "ocr_system": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -172,7 +172,8 @@ Wherein, the format of `config.json` is as follows:
         "ocr_system": {
             "init_args": {
                 "version": "1.0.0",
-                "use_gpu": true
+                "use_gpu": true,
+                "enable_mkldnn": false
             },
             "predict_args": {
             }


### PR DESCRIPTION
hubserving部署方式，在config.json增加开启mkldnn的的参数设置。
由于只测试过ocr的4个接口，table的没测试过所以没在相应的config.json里增加。