### PR TITLE
Fix: broken link for whl package documentation.

### DIFF
--- a/ppstructure/docs/quickstart_en.md
+++ b/ppstructure/docs/quickstart_en.md
@@ -311,7 +311,7 @@ Please refer to: [Key Information Extraction](../kie/README.md) .
 | save_pdf    | Whether to convert docx to pdf when recovery| False |
 | structure_version |  Structure version, optional PP-structure and PP-structurev2  | PP-structure |
 
-Most of the parameters are consistent with the PaddleOCR whl package, see [whl package documentation](../../doc/doc_en/whl.md)
+Most of the parameters are consistent with the PaddleOCR whl package, see [whl package documentation](../../doc/doc_en/whl_en.md)
 
 <a name="3"></a>
 ## 3. Summary


### PR DESCRIPTION
This proposed change fixes the broken link under the section `2.4 Parameter Description` in the last line that says: Most of the parameters are consistent with the PaddleOCR whl package, see `whl package documentation`.