### PR TITLE
新增gpu_id参数，可以在推理时使用特定GPU进行推理

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -42,6 +42,7 @@ def init_args():
     parser.add_argument("--min_subgraph_size", type=int, default=15)
     parser.add_argument("--precision", type=str, default="fp32")
     parser.add_argument("--gpu_mem", type=int, default=500)
+    parser.add_argument("--gpu_id", type=int, default=0)
 
     # params for text detector
     parser.add_argument("--image_dir", type=str)
@@ -219,7 +220,7 @@ def create_predictor(args, mode, logger):
                 logger.warning(
                     "GPU is not found in current device by nvidia-smi. Please check your device or ignore it if run on jetson."
                 )
-            config.enable_use_gpu(args.gpu_mem, 0)
+            config.enable_use_gpu(args.gpu_mem, args.gpu_id)
             if args.use_tensorrt:
                 config.enable_tensorrt_engine(
                     workspace_size=1 << 30,


### PR DESCRIPTION
在python代码中使用：
`os.environ['CUDA_VISIBLE_DEVICES'] = '1'`
无法指定使用第2块显卡，始终会使用第一张显卡；
通过查看源码，发现tools/infer/utility.py中存在如下代码：
`config.enable_use_gpu(args.gpu_mem, 0)`
设置是使用第一个gpu，即id是0的GPU，通过将上述代码修改为第2块显卡的id，可以将推理放在第2块显卡：
`config.enable_use_gpu(args.gpu_mem, 1)`
但这样做侵入太大且不够灵活，因此在推理模块的初始化参数中，新增了`args.gpu_id`参数，这样就可以在推理时使用特定GPU进行推理！

