### PR TITLE
Fix padding value in rec model and box sort in det model

### DIFF
--- a/deploy/cpp_infer/src/preprocess_op.cpp
+++ b/deploy/cpp_infer/src/preprocess_op.cpp
@@ -112,7 +112,7 @@ void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
              cv::INTER_LINEAR);
   cv::copyMakeBorder(resize_img, resize_img, 0, 0, 0,
                      int(imgW - resize_img.cols), cv::BORDER_CONSTANT,
-                     {127, 127, 127});
+                     {0, 0, 0});
 }
 
 void ClsResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,

--- a/deploy/cpp_infer/src/utility.cpp
+++ b/deploy/cpp_infer/src/utility.cpp
@@ -308,7 +308,7 @@ void Utility::sorted_boxes(std::vector<OCRPredictResult> &ocr_result) {
   std::sort(ocr_result.begin(), ocr_result.end(), Utility::comparison_box);
   if (ocr_result.size() > 0) {
     for (int i = 0; i < ocr_result.size() - 1; i++) {
-      for (int j = i; j > 0; j--) {
+      for (int j = i; j >= 0; j--) {
         if (abs(ocr_result[j + 1].box[0][1] - ocr_result[j].box[0][1]) < 10 &&
             (ocr_result[j + 1].box[0][0] < ocr_result[j].box[0][0])) {
           std::swap(ocr_result[i], ocr_result[i + 1]);


### PR DESCRIPTION
1. 将rec模型预处理中的padding值，由127换为0.
2. 检测Box的排序，曾经漏掉了第一个box和第零个box的check.