### PR TITLE
Update parameter default type and value for image shapes

### DIFF
--- a/doc/doc_en/inference_args_en.md
+++ b/doc/doc_en/inference_args_en.md
@@ -88,7 +88,7 @@ The relevant parameters of the PSE algorithm are as follows
 | :--: | :--: | :--: | :--: |
 |  rec_algorithm | str | "CRNN" | Text recognition algorithm name, currently supports `CRNN`, `SRN`, `RARE`, `NETR`, `SAR`, `ViTSTR`, `ABINet`, `VisionLAN`, `SPIN`, `RobustScanner`, `SVTR`, `SVTR_LCNet` |
 |  rec_model_dir | str | None, it is required if using the recognition model | recognition inference model paths |
-|  rec_image_shape | list | [3, 48, 320] | Image size at the time of recognition |
+|  rec_image_shape | str | "3, 48, 320" | Image size at the time of recognition |
 |  rec_batch_num | int | 6 | batch size |
 |  max_text_length | int | 25 | The maximum length of the recognition result, valid in `SRN` |
 |  rec_char_dict_path | str | "./ppocr/utils/ppocr_keys_v1.txt" | character dictionary file |
@@ -115,7 +115,7 @@ The relevant parameters of the PSE algorithm are as follows
 | :--: | :--: | :--: | :--: |
 |  use_angle_cls | bool | False | whether to use an angle classifier |
 |  cls_model_dir | str | None, if you need to use, you must specify the path explicitly | angle classifier inference model path |
-|  cls_image_shape | list | [3, 48, 192] | prediction shape |
+|  cls_image_shape | str | "3, 48, 192" | prediction shape |
 |  label_list | list | ['0', '180'] | The angle value corresponding to the class id |
 |  cls_batch_num | int | 6 | batch size |
 |  cls_thresh | float | 0.9 | Prediction threshold, when the model prediction result is 180 degrees, and the score is greater than the threshold, the final prediction result is considered to be 180 degrees and needs to be flipped |


### PR DESCRIPTION
The default image shape datatype for rec_image_shape and cls_image_shape is a list and the default value is also provided as a list argument. However, in the updated version, this is no longer the case. Now the default type is str, and the default value is also provided by a string.  Hence, updating these two parameter default datatype and value is required.