### PR TITLE
matmul use fp32 compute_type

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -152,9 +152,10 @@ def main(config, device, logger, vdl_writer):
         AMP_RELATED_FLAGS_SETTING = {'FLAGS_max_inplace_grad_add': 8, }
         if paddle.is_compiled_with_cuda():
             AMP_RELATED_FLAGS_SETTING.update({
-                'FLAGS_cudnn_batchnorm_spatial_persistent': 1
+                'FLAGS_cudnn_batchnorm_spatial_persistent': 1,
+                'FLAGS_gemm_use_half_precision_compute_type': 0,
             })
-        paddle.fluid.set_flags(AMP_RELATED_FLAGS_SETTING)
+        paddle.set_flags(AMP_RELATED_FLAGS_SETTING)
         scale_loss = config["Global"].get("scale_loss", 1.0)
         use_dynamic_loss_scaling = config["Global"].get(
             "use_dynamic_loss_scaling", False)


### PR DESCRIPTION
修复rec v3模型amp训练精度偏低问题：由于该模型中matmul调用BatchedGEMM，框架默认使用FP16累加因此会损失精度。

本PR通过环境变量FLAGS_gemm_use_half_precision_compute_type=False，使BatchedGEMM使用FP32累加，AMP-O1和O2可达到精度对齐。