### PR TITLE
[PPOCRLable] Improve KIE lable mode

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1608,7 +1608,7 @@ class MainWindow(QMainWindow):
         # box['ratio'] of the shapes saved in lockedShapes contains the ratio of the
         # four corner coordinates of the shapes to the height and width of the image
         for box in self.canvas.lockedShapes:
-            ser_label = 'other' if not self.kie_mode else box['ser_label']
+            ser_label = 'other' if not self.kie_mode else box['label']
             if self.canvas.isInTheSameImage:
                 shapes.append((box['transcription'], [[s[0] * width, s[1] * height] for s in box['ratio']],
                                DEFAULT_LOCK_COLOR, ser_label, box['difficult']))

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1617,7 +1617,7 @@ class MainWindow(QMainWindow):
                                DEFAULT_LOCK_COLOR, ser_label, box['difficult']))
         if imgidx in self.PPlabel.keys():
             for box in self.PPlabel[imgidx]:
-                ser_label = 'other' if not self.kie_mode else box.get('ser_label', 'other')
+                ser_label = 'other' if not self.kie_mode else box.get('label', 'other')
                 shapes.append((box['transcription'], box['points'], None, ser_label, box.get('difficult', False)))
 
         if shapes != []:

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1415,7 +1415,7 @@ class MainWindow(QMainWindow):
 
     def _get_rgb_by_label(self, label, kie_mode):
         shift_auto_shape_color = 2  # use for random color
-        if kie_mode and label != "None":
+        if kie_mode and label != "other":
             item = self.keyList.findItemsByLabel(label)[0]
             label_id = self.keyList.indexFromItem(item).row() + 1
             label_id += shift_auto_shape_color

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -21,6 +21,8 @@ import os.path
 import platform
 import subprocess
 import sys
+from copy import deepcopy
+
 import xlrd
 from functools import partial
 
@@ -2637,8 +2639,13 @@ class MainWindow(QMainWindow):
 
         if self.kie_mode:
             with open(self.ser_label_txt_path, 'w', encoding='utf-8') as f:
-                f.write('other\n')  # make other always in the front
-                for key in self.existed_ser_label_set:
+
+                save_list = deepcopy(self.existed_ser_label_set)
+                save_list = [label for label in save_list if label != 'other']
+                save_list = ['other'] + save_list  # make sure 'other' always in the first place
+                save_list.sort()
+
+                for key in save_list:
                     f.write(str(key).lower() + '\n')  # make other always in the front
 
         if mode == 'Manual':

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -21,7 +21,6 @@ import os.path
 import platform
 import subprocess
 import sys
-
 import xlrd
 from functools import partial
 

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -21,7 +21,6 @@ import os.path
 import platform
 import subprocess
 import sys
-from copy import deepcopy
 
 import xlrd
 from functools import partial
@@ -1388,6 +1387,7 @@ class MainWindow(QMainWindow):
 
                     self._update_shape_color(shape)
                     self.keyDialog.addLabelHistory(key_text)
+                    self.existed_ser_label_set.add(key_text)
 
             self.addLabel(shape)
             if self.beginner():  # Switch to edit mode.
@@ -1779,6 +1779,9 @@ class MainWindow(QMainWindow):
                     self.keyList.addItem(item)
                     rgb = self._get_rgb_by_label(key_text, self.kie_mode)
                     self.keyList.setItemLabel(item, key_text, rgb)
+
+                    if self.keyDialog is not None:
+                        self.keyDialog.addLabelHistory(key_text)
 
         if self.keyDialog is None:
             # key list dialog
@@ -2639,11 +2642,9 @@ class MainWindow(QMainWindow):
 
         if self.kie_mode:
             with open(self.ser_label_txt_path, 'w', encoding='utf-8') as f:
-
-                save_list = deepcopy(self.existed_ser_label_set)
-                save_list = [label for label in save_list if label != 'other']
-                save_list = ['other'] + save_list  # make sure 'other' always in the first place
+                save_list = [label for label in self.existed_ser_label_set if label != 'other']
                 save_list.sort()
+                save_list = ['other'] + save_list  # make sure 'other' always in the first place
 
                 for key in save_list:
                     f.write(str(key).lower() + '\n')  # make other always in the front
@@ -2726,6 +2727,7 @@ class MainWindow(QMainWindow):
         key_text, _ = self.keyDialog.popUp(self.key_previous_text)
         if key_text is None:
             return
+        key_text = str(key_text).lower()
         self.key_previous_text = key_text
         for shape in self.canvas.selectedShapes:
             shape.ser_label = key_text
@@ -2737,7 +2739,8 @@ class MainWindow(QMainWindow):
 
             self._update_shape_color(shape)
             self.keyDialog.addLabelHistory(key_text)
