### PR TITLE
Fix sorted_boxes() function bug: the index j can not skip 0.

### DIFF
--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -123,7 +123,7 @@ def sorted_boxes(dt_boxes):
     _boxes = list(sorted_boxes)
 
     for i in range(num_boxes - 1):
-        for j in range(i, 0, -1):
+        for j in range(i, -1, -1):
             if abs(_boxes[j + 1][0][1] - _boxes[j][0][1]) < 10 and \
                     (_boxes[j + 1][0][0] < _boxes[j][0][0]):
                 tmp = _boxes[j]


### PR DESCRIPTION
The index j will skip 0. That will not swap the first with second, even if the first  box is actually on the second right.
```
    for i in range(num_boxes - 1):
        for j in range(i, 0, -1):
```