### PR TITLE
Resolve DeprecationWarning for `np.int`

### DIFF
--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -185,10 +185,10 @@ class DBPostProcess(object):
         '''
         h, w = bitmap.shape[:2]
         box = _box.copy()
-        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int), 0, w - 1)
-        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int), 0, w - 1)
-        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int), 0, h - 1)
-        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int), 0, h - 1)
+        xmin = np.clip(np.floor(box[:, 0].min()).astype(int), 0, w - 1)
+        xmax = np.clip(np.ceil(box[:, 0].max()).astype(int), 0, w - 1)
+        ymin = np.clip(np.floor(box[:, 1].min()).astype(int), 0, h - 1)
+        ymax = np.clip(np.ceil(box[:, 1].max()).astype(int), 0, h - 1)
 
         mask = np.zeros((ymax - ymin + 1, xmax - xmin + 1), dtype=np.uint8)
         box[:, 0] = box[:, 0] - xmin


### PR DESCRIPTION
This PR aims to resolve the `DeprecationWarning` raised due to usage of `np.int`.

`np.int` [has been deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), and migration is deemed safe, as per:
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. 
To silence this warning, use `int` by itself. Doing this will not modify 
any behavior and is safe. When replacing `np.int`, you may wish to use e.g.
`np.int64` or `np.int32` to specify the precision. If you wish to review
your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: 
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

Furthermore, as this is only used in calculating box score, 32 bits are enough since we can safely assume the box's 4 coordinates are less than 2^32 - 1, as any coordinates that would require a 64-bit integer is highly likely the result of a bug rather than being the result of sane usage.