-            
+            self.existed_ser_label_set.add(key_text)
+
         # save changed shape
         self.setDirty()
 

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1225,12 +1225,12 @@ class MainWindow(QMainWindow):
 
         # Can add different annotation formats here
         for box in self.result_dic:
-            trans_dic = {"transcription": box[1][0], "points": box[0], "difficult": False}
+            trans_dic = {"label": box[1][0], "points": box[0], "difficult": False}
             if self.kie_mode:
                 if len(box) == 3:
-                    trans_dic.update({"label": box[2]})
+                    trans_dic.update({"ser_label": box[2]})
                 else:
-                    trans_dic.update({"label": "other"})
+                    trans_dic.update({"ser_label": "other"})
             if trans_dic["label"] == "" and mode == 'Auto':
                 continue
             shapes.append(trans_dic)
@@ -1238,9 +1238,9 @@ class MainWindow(QMainWindow):
         try:
             trans_dic = []
             for box in shapes:
-                trans_dict = {"transcription": box['transcription'], "points": box['points'], "difficult": box['difficult']}
+                trans_dict = {"transcription": box['label'], "points": box['points'], "difficult": box['difficult']}
                 if self.kie_mode:
-                    trans_dict.update({"label": box['label']})
+                    trans_dict.update({"label": box['ser_label']})
                 trans_dic.append(trans_dict)
             self.PPlabel[annotationFilePath] = trans_dic
             if mode == 'Auto':

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1374,6 +1374,7 @@ class MainWindow(QMainWindow):
             shape = self.canvas.setLastLabel(text, None, None, None)  # generate_color, generate_color
             if self.kie_mode:
                 key_text, _ = self.keyDialog.popUp(self.key_previous_text)
+                key_text = str(key_text).lower()
                 if key_text is not None:
                     shape = self.canvas.setLastLabel(text, None, None, key_text)  # generate_color, generate_color
                     self.key_previous_text = key_text

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1802,6 +1802,7 @@ class MainWindow(QMainWindow):
             self.PPlabelpath = dirpath + '/Label.txt'
             self.PPlabel = self.loadLabelFile(self.PPlabelpath)
             self.Cachelabelpath = dirpath + '/Cache.cach'
+            self.ser_label_txt_path = dirpath + '/ser_class_list.txt'
             self.Cachelabel = self.loadLabelFile(self.Cachelabelpath)
             if self.Cachelabel:
                 self.PPlabel = dict(self.Cachelabel, **self.PPlabel)
@@ -2633,6 +2634,12 @@ class MainWindow(QMainWindow):
                 if key in savedfile and self.PPlabel[key] != []:
                     f.write(key + '\t')
                     f.write(json.dumps(self.PPlabel[key], ensure_ascii=False) + '\n')
+
+        if self.kie_mode:
+            with open(self.ser_label_txt_path, 'w', encoding='utf-8') as f:
+                f.write('other\n')  # make other always in the front
+                for key in self.existed_ser_label_set:
+                    f.write(str(key).lower() + '\n')  # make other always in the front
 
         if mode == 'Manual':
             if self.lang == 'ch':

--- a/PPOCRLabel/README.md
+++ b/PPOCRLabel/README.md
@@ -12,7 +12,9 @@ PPOCRLabelv2 is a semi-automatic graphic annotation tool suitable for OCR field,
 
 ### Recent Update
 
-- 2022.05: Add table annotations, follow `2.2 Table Annotations` for more information （by [whjdark](https://github.com/peterh0323); [Evezerest](https://github.com/Evezerest))
+- 2023.02：（by [PeterH0323](https://github.com/peterh0323) ）：
+  - Improve the KIE label field, and the txt file of SER's class list will be automatically generated when saving.
+- 2022.05: Add table annotations, follow `2.2 Table Annotations` for more information （by [whjdark](https://github.com/whjdark); [Evezerest](https://github.com/Evezerest))
 - 2022.02:（by [PeterH0323](https://github.com/peterh0323) ）
   - Add KIE Mode by using `--kie`, for [detection + identification + keyword extraction] labeling.
   - Improve user experience: prompt for the number of files and labels, optimize interaction, and fix bugs such as only use CPU when inference

--- a/PPOCRLabel/README_ch.md
+++ b/PPOCRLabel/README_ch.md
@@ -11,7 +11,9 @@ PPOCRLabel是一款适用于OCR领域的半自动化图形标注工具，内置P
 | <img src="./data/gif/multi-point.gif" width="80%"/> |  <img src="./data/gif/kie.gif" width="100%"/>  |
 
 #### 近期更新
-- 2022.05：**新增表格标注**，使用方法见下方`2.2 表格标注`（by [whjdark](https://github.com/peterh0323); [Evezerest](https://github.com/Evezerest))
+- 2023.02：**完善关键信息标注**（by [PeterH0323](https://github.com/peterh0323) ）：
+  - 完善 KIE 标注字段，保存的时候会自动生成 SER 的 class list 的 txt 文件
+- 2022.05：**新增表格标注**，使用方法见下方`2.2 表格标注`（by [whjdark](https://github.com/whjdark); [Evezerest](https://github.com/Evezerest))
 - 2022.02：**新增关键信息标注**、优化标注体验（by [PeterH0323](https://github.com/peterh0323) ）
   - 新增：使用 `--kie` 进入 KIE 功能，用于打【检测+识别+关键字提取】的标签
   - 提升用户体验：新增文件与标记数目提示、优化交互、修复gpu使用等问题。

--- a/PPOCRLabel/README_ch.md
+++ b/PPOCRLabel/README_ch.md
@@ -11,10 +11,10 @@ PPOCRLabel是一款适用于OCR领域的半自动化图形标注工具，内置P
 | <img src="./data/gif/multi-point.gif" width="80%"/> |  <img src="./data/gif/kie.gif" width="100%"/>  |
 
 #### 近期更新
-- 2023.02：**完善关键信息标注**（by [PeterH0323](https://github.com/peterh0323) ）：
+- 2023.02：**完善关键信息标注**（by [PeterH0323](https://github.com/peterh0323)）
   - 完善 KIE 标注字段，保存的时候会自动生成 SER 的 class list 的 txt 文件
 - 2022.05：**新增表格标注**，使用方法见下方`2.2 表格标注`（by [whjdark](https://github.com/whjdark); [Evezerest](https://github.com/Evezerest))
-- 2022.02：**新增关键信息标注**、优化标注体验（by [PeterH0323](https://github.com/peterh0323) ）
+- 2022.02：**新增关键信息标注**、优化标注体验（by [PeterH0323](https://github.com/peterh0323)）
   - 新增：使用 `--kie` 进入 KIE 功能，用于打【检测+识别+关键字提取】的标签
   - 提升用户体验：新增文件与标记数目提示、优化交互、修复gpu使用等问题。
   - 新增功能：使用 `C` 和 `X` 对标记框进行旋转。

--- a/PPOCRLabel/libs/canvas.py
+++ b/PPOCRLabel/libs/canvas.py
@@ -796,7 +796,7 @@ class Canvas(QWidget):
         points = [p1+p2 for p1, p2 in zip(self.selectedShape.points, [step]*4)]
         return True in map(self.outOfPixmap, points)
 
-    def setLastLabel(self, text, line_color=None, fill_color=None, key_cls=None):
+    def setLastLabel(self, text, line_color=None, fill_color=None, ser_label=None):
         assert text
         self.shapes[-1].label = text
         if line_color:
@@ -805,8 +805,8 @@ class Canvas(QWidget):
         if fill_color:
             self.shapes[-1].fill_color = fill_color
 
-        if key_cls:
-            self.shapes[-1].key_cls = key_cls
+        if ser_label:
+            self.shapes[-1].ser_label = ser_label
 
         self.storeShapes()
 

--- a/PPOCRLabel/libs/shape.py
+++ b/PPOCRLabel/libs/shape.py
@@ -46,14 +46,14 @@ class Shape(object):
     point_size = 8
     scale = 1.0
 
-    def __init__(self, label=None, line_color=None, difficult=False, key_cls="None", paintLabel=False, paintIdx=False):
+    def __init__(self, label=None, line_color=None, difficult=False, ser_label="other", paintLabel=False, paintIdx=False):
         self.label = label
         self.idx = None # bbox order, only for table annotation
         self.points = []
         self.fill = False
         self.selected = False
         self.difficult = difficult
-        self.key_cls = key_cls
+        self.ser_label = ser_label
         self.paintLabel = paintLabel
         self.paintIdx = paintIdx
         self.locked = False
@@ -251,7 +251,7 @@ class Shape(object):
         if self.fill_color != Shape.fill_color:
             shape.fill_color = self.fill_color
         shape.difficult = self.difficult
-        shape.key_cls = self.key_cls
+        shape.ser_label = self.ser_label
         return shape
 
     def __len__(self):


### PR DESCRIPTION
完善了 KIE 的标注功能，**该 PR 对于使用 PPOCRLabl 在 KIE 任务打标签十分重要**

1、默认标签从 `None` -> `other`
2、标签中将所有的 key_cls -> `label`，用户无需进行转换就可以进行训练，对应了文档中的标签例子
3、保存的时候会保存 SER 的一份 class txt，other 始终位于第一行，其余的标签会进行排序然后保存，以便用户快速进行训练，对应了文档中的标签例子
4、代码中兼容以前的版本，如果用户使用以前的 key_cls 的标签自动转换最新的 `label` 字段

标签文件对其文档： https://github.com/PaddlePaddle/PaddleOCR/blob/dygraph/doc/doc_ch/kie.md#12-%E8%87%AA%E5%AE%9A%E4%B9%89%E6%95%B0%E6%8D%AE%E9%9B%86