### PR TITLE
Fix low speed bug of eval during training for EAST

### DIFF
--- a/ppocr/postprocess/east_postprocess.py
+++ b/ppocr/postprocess/east_postprocess.py
@@ -81,6 +81,7 @@ class EASTPostProcess(object):
         try:
             check_install('lanms', 'lanms-nova')
             import lanms
+            boxes = lanms.merge_quadrangle_n9(boxes, nms_thresh)
         except:
             print(
                 'You should install lanms by pip3 install lanms-nova to speed up nms_locality'


### PR DESCRIPTION
 EAST模型的后处理代码中导入了lanms模块却没有使用，导致后处理缓慢，严重影响了训练中的评估速度。