### PR TITLE
改进文档`deploy/hubserving/readme.md`和`doc/doc_ch/models_list.md`

### DIFF
--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -3,7 +3,7 @@
 - [基于PaddleHub Serving的服务部署](#基于paddlehub-serving的服务部署)
   - [1. 近期更新](#1-近期更新)
   - [2. 快速启动服务](#2-快速启动服务)
-    - [2.1 准备环境](#21-准备环境)
+    - [2.1 安装paddlehub](#21-安装paddlehub)
     - [2.2 下载推理模型](#22-下载推理模型)
     - [2.3 安装服务模块](#23-安装服务模块)
     - [2.4 启动服务](#24-启动服务)
@@ -15,8 +15,8 @@
 
 
 PaddleOCR提供2种服务部署方式：
-- 基于PaddleHub Serving的部署：代码路径为"`./deploy/hubserving`"，按照本教程使用；
-- 基于PaddleServing的部署：代码路径为"`./deploy/pdserving`"，使用方法参考[文档](../../deploy/pdserving/README_CN.md)。
+- 基于PaddleHub Serving的部署：代码路径为`./deploy/hubserving`，按照本教程使用；
+- 基于PaddleServing的部署：代码路径为`./deploy/pdserving`，使用方法参考[文档](../../deploy/pdserving/README_CN.md)。
 
 # 基于PaddleHub Serving的服务部署
 
@@ -51,120 +51,77 @@ deploy/hubserving/ocr_system/
 
 ## 2. 快速启动服务
 以下步骤以检测+识别2阶段串联服务为例，如果只需要检测服务或识别服务，替换相应文件路径即可。
-### 2.1 准备环境
-```shell
-# 安装paddlehub  
-# paddlehub 需要 python>3.6.2
+### 2.1 安装paddlehub
+paddlehub 需要 python>3.6.2
+```bash
 pip3 install paddlehub==2.1.0 --upgrade -i https://mirror.baidu.com/pypi/simple
 ```
 
 ### 2.2 下载推理模型
 安装服务模块前，需要准备推理模型并放到正确路径。默认使用的是PP-OCRv3模型，默认模型路径为：
+| 模型 | 路径 |
+| ------- | - |
+| 检测模型 | `./inference/ch_PP-OCRv3_det_infer/` |
+| 识别模型 | `./inference/ch_PP-OCRv3_rec_infer/` |
+| 方向分类器 | `./inference/ch_ppocr_mobile_v2.0_cls_infer/` |
+| 版面分析模型 | `./inference/picodet_lcnet_x1_0_fgd_layout_infer/` |
+| 表格结构识别模型 | `./inference/ch_ppstructure_mobile_v2.0_SLANet_infer/` |
+| 关键信息抽取SER模型 | `./inference/ser_vi_layoutxlm_xfund_infer/` |
+| 关键信息抽取RE模型 | `./inference/re_vi_layoutxlm_xfund_infer/` |
 
-```
-检测模型：./inference/ch_PP-OCRv3_det_infer/
-识别模型：./inference/ch_PP-OCRv3_rec_infer/
-方向分类器：./inference/ch_ppocr_mobile_v2.0_cls_infer/
-版面分析模型：./inference/picodet_lcnet_x1_0_fgd_layout_infer/
-表格结构识别模型：./inference/ch_ppstructure_mobile_v2.0_SLANet_infer/
-关键信息抽取SER模型：./inference/ser_vi_layoutxlm_xfund_infer/
-关键信息抽取RE模型：./inference/re_vi_layoutxlm_xfund_infer/
-```
+**模型路径可在`params.py`中查看和修改。**
 
-**模型路径可在`params.py`中查看和修改。** 更多模型可以从PaddleOCR提供的模型库[PP-OCR](../../doc/doc_ch/models_list.md)和[PP-Structure](../../ppstructure/docs/models_list.md)下载，也可以替换成自己训练转换好的模型。
+更多模型可以从PaddleOCR提供的模型库[PP-OCR](../../doc/doc_ch/models_list.md)和[PP-Structure](../../ppstructure/docs/models_list.md)下载，也可以替换成自己训练转换好的模型。
 
 ### 2.3 安装服务模块
 PaddleOCR提供5种服务模块，根据需要安装所需模块。
 
-* 在Linux环境下，安装示例如下：
-```shell
-# 安装检测服务模块：  
-hub install deploy/hubserving/ocr_det/
-
-# 或，安装分类服务模块：  
-hub install deploy/hubserving/ocr_cls/
-
-# 或，安装识别服务模块：  
-hub install deploy/hubserving/ocr_rec/
-
-# 或，安装检测+识别串联服务模块：  
-hub install deploy/hubserving/ocr_system/
-
-# 或，安装表格识别服务模块：  
-hub install deploy/hubserving/structure_table/
-
-# 或，安装PP-Structure服务模块：  
-hub install deploy/hubserving/structure_system/
-
-# 或，安装版面分析服务模块：  
-hub install deploy/hubserving/structure_layout/
-
-# 或，安装关键信息抽取SER服务模块：  
-hub install deploy/hubserving/kie_ser/
-
-# 或，安装关键信息抽取SER+RE服务模块：  
-hub install deploy/hubserving/kie_ser_re/
-```
-
-* 在Windows环境下(文件夹的分隔符为`\`)，安装示例如下：
-```shell
-# 安装检测服务模块：  
-hub install deploy\hubserving\ocr_det\
-
-# 或，安装分类服务模块：  
-hub install deploy\hubserving\ocr_cls\
-
-# 或，安装识别服务模块：  
-hub install deploy\hubserving\ocr_rec\
-
-# 或，安装检测+识别串联服务模块：
-hub install deploy\hubserving\ocr_system\
-
-# 或，安装表格识别服务模块：
-hub install deploy\hubserving\structure_table\
-
-# 或，安装PP-Structure服务模块：  
-hub install deploy\hubserving\structure_system\
-
-# 或，安装版面分析服务模块：
-hub install deploy\hubserving\structure_layout\
-
-# 或，安装关键信息抽取SER服务模块：  
-hub install deploy\hubserving\kie_ser\
-
-# 或，安装关键信息抽取SER+RE服务模块：  
-hub install deploy\hubserving\kie_ser_re\
-```
+在Linux环境下，安装模块命令如下表（Windows环境请将`/`替换为`\`）：
+| 服务模块 | 命令 |
+| ------- | - |
+| 检测 | `hub install deploy/hubserving/ocr_det/` |
+| 分类 | `hub install deploy/hubserving/ocr_cls/` |
+| 识别 | `hub install deploy/hubserving/ocr_rec/` |
+| 检测+识别串联 | `hub install deploy/hubserving/ocr_system/` |
+| 表格识别 | `hub install deploy/hubserving/structure_table/` |
+| PP-Structure | `hub install deploy/hubserving/structure_system/` |
+| 版面分析 | `hub install deploy/hubserving/structure_layout/` |
+| 关键信息抽取SER | `hub install deploy/hubserving/kie_ser/` |
+| 关键信息抽取SER+RE | `hub install deploy/hubserving/kie_ser_re/` |
 
 ### 2.4 启动服务
 #### 2.4.1. 命令行命令启动（仅支持CPU）
-**启动命令：**  
-```shell
-$ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
-                    --port XXXX \
-                    --use_multiprocess \
-                    --workers \
+**启动命令：**
+```bash
+hub serving start --modules Module1==Version1, Module2==Version2, ... \
+                  --port 8866 \
+                  --use_multiprocess \
+                  --workers \
 ```
 
-**参数：**  
+**参数：**
+|参数|用途|
+|---|---|
+|`--modules`/`-m`|PaddleHub Serving预安装模型，以多个Module==Version键值对的形式列出<br>**当不指定Version时，默认选择最新版本**|
+|`--port`/`-p`|服务端口，默认为8866|
+|`--use_multiprocess`|是否启用并发方式，默认为单进程方式，推荐多核CPU机器使用此方式<br>**Windows操作系统只支持单进程方式**|
+|`--workers`|在并发方式下指定的并发任务数，默认为`2*cpu_count-1`，其中`cpu_count`为CPU核数|
 
-|参数|用途|  
-|---|---|  
-|--modules/-m|PaddleHub Serving预安装模型，以多个Module==Version键值对的形式列出<br>*`当不指定Version时，默认选择最新版本`*|  
-|--port/-p|服务端口，默认为8866|  
-|--use_multiprocess|是否启用并发方式，默认为单进程方式，推荐多核CPU机器使用此方式<br>*`Windows操作系统只支持单进程方式`*|
-|--workers|在并发方式下指定的并发任务数，默认为`2*cpu_count-1`，其中`cpu_count`为CPU核数|  
-
-如启动串联服务：  ```hub serving start -m ocr_system```  
+如启动串联服务：
+```bash
+hub serving start -m ocr_system
+```
 
 这样就完成了一个服务化API的部署，使用默认端口号8866。
 
 #### 2.4.2 配置文件启动（支持CPU、GPU）
-**启动命令：**  
-```hub serving start -c config.json```  
+**启动命令：**
+```bash
+hub serving start -c config.json
+```
 
 其中，`config.json`格式如下：
-```python
+```json
 {
     "modules_info": {
         "ocr_system": {
@@ -182,48 +139,59 @@ $ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
 }
 ```
 
-- `init_args`中的可配参数与`module.py`中的`_initialize`函数接口一致。其中，**当`use_gpu`为`true`时，表示使用GPU启动服务**。  
+- `init_args`中的可配参数与`module.py`中的`_initialize`函数接口一致。
+
+   **当`use_gpu`为`true`时，表示使用GPU启动服务。**
 - `predict_args`中的可配参数与`module.py`中的`predict`函数接口一致。
 
-**注意:**  
+**注意：**
 - 使用配置文件启动服务时，其他参数会被忽略。
-- 如果使用GPU预测(即，`use_gpu`置为`true`)，则需要在启动服务之前，设置CUDA_VISIBLE_DEVICES环境变量，如：```export CUDA_VISIBLE_DEVICES=0```，否则不用设置。
+- 如果使用GPU预测(即，`use_gpu`置为`true`)，则需要在启动服务之前，设置CUDA_VISIBLE_DEVICES环境变量，如：
+  ```bash
+  export CUDA_VISIBLE_DEVICES=0
+  ```
 - **`use_gpu`不可与`use_multiprocess`同时为`true`**。
 
-如，使用GPU 3号卡启动串联服务：  
-```shell
+如，使用GPU 3号卡启动串联服务：
+```bash
 export CUDA_VISIBLE_DEVICES=3
 hub serving start -c deploy/hubserving/ocr_system/config.json
 ```
 
 ## 3. 发送预测请求
-配置好服务端，可使用以下命令发送预测请求，获取预测结果:  
+配置好服务端，可使用以下命令发送预测请求，获取预测结果：
+```bash
+python tools/test_hubserving.py --server_url=server_url --image_dir=image_path
+```
 
-```python tools/test_hubserving.py --server_url=server_url --image_dir=image_path```  
+需要给脚本传递2个参数：
+- `server_url`：服务地址，格式为`http://[ip_address]:[port]/predict/[module_name]`
 
-需要给脚本传递2个参数：  
-- **server_url**：服务地址，格式为  
-`http://[ip_address]:[port]/predict/[module_name]`  
-例如，如果使用配置文件启动分类，检测、识别，检测+分类+识别3阶段，表格识别和PP-Structure服务，那么发送请求的url将分别是：  
-`http://127.0.0.1:8865/predict/ocr_det`  
-`http://127.0.0.1:8866/predict/ocr_cls`  
-`http://127.0.0.1:8867/predict/ocr_rec`  
-`http://127.0.0.1:8868/predict/ocr_system`  
-`http://127.0.0.1:8869/predict/structure_table`  
-`http://127.0.0.1:8870/predict/structure_system`  
-`http://127.0.0.1:8870/predict/structure_layout`  
-`http://127.0.0.1:8871/predict/kie_ser`  
-`http://127.0.0.1:8872/predict/kie_ser_re`
-- **image_dir**：测试图像路径，可以是单张图片路径，也可以是图像集合目录路径  
-- **visualize**：是否可视化结果，默认为False  
-- **output**：可视化结果保存路径，默认为`./hubserving_result`
+   例如，如果使用配置文件启动分类，检测、识别，检测+分类+识别3阶段，表格识别和PP-Structure服务
 
-访问示例：  
-```python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_system --image_dir=./doc/imgs/ --visualize=false```
+   并为每个服务修改了port，那么发送请求的url将分别是：
+   ```
+   http://127.0.0.1:8865/predict/ocr_det
+   http://127.0.0.1:8866/predict/ocr_cls
+   http://127.0.0.1:8867/predict/ocr_rec
+   http://127.0.0.1:8868/predict/ocr_system
+   http://127.0.0.1:8869/predict/structure_table
+   http://127.0.0.1:8870/predict/structure_system
+   http://127.0.0.1:8870/predict/structure_layout
+   http://127.0.0.1:8871/predict/kie_ser
+   http://127.0.0.1:8872/predict/kie_ser_re
+   ```
+- `image_dir`：测试图像路径，可以是单张图片路径，也可以是图像集合目录路径
+- `visualize`：是否可视化结果，默认为False
+- `output`：可视化结果保存路径，默认为`./hubserving_result`
+
+访问示例：
+```bash
+python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_system --image_dir=./doc/imgs/ --visualize=false
+```
 
 ## 4. 返回结果格式说明
 返回结果为列表（list），列表中的每一项为词典（dict），词典一共可能包含3种字段，信息如下：
-
 |字段名称|数据类型|意义|
 |---|---|---|
 |angle|str|文本角度|
@@ -231,41 +199,50 @@ hub serving start -c deploy/hubserving/ocr_system/config.json
 |confidence|float| 文本识别置信度或文本角度分类置信度|
 |text_region|list|文本位置坐标|
 |html|str|表格的html字符串|
-|regions|list|版面分析+表格识别+OCR的结果，每一项为一个list，包含表示区域坐标的`bbox`，区域类型的`type`和区域结果的`res`三个字段|
+|regions|list|版面分析+表格识别+OCR的结果，每一项为一个list<br>包含表示区域坐标的`bbox`，区域类型的`type`和区域结果的`res`三个字段|
 |layout|list|版面分析的结果，每一项一个dict，包含版面区域坐标的`bbox`，区域类型的`label`|
 
 不同模块返回的字段不同，如，文本识别服务模块返回结果不含`text_region`字段，具体信息如下：
-
-| 字段名/模块名 | ocr_det | ocr_cls | ocr_rec | ocr_system | structure_table | structure_system | Structure_layout | kie_ser | kie_re |
-|  ---  |  ---  |  ---  |  ---  |  ---  | ---  |  ---  |  ---  | ---  |  ---  |
-|angle| | ✔ | | ✔ | |||
-|text| | |✔|✔| | ✔ |  | ✔ | ✔ |
-|confidence| |✔ |✔| | | ✔| |✔ | ✔ |
-|text_region| ✔| | |✔ | | ✔| |✔ | ✔ |
-|html| | | | |✔ |✔||| |
-|regions| | | | |✔ |✔ | || |
-|layout| | | | | | | ✔ || |
-|ser_res| | | | | | |  |  ✔ | |
-|re_res| | | | | | |  | |  ✔ |
+|字段名/模块名     |ocr_det |ocr_cls |ocr_rec |ocr_system |structure_table |structure_system |structure_layout |kie_ser |kie_re |
+|---             |---     |---     |---     |---        |---             |---              |---              |---     |---    |
+|angle           |        |✔       |        |✔          |                |                 |                 |
+|text            |        |        |✔       |✔          |                |✔                |                 |✔       |✔      |
+|confidence      |        |✔       |✔       |           |                |✔                |                 |✔       |✔      |
+|text_region     |✔       |        |        |✔          |                |✔                |                 |✔       |✔      |
+|html            |        |        |        |           |✔               |✔                |                 |        |       |
+|regions         |        |        |        |           |✔               |✔                |                 |        |       |
+|layout          |        |        |        |           |                |                 |✔                |        |       |
+|ser_res         |        |        |        |           |                |                 |                 |✔       |       |
+|re_res          |        |        |        |           |                |                 |                 |        |✔      |
 
 
 **说明：** 如果需要增加、删除、修改返回字段，可在相应模块的`module.py`文件中进行修改，完整流程参考下一节自定义修改服务模块。
 
 ## 5. 自定义修改服务模块
-如果需要修改服务逻辑，你一般需要操作以下步骤（以修改`ocr_system`为例）：  
+如果需要修改服务逻辑，一般需要操作以下步骤（以修改`deploy/hubserving/ocr_system`为例）：
 
-- 1、 停止服务  
-```hub serving stop --port/-p XXXX```  
+1. 停止服务：
+   ```bash
+   hub serving stop --port/-p XXXX
+   ```
+2. 到`deploy/hubserving/ocr_system`下的`module.py`和`params.py`等文件中根据实际需求修改代码。
 
-- 2、 到相应的`module.py`和`params.py`等文件中根据实际需求修改代码。  
-例如，如果需要替换部署服务所用模型，则需要到`params.py`中修改模型路径参数`det_model_dir`和`rec_model_dir`，如果需要关闭文本方向分类器，则将参数`use_angle_cls`置为`False`，当然，同时可能还需要修改其他相关参数，请根据实际情况修改调试。 **强烈建议修改后先直接运行`module.py`调试，能正确运行预测后再启动服务测试。**
-**注意** PPOCR-v3识别模型使用的图片输入shape为`3,48,320`,因此需要修改`params.py`中的`cfg.rec_image_shape = "3, 48, 320"`，如果不使用PPOCR-v3识别模型，则无需修改该参数。
+   例如，如果需要替换部署服务所用模型，则需要到`params.py`中修改模型路径参数`det_model_dir`和`rec_model_dir`，如果需要关闭文本方向分类器，则将参数`use_angle_cls`置为`False`
 
-- 3、 卸载旧服务包  
-```hub uninstall ocr_system```  
+   当然，同时可能还需要修改其他相关参数，请根据实际情况修改调试。
 
-- 4、 安装修改后的新服务包  
-```hub install deploy/hubserving/ocr_system/```  
+   **强烈建议修改后先直接运行`module.py`调试，能正确运行预测后再启动服务测试。**
 
-- 5、重新启动服务  
-```hub serving start -m ocr_system```  
+   **注意：** PPOCR-v3识别模型使用的图片输入shape为`3,48,320`,因此需要修改`params.py`中的`cfg.rec_image_shape = "3, 48, 320"`，如果不使用PPOCR-v3识别模型，则无需修改该参数。
+3. 如果目录下存在`__pycache__`目录请将其删除：
+   ```bash
+   find -name '__pycache__' -exec rm -r {} \;
+   ```
+4. 安装修改后的新服务包：
+   ```bash
+   hub install deploy/hubserving/ocr_system/
+   ```
+5. 重新启动服务：
+   ```bash
+   hub serving start -m ocr_system
+   ```

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -3,7 +3,7 @@
 - [基于PaddleHub Serving的服务部署](#基于paddlehub-serving的服务部署)
   - [1. 近期更新](#1-近期更新)
   - [2. 快速启动服务](#2-快速启动服务)
-    - [2.1 安装paddlehub](#21-安装paddlehub)
+    - [2.1 安装PaddleHub](#21-安装PaddleHub)
     - [2.2 下载推理模型](#22-下载推理模型)
     - [2.3 安装服务模块](#23-安装服务模块)
     - [2.4 启动服务](#24-启动服务)
@@ -51,7 +51,7 @@ deploy/hubserving/ocr_system/
 
 ## 2. 快速启动服务
 以下步骤以检测+识别2阶段串联服务为例，如果只需要检测服务或识别服务，替换相应文件路径即可。
-### 2.1 安装paddlehub
+### 2.1 安装PaddleHub
 paddlehub 需要 python>3.6.2
 ```bash
 pip3 install paddlehub==2.1.0 --upgrade -i https://mirror.baidu.com/pypi/simple
@@ -237,7 +237,7 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
 3. （可选）如果想要重命名模块需要更改`module.py`文件中的以下行：
    - [`from deploy.hubserving.ocr_system.params import read_params`中的`ocr_system`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L35)
    - [`name="ocr_system",`中的`ocr_system`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L39)
-4. （可选）可能需要删除`__pycache__`目录以强制刷新cpy缓存：
+4. （可选）可能需要删除`__pycache__`目录以强制刷新CPython缓存：
    ```bash
    find deploy/hubserving/ocr_system -name '__pycache__' -exec rm -r {} \;
    ```

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -234,9 +234,9 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
    **强烈建议修改后先直接运行`module.py`调试，能正确运行预测后再启动服务测试。**
 
    **注意：** PPOCR-v3识别模型使用的图片输入shape为`3,48,320`,因此需要修改`params.py`中的`cfg.rec_image_shape = "3, 48, 320"`，如果不使用PPOCR-v3识别模型，则无需修改该参数。
-3. （可选）如果想要重命名模块需要更改以下行：
-   https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_rec/module.py#L35
-   https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_rec/module.py#L39
+3. （可选）如果想要重命名模块需要更改`module.py`文件中的以下行：
+   - [`from deploy.hubserving.ocr_system.params import read_params`中的`ocr_system`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L35)
+   - [`name="ocr_system",`中的`ocr_system`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L39)
 4. （可选）可能需要删除`__pycache__`目录以强制刷新cpy缓存：
    ```bash
    find deploy/hubserving/ocr_system -name '__pycache__' -exec rm -r {} \;

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -76,18 +76,18 @@ pip3 install paddlehub==2.1.0 --upgrade -i https://mirror.baidu.com/pypi/simple
 ### 2.3 安装服务模块
 PaddleOCR提供5种服务模块，根据需要安装所需模块。
 
-在Linux环境下，安装模块命令如下表（Windows环境请将`/`替换为`\`）：
+在Linux环境（Windows环境请将`/`替换为`\`）下，安装模块命令如下表：
 | 服务模块 | 命令 |
 | ------- | - |
-| 检测 | `hub install deploy/hubserving/ocr_det/` |
-| 分类 | `hub install deploy/hubserving/ocr_cls/` |
-| 识别 | `hub install deploy/hubserving/ocr_rec/` |
-| 检测+识别串联 | `hub install deploy/hubserving/ocr_system/` |
-| 表格识别 | `hub install deploy/hubserving/structure_table/` |
-| PP-Structure | `hub install deploy/hubserving/structure_system/` |
-| 版面分析 | `hub install deploy/hubserving/structure_layout/` |
-| 关键信息抽取SER | `hub install deploy/hubserving/kie_ser/` |
-| 关键信息抽取SER+RE | `hub install deploy/hubserving/kie_ser_re/` |
+| 检测 | `hub install deploy/hubserving/ocr_det` |
+| 分类 | `hub install deploy/hubserving/ocr_cls` |
+| 识别 | `hub install deploy/hubserving/ocr_rec` |
+| 检测+识别串联 | `hub install deploy/hubserving/ocr_system` |
+| 表格识别 | `hub install deploy/hubserving/structure_table` |
+| PP-Structure | `hub install deploy/hubserving/structure_system` |
+| 版面分析 | `hub install deploy/hubserving/structure_layout` |
+| 关键信息抽取SER | `hub install deploy/hubserving/kie_ser` |
+| 关键信息抽取SER+RE | `hub install deploy/hubserving/kie_ser_re` |
 
 ### 2.4 启动服务
 #### 2.4.1. 命令行命令启动（仅支持CPU）
@@ -214,7 +214,6 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
 |layout          |        |        |        |           |                |                 |✔                |        |       |
 |ser_res         |        |        |        |           |                |                 |                 |✔       |       |
 |re_res          |        |        |        |           |                |                 |                 |        |✔      |
-
 
 **说明：** 如果需要增加、删除、修改返回字段，可在相应模块的`module.py`文件中进行修改，完整流程参考下一节自定义修改服务模块。
 

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -207,7 +207,7 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
 |---             |---     |---     |---     |---        |---             |---              |---              |---     |---    |
 |angle           |        |✔       |        |✔          |                |                 |                 |
 |text            |        |        |✔       |✔          |                |✔                |                 |✔       |✔      |
-|confidence      |        |✔       |✔       |           |                |✔                |                 |✔       |✔      |
+|confidence      |        |✔       |✔       |✔          |                |✔                |                 |✔       |✔      |
 |text_region     |✔       |        |        |✔          |                |✔                |                 |✔       |✔      |
 |html            |        |        |        |           |✔               |✔                |                 |        |       |
 |regions         |        |        |        |           |✔               |✔                |                 |        |       |

--- a/deploy/hubserving/readme.md
+++ b/deploy/hubserving/readme.md
@@ -234,15 +234,18 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
    **强烈建议修改后先直接运行`module.py`调试，能正确运行预测后再启动服务测试。**
 
    **注意：** PPOCR-v3识别模型使用的图片输入shape为`3,48,320`,因此需要修改`params.py`中的`cfg.rec_image_shape = "3, 48, 320"`，如果不使用PPOCR-v3识别模型，则无需修改该参数。
-3. 如果目录下存在`__pycache__`目录请将其删除：
+3. （可选）如果想要重命名模块需要更改以下行：
+   https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_rec/module.py#L35
+   https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_rec/module.py#L39
+4. （可选）可能需要删除`__pycache__`目录以强制刷新cpy缓存：
    ```bash
-   find -name '__pycache__' -exec rm -r {} \;
+   find deploy/hubserving/ocr_system -name '__pycache__' -exec rm -r {} \;
    ```
-4. 安装修改后的新服务包：
+5. 安装修改后的新服务包：
    ```bash
-   hub install deploy/hubserving/ocr_system/
+   hub install deploy/hubserving/ocr_system
    ```
-5. 重新启动服务：
+6. 重新启动服务：
    ```bash
    hub serving start -m ocr_system
    ```

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -3,7 +3,7 @@ English | [简体中文](readme.md)
 - [Service deployment based on PaddleHub Serving](#service-deployment-based-on-paddlehub-serving)
   - [1. Update](#1-update)
   - [2. Quick start service](#2-quick-start-service)
-    - [2.1 Prepare the environment](#21-prepare-the-environment)
+    - [2.1 Install PaddleHub](#21-install-paddlehub)
     - [2.2 Download inference model](#22-download-inference-model)
     - [2.3 Install Service Module](#23-install-service-module)
     - [2.4 Start service](#24-start-service)
@@ -15,8 +15,8 @@ English | [简体中文](readme.md)
 
 
 PaddleOCR provides 2 service deployment methods:
-- Based on **PaddleHub Serving**: Code path is "`./deploy/hubserving`". Please follow this tutorial.
-- Based on **PaddleServing**: Code path is "`./deploy/pdserving`". Please refer to the [tutorial](../../deploy/pdserving/README.md) for usage.
+- Based on **PaddleHub Serving**: Code path is `./deploy/hubserving`. Please follow this tutorial.
+- Based on **PaddleServing**: Code path is `./deploy/pdserving`. Please refer to the [tutorial](../../deploy/pdserving/README.md) for usage.
 
 # Service deployment based on PaddleHub Serving
 
@@ -53,11 +53,9 @@ deploy/hubserving/ocr_system/
 ## 2. Quick start service
 The following steps take the 2-stage series service as an example. If only the detection service or recognition service is needed, replace the corresponding file path.
 
-### 2.1 Prepare the environment
+### 2.1 Install PaddleHub
 ```bash
-# Install paddlehub
-# python>3.6.2 is required bt paddlehub
-pip3 install paddlehub==2.1.0 --upgrade -i https://pypi.tuna.tsinghua.edu.cn/simple
+pip3 install paddlehub==2.1.0 --upgrade
 ```
 
 ### 2.2 Download inference model
@@ -72,7 +70,8 @@ KIE(SER): ./inference/ser_vi_layoutxlm_xfund_infer/
 KIE(SER+RE): ./inference/re_vi_layoutxlm_xfund_infer/
 ```
 
-**The model path can be found and modified in `params.py`.** More models provided by PaddleOCR can be obtained from the [model library](../../doc/doc_en/models_list_en.md). You can also use models trained by yourself.
+**The model path can be found and modified in `params.py`.**
+More models provided by PaddleOCR can be obtained from the [model library](../../doc/doc_en/models_list_en.md). You can also use models trained by yourself.
 
 ### 2.3 Install Service Module
 PaddleOCR provides 5 kinds of service modules, install the required modules according to your needs.
@@ -139,19 +138,19 @@ hub install deploy\hubserving\kie_ser_re\
 
 **start command：**
 ```bash
-$ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
-                    --port XXXX \
-                    --use_multiprocess \
-                    --workers \
+hub serving start --modules Module1==Version1, Module2==Version2, ... \
+                  --port 8866 \
+                  --use_multiprocess \
+                  --workers \
 ```
 **parameters：**
 
 |parameters|usage|
 |---|---|
-|--modules/-m|PaddleHub Serving pre-installed model, listed in the form of multiple Module==Version key-value pairs<br>*`When Version is not specified, the latest version is selected by default`*|
-|--port/-p|Service port, default is 8866|
-|--use_multiprocess|Enable concurrent mode, the default is single-process mode, this mode is recommended for multi-core CPU machines<br>*`Windows operating system only supports single-process mode`*|
-|--workers|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|
+|`--modules`/`-m`|PaddleHub Serving pre-installed model, listed in the form of multiple Module==Version key-value pairs<br>**When Version is not specified, the latest version is selected by default**|
+|`--port`/`-p`|Service port, default is 8866|
+|`--use_multiprocess`|Enable concurrent mode, the default is single-process mode, this mode is recommended for multi-core CPU machines<br>**Windows operating system only supports single-process mode**|
+|`--workers`|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|
 
 For example, start the 2-stage series service:
 ```bash
@@ -166,7 +165,7 @@ This completes the deployment of a service API, using the default port number 88
 hub serving start --config/-c config.json
 ```
 Wherein, the format of `config.json` is as follows:
-```python
+```json
 {
     "modules_info": {
         "ocr_system": {
@@ -183,12 +182,17 @@ Wherein, the format of `config.json` is as follows:
     "workers": 2
 }
 ```
-- The configurable parameters in `init_args` are consistent with the `_initialize` function interface in `module.py`. Among them, **when `use_gpu` is `true`, it means that the GPU is used to start the service**.
+- The configurable parameters in `init_args` are consistent with the `_initialize` function interface in `module.py`.
+
+  **When `use_gpu` is `true`, it means that the GPU is used to start the service**.
 - The configurable parameters in `predict_args` are consistent with the `predict` function interface in `module.py`.
 
 **Note:**
 - When using the configuration file to start the service, other parameters will be ignored.
-- If you use GPU prediction (that is, `use_gpu` is set to `true`), you need to set the environment variable CUDA_VISIBLE_DEVICES before starting the service, such as: ```export CUDA_VISIBLE_DEVICES=0```, otherwise you do not need to set it.
+- If you use GPU prediction (that is, `use_gpu` is set to `true`), you need to set the environment variable CUDA_VISIBLE_DEVICES before starting the service, such as:
+  ```bash
+  export CUDA_VISIBLE_DEVICES=0
+  ```
 - **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**
 
 For example, use GPU card No. 3 to start the 2-stage series service:
@@ -206,17 +210,22 @@ python tools/test_hubserving.py --server_url=server_url --image_dir=image_path
 Two parameters need to be passed to the script:
 - **server_url**：service address，format of which is
 `http://[ip_address]:[port]/predict/[module_name]`
-For example, if using the configuration file to start the text angle classification, text detection, text recognition, detection+classification+recognition 3 stages, table recognition and PP-Structure service, then the `server_url` to send the request will be:
 
-`http://127.0.0.1:8865/predict/ocr_det`
-`http://127.0.0.1:8866/predict/ocr_cls`
-`http://127.0.0.1:8867/predict/ocr_rec`
-`http://127.0.0.1:8868/predict/ocr_system`
-`http://127.0.0.1:8869/predict/structure_table`
-`http://127.0.0.1:8870/predict/structure_system`
-`http://127.0.0.1:8870/predict/structure_layout`
-`http://127.0.0.1:8871/predict/kie_ser`
-`http://127.0.0.1:8872/predict/kie_ser_re`
+  For example, if using the configuration file to start the text angle classification, text detection, text recognition, detection+classification+recognition 3 stages, table recognition and PP-Structure service,
+
+  also modified the port for each services, then the `server_url` to send the request will be:
+
+  ```
+  http://127.0.0.1:8865/predict/ocr_det
+  http://127.0.0.1:8866/predict/ocr_cls
+  http://127.0.0.1:8867/predict/ocr_rec
+  http://127.0.0.1:8868/predict/ocr_system
+  http://127.0.0.1:8869/predict/structure_table
+  http://127.0.0.1:8870/predict/structure_system
+  http://127.0.0.1:8870/predict/structure_layout
+  http://127.0.0.1:8871/predict/kie_ser
+  http://127.0.0.1:8872/predict/kie_ser_re
+  ```
 - **image_dir**：Test image path, can be a single image path or an image directory path
 - **visualize**：Whether to visualize the results, the default value is False
 - **output**：The floder to save Visualization result, default value is `./hubserving_result`
@@ -241,17 +250,17 @@ The returned result is a list. Each item in the list is a dict. The dict may con
 
 The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`. The details are as follows:
 
-| field name/module name | ocr_det | ocr_cls | ocr_rec | ocr_system | structure_table | structure_system | structure_layout | kie_ser | kie_re |
-|  ---  |  ---  |  ---  |  ---  |  ---  | ---  |  ---  |  ---  | ---  |  ---  |
-|angle| | ✔ | | ✔ | |||
-|text| | |✔|✔| | ✔ |  | ✔ | ✔ |
-|confidence| |✔ |✔| | | ✔| |✔ | ✔ |
-|text_region| ✔| | |✔ | | ✔| |✔ | ✔ |
-|html| | | | |✔ |✔||| |
-|regions| | | | |✔ |✔ | || |
-|layout| | | | | | | ✔ || |
-|ser_res| | | | | | |  |  ✔ | |
-|re_res| | | | | | |  | |  ✔ |
+|field name/module name |ocr_det |ocr_cls |ocr_rec |ocr_system |structure_table |structure_system |structure_layout |kie_ser |kie_re |
+|---                    |---     |---     |---     |---        |---             |---              |---              |---     |---    |
+|angle                  |        |✔       |        |✔          |                |                 |                 |
+|text                   |        |        |✔       |✔          |                |✔                |                 |✔       |✔      |
+|confidence             |        |✔       |✔       |           |                |✔                |                 |✔       |✔      |
+|text_region            |✔       |        |        |✔          |                |✔                |                 |✔       |✔      |
+|html                   |        |        |        |           |✔               |✔                |                 |        |       |
+|regions                |        |        |        |           |✔               |✔                |                 |        |       |
+|layout                 |        |        |        |           |                |                 |✔                |        |       |
+|ser_res                |        |        |        |           |                |                 |                 |✔       |       |
+|re_res                 |        |        |        |           |                |                 |                 |        |✔      |
 
 **Note：** If you need to add, delete or modify the returned fields, you can modify the file `module.py` of the corresponding module. For the complete process, refer to the user-defined modification service module in the next section.
 

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -8,10 +8,10 @@ English | [简体中文](readme.md)
     - [2.3 Install Service Module](#23-install-service-module)
     - [2.4 Start service](#24-start-service)
       - [2.4.1 Start with command line parameters (CPU only)](#241-start-with-command-line-parameters-cpu-only)
-      - [2.4.2 Start with configuration file（CPU、GPU）](#242-start-with-configuration-filecpugpu)
+      - [2.4.2 Start with configuration file（CPU and GPU）](#242-start-with-configuration-filecpugpu)
   - [3. Send prediction requests](#3-send-prediction-requests)
   - [4. Returned result format](#4-returned-result-format)
-  - [5. User defined service module modification](#5-user-defined-service-module-modification)
+  - [5. User-defined service module modification](#5-user-defined-service-module-modification)
 
 PaddleOCR provides 2 service deployment methods:
 - Based on **PaddleHub Serving**: Code path is `./deploy/hubserving`. Please follow this tutorial.
@@ -19,7 +19,7 @@ PaddleOCR provides 2 service deployment methods:
 
 # Service deployment based on PaddleHub Serving
 
-The hubserving service deployment directory includes seven service packages: text detection, text angle class, text recognition, text detection+text angle class+text recognition three-stage series connection, layout analysis, table recognition and PP-Structure. Please select the corresponding service package to install and start service according to your needs. The directory is as follows:
+The hubserving service deployment directory includes seven service packages: text detection, text angle class, text recognition, text detection+text angle class+text recognition three-stage series connection, layout analysis, table recognition, and PP-Structure. Please select the corresponding service package to install and start the service according to your needs. The directory is as follows:
 ```
 deploy/hubserving/
   └─  ocr_det     text detection module service package
@@ -39,7 +39,7 @@ deploy/hubserving/ocr_system/
   └─  __init__.py    Empty file, required
   └─  config.json    Configuration file, optional, passed in as a parameter when using configuration to start the service
   └─  module.py      Main module file, required, contains the complete logic of the service
-  └─  params.py      Parameter file, required, including parameters such as model path, pre- and post-processing parameters
+  └─  params.py      Parameter file, required, including parameters such as model path, pre and post-processing parameters
 ```
 ## 1. Update
 
@@ -74,7 +74,7 @@ More models provided by PaddleOCR can be obtained from the [model library](../..
 ### 2.3 Install Service Module
 PaddleOCR provides 5 kinds of service modules, install the required modules according to your needs.
 
-* On Linux platform(replace `/` with `\` if using Windows), the examples are as following table:
+* On the Linux platform(replace `/` with `\` if using Windows), the examples are as the following table:
 | Service model | Command |
 | text detection | `hub install deploy/hubserving/ocr_det` |
 | text angle class: | `hub install deploy/hubserving/ocr_cls` |
@@ -87,7 +87,7 @@ PaddleOCR provides 5 kinds of service modules, install the required modules acco
 
 ### 2.4 Start service
 #### 2.4.1 Start with command line parameters (CPU only)
-**start command：**
+**start command:**
 ```bash
 hub serving start --modules Module1==Version1, Module2==Version2, ... \
                   --port 8866 \
@@ -95,12 +95,12 @@ hub serving start --modules Module1==Version1, Module2==Version2, ... \
                   --workers \
 ```
 
-**parameters：**
+**Parameters:**
 |parameters|usage|
 |---|---|
 |`--modules`/`-m`|PaddleHub Serving pre-installed model, listed in the form of multiple Module==Version key-value pairs<br>**When Version is not specified, the latest version is selected by default**|
 |`--port`/`-p`|Service port, default is 8866|
-|`--use_multiprocess`|Enable concurrent mode, the default is single-process mode, this mode is recommended for multi-core CPU machines<br>**Windows operating system only supports single-process mode**|
+|`--use_multiprocess`|Enable concurrent mode, by default using the single-process mode, this mode is recommended for multi-core CPU machines<br>**Windows operating system only supports single-process mode**|
 |`--workers`|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|
 
 For example, start the 2-stage series service:
@@ -110,8 +110,8 @@ hub serving start -m ocr_system
 
 This completes the deployment of a service API, using the default port number 8866.
 
-#### 2.4.2 Start with configuration file（CPU、GPU）
-**start command：**
+#### 2.4.2 Start with configuration file（CPU and GPU）
+**start command:**
 ```bash
 hub serving start --config/-c config.json
 ```
@@ -160,12 +160,12 @@ python tools/test_hubserving.py --server_url=server_url --image_dir=image_path
 ```
 
 Two parameters need to be passed to the script:
-- **server_url**：service address，format of which is
+- **server_url**:service address, the format of which is
 `http://[ip_address]:[port]/predict/[module_name]`
 
   For example, if using the configuration file to start the text angle classification, text detection, text recognition, detection+classification+recognition 3 stages, table recognition and PP-Structure service,
 
-  also modified the port for each services, then the `server_url` to send the request will be:
+  also modified the port for each service, then the `server_url` to send the request will be:
 
   ```
   http://127.0.0.1:8865/predict/ocr_det
@@ -178,9 +178,9 @@ Two parameters need to be passed to the script:
   http://127.0.0.1:8871/predict/kie_ser
   http://127.0.0.1:8872/predict/kie_ser_re
   ```
-- **image_dir**：Test image path, can be a single image path or an image directory path
-- **visualize**：Whether to visualize the results, the default value is False
-- **output**：The floder to save Visualization result, default value is `./hubserving_result`
+- **image_dir**:Test image path, which can be a single image path or an image directory path
+- **visualize**:Whether to visualize the results, the default value is False
+- **output**:The folder to save the Visualization result, the default value is `./hubserving_result`
 
 Example:
 ```bash
@@ -188,7 +188,7 @@ python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_s
 ```
 
 ## 4. Returned result format
-The returned result is a list. Each item in the list is a dict. The dict may contain three fields. The information is as follows:
+The returned result is a list. Each item in the list is a dictionary which may contain three fields. The information is as follows:
 
 |field name|data type|description|
 |----|----|----|
@@ -196,11 +196,11 @@ The returned result is a list. Each item in the list is a dict. The dict may con
 |text|str|text content|
 |confidence|float|text recognition confidence|
 |text_region|list|text location coordinates|
-|html|str|table html str|
+|html|str|table HTML string|
 |regions|list|The result of layout analysis + table recognition + OCR, each item is a list<br>including `bbox` indicating area coordinates, `type` of area type and `res` of area results|
 |layout|list|The result of layout analysis, each item is a dict, including `bbox` indicating area coordinates, `label` of area type|
 
-The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`, detailed table as following:
+The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`, detailed table is as follows:
 
 |field name/module name |ocr_det |ocr_cls |ocr_rec |ocr_system |structure_table |structure_system |structure_layout |kie_ser |kie_re |
 |---                    |---     |---     |---     |---        |---             |---              |---              |---     |---    |
@@ -214,9 +214,9 @@ The fields returned by different modules are different. For example, the results
 |ser_res                |        |        |        |           |                |                 |                 |✔       |       |
 |re_res                 |        |        |        |           |                |                 |                 |        |✔      |
 
-**Note：** If you need to add, delete or modify the returned fields, you can modify the file `module.py` of the corresponding module. For the complete process, refer to the user-defined modification service module in the next section.
+**Note:** If you need to add, delete or modify the returned fields, you can modify the file `module.py` of the corresponding module. For the complete process, refer to the user-defined modification service module in the next section.
 
-## 5. User defined service module modification
+## 5. User-defined service module modification
 If you need to modify the service logic, the following steps are generally required (take the modification of `deploy/hubserving/ocr_system` for example):
 
 1. Stop service:
@@ -232,10 +232,10 @@ hub serving stop --port/-p XXXX
    **It is suggested to run `module.py` directly for debugging after modification before starting the service test.**
 
    **Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.
-3. (Optional) If you want to rename the module, following lines should be modified:
+3. (Optional) If you want to rename the module, the following lines should be modified:
    - [`ocr_system` within `from deploy.hubserving.ocr_system.params import read_params`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L35)
    - [`ocr_system` within `name="ocr_system",`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L39)
-4. (Optional) It may requires you to delete the directory `__pycache__` to force flush CPython build cache:
+4. (Optional) It may require you to delete the directory `__pycache__` to force flush build cache of CPython:
    ```bash
    find deploy/hubserving/ocr_system -name '__pycache__' -exec rm -r {} \;
    ```

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -13,7 +13,6 @@ English | [简体中文](readme.md)
   - [4. Returned result format](#4-returned-result-format)
   - [5. User defined service module modification](#5-user-defined-service-module-modification)
 
-
 PaddleOCR provides 2 service deployment methods:
 - Based on **PaddleHub Serving**: Code path is `./deploy/hubserving`. Please follow this tutorial.
 - Based on **PaddleServing**: Code path is `./deploy/pdserving`. Please refer to the [tutorial](../../deploy/pdserving/README.md) for usage.
@@ -49,7 +48,6 @@ deploy/hubserving/ocr_system/
 * 2022.03.30 add PP-Structure and table recognition services.
 * 2022.05.05 add PP-OCRv3 text detection and recognition services.
 
-
 ## 2. Quick start service
 The following steps take the 2-stage series service as an example. If only the detection service or recognition service is needed, replace the corresponding file path.
 
@@ -60,15 +58,15 @@ pip3 install paddlehub==2.1.0 --upgrade
 
 ### 2.2 Download inference model
 Before installing the service module, you need to prepare the inference model and put it in the correct path. By default, the PP-OCRv3 models are used, and the default model path is:
-```
-text detection model: ./inference/ch_PP-OCRv3_det_infer/
-text recognition model: ./inference/ch_PP-OCRv3_rec_infer/
-text angle classifier: ./inference/ch_ppocr_mobile_v2.0_cls_infer/
-layout parse model: ./inference/picodet_lcnet_x1_0_fgd_layout_infer/
-tanle recognition: ./inference/ch_ppstructure_mobile_v2.0_SLANet_infer/
-KIE(SER): ./inference/ser_vi_layoutxlm_xfund_infer/
-KIE(SER+RE): ./inference/re_vi_layoutxlm_xfund_infer/
-```
+| Model | Path |
+| ------- | - |
+| text detection model | ./inference/ch_PP-OCRv3_det_infer/ |
+| text recognition model | ./inference/ch_PP-OCRv3_rec_infer/ |
+| text angle classifier | ./inference/ch_ppocr_mobile_v2.0_cls_infer/ |
+| layout parse model | ./inference/picodet_lcnet_x1_0_fgd_layout_infer/ |
+| tanle recognition | ./inference/ch_ppstructure_mobile_v2.0_SLANet_infer/ |
+| KIE(SER) | ./inference/ser_vi_layoutxlm_xfund_infer/ |
+| KIE(SER+RE) | ./inference/re_vi_layoutxlm_xfund_infer/ |
 
 **The model path can be found and modified in `params.py`.**
 More models provided by PaddleOCR can be obtained from the [model library](../../doc/doc_en/models_list_en.md). You can also use models trained by yourself.
@@ -76,66 +74,19 @@ More models provided by PaddleOCR can be obtained from the [model library](../..
 ### 2.3 Install Service Module
 PaddleOCR provides 5 kinds of service modules, install the required modules according to your needs.
 
-* On Linux platform, the examples are as follows.
-```bash
-# Install the text detection service module:
-hub install deploy/hubserving/ocr_det/
-
-# Or, install the text angle class service module:
-hub install deploy/hubserving/ocr_cls/
-
-# Or, install the text recognition service module:
-hub install deploy/hubserving/ocr_rec/
-
-# Or, install the 2-stage series service module:
-hub install deploy/hubserving/ocr_system/
-
-# Or install table recognition service module
-hub install deploy/hubserving/structure_table/
-
-# Or install PP-Structure service module
-hub install deploy/hubserving/structure_system/
-
-# Or install KIE(SER) service module
-hub install deploy/hubserving/kie_ser/
-
-# Or install KIE(SER+RE) service module
-hub install deploy/hubserving/kie_ser_re/
-```
-
-* On Windows platform, the examples are as follows.
-```bash
-# Install the detection service module:
-hub install deploy\hubserving\ocr_det\
-
-# Or, install the angle class service module:
-hub install deploy\hubserving\ocr_cls\
-
-# Or, install the recognition service module:
-hub install deploy\hubserving\ocr_rec\
-
-# Or, install the 2-stage series service module:
-hub install deploy\hubserving\ocr_system\
-
-# Or install table recognition service module
-hub install deploy/hubserving/structure_table/
-
-# Or install PP-Structure service module
-hub install deploy\hubserving\structure_system\
-
-# Or install layout analysis service module
-hub install deploy\hubserving\structure_layout\
-
-# Or install KIE(SER) service module
-hub install deploy\hubserving\kie_ser\
-
-# Or install KIE(SER+RE) service module
-hub install deploy\hubserving\kie_ser_re\
-```
+* On Linux platform(replace `/` with `\` if using Windows), the examples are as following table:
+| Service model | Command |
+| text detection | `hub install deploy/hubserving/ocr_det` |
+| text angle class: | `hub install deploy/hubserving/ocr_cls` |
+| text recognition: | `hub install deploy/hubserving/ocr_rec` |
+| 2-stage series: | `hub install deploy/hubserving/ocr_system` |
+| table recognition | `hub install deploy/hubserving/structure_table` |
+| PP-Structure | `hub install deploy/hubserving/structure_system` |
+| KIE(SER) | `hub install deploy/hubserving/kie_ser` |
+| KIE(SER+RE) | `hub install deploy/hubserving/kie_ser_re` |
 
 ### 2.4 Start service
 #### 2.4.1 Start with command line parameters (CPU only)
-
 **start command：**
 ```bash
 hub serving start --modules Module1==Version1, Module2==Version2, ... \
@@ -143,8 +94,8 @@ hub serving start --modules Module1==Version1, Module2==Version2, ... \
                   --use_multiprocess \
                   --workers \
 ```
-**parameters：**
 
+**parameters：**
 |parameters|usage|
 |---|---|
 |`--modules`/`-m`|PaddleHub Serving pre-installed model, listed in the form of multiple Module==Version key-value pairs<br>**When Version is not specified, the latest version is selected by default**|
@@ -164,7 +115,8 @@ This completes the deployment of a service API, using the default port number 88
 ```bash
 hub serving start --config/-c config.json
 ```
-Wherein, the format of `config.json` is as follows:
+
+In which the format of `config.json` is as follows:
 ```json
 {
     "modules_info": {
@@ -187,13 +139,13 @@ Wherein, the format of `config.json` is as follows:
   **When `use_gpu` is `true`, it means that the GPU is used to start the service**.
 - The configurable parameters in `predict_args` are consistent with the `predict` function interface in `module.py`.
 
-**Note:**
-- When using the configuration file to start the service, other parameters will be ignored.
-- If you use GPU prediction (that is, `use_gpu` is set to `true`), you need to set the environment variable CUDA_VISIBLE_DEVICES before starting the service, such as:
-  ```bash
-  export CUDA_VISIBLE_DEVICES=0
-  ```
-- **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**
+  **Note:**
+  - When using the configuration file to start the service, other parameters will be ignored.
+  - If you use GPU prediction (that is, `use_gpu` is set to `true`), you need to set the environment variable CUDA_VISIBLE_DEVICES before starting the service, such as:
+    ```bash
+    export CUDA_VISIBLE_DEVICES=0
+    ```
+  - **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**
 
 For example, use GPU card No. 3 to start the 2-stage series service:
 ```bash
@@ -230,7 +182,7 @@ Two parameters need to be passed to the script:
 - **visualize**：Whether to visualize the results, the default value is False
 - **output**：The floder to save Visualization result, default value is `./hubserving_result`
 
-**Eg.**
+Example:
 ```bash
 python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_system --image_dir=./doc/imgs/ --visualize=false`
 ```
@@ -248,7 +200,7 @@ The returned result is a list. Each item in the list is a dict. The dict may con
 |regions|list|The result of layout analysis + table recognition + OCR, each item is a list<br>including `bbox` indicating area coordinates, `type` of area type and `res` of area results|
 |layout|list|The result of layout analysis, each item is a dict, including `bbox` indicating area coordinates, `label` of area type|
 
-The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`. The details are as follows:
+The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`, detailed table as following:
 
 |field name/module name |ocr_det |ocr_cls |ocr_rec |ocr_system |structure_table |structure_system |structure_layout |kie_ser |kie_re |
 |---                    |---     |---     |---     |---        |---             |---              |---              |---     |---    |

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -226,9 +226,9 @@ hub serving stop --port/-p XXXX
 2. Modify the code in the corresponding files under `deploy/hubserving/ocr_system`, such as `module.py` and `params.py`, to your actual needs.
 
    For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`.
-   
+
    Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation.
-   
+
    **It is suggested to run `module.py` directly for debugging after modification before starting the service test.**
 
    **Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -245,7 +245,7 @@ The returned result is a list. Each item in the list is a dict. The dict may con
 |confidence|float|text recognition confidence|
 |text_region|list|text location coordinates|
 |html|str|table html str|
-|regions|list|The result of layout analysis + table recognition + OCR, each item is a list, including `bbox` indicating area coordinates, `type` of area type and `res` of area results|
+|regions|list|The result of layout analysis + table recognition + OCR, each item is a list<br>including `bbox` indicating area coordinates, `type` of area type and `res` of area results|
 |layout|list|The result of layout analysis, each item is a dict, including `bbox` indicating area coordinates, `label` of area type|
 
 The fields returned by different modules are different. For example, the results returned by the text recognition service module do not contain `text_region`. The details are as follows:
@@ -265,24 +265,33 @@ The fields returned by different modules are different. For example, the results
 **Note：** If you need to add, delete or modify the returned fields, you can modify the file `module.py` of the corresponding module. For the complete process, refer to the user-defined modification service module in the next section.
 
 ## 5. User defined service module modification
-If you need to modify the service logic, the following steps are generally required (take the modification of `ocr_system` for example):
+If you need to modify the service logic, the following steps are generally required (take the modification of `deploy/hubserving/ocr_system` for example):
 
-- 1. Stop service
+1. Stop service:
 ```bash
 hub serving stop --port/-p XXXX
 ```
-- 2. Modify the code in the@ deploy/hubserving/readme_en.md corresponding files, like `module.py` and `params.py`, according to the actual needs.
-For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`. Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation. It is suggested to run `module.py` directly for debugging after modification before starting the service test.
-**Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.
-- 3. Uninstall old service module
-```bash
-hub uninstall ocr_system
-```
-- 4. Install modified service module
-```bash
-hub install deploy/hubserving/ocr_system/
-```
-- 5. Restart service
-```bash
-hub serving start -m ocr_system
-```
+2. Modify the code in the corresponding files under `deploy/hubserving/ocr_system`, such as `module.py` and `params.py`, to your actual needs.
+
+   For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`.
+   
+   Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation.
+   
+   **It is suggested to run `module.py` directly for debugging after modification before starting the service test.**
+
+   **Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.
+3. (Optional) If you want to rename the module, following lines should be modified:
+   - [`ocr_system` within `from deploy.hubserving.ocr_system.params import read_params`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L35)
+   - [`ocr_system` within `name="ocr_system",`](https://github.com/PaddlePaddle/PaddleOCR/blob/a923f35de57b5e378f8dd16e54d0a3e4f51267fd/deploy/hubserving/ocr_system/module.py#L39)
+4. (Optional) It may requires you to delete the directory `__pycache__` to force flush CPython build cache:
+   ```bash
+   find deploy/hubserving/ocr_system -name '__pycache__' -exec rm -r {} \;
+   ```
+5. Install modified service module:
+   ```bash
+   hub install deploy/hubserving/ocr_system/
+   ```
+6. Restart service:
+   ```bash
+   hub serving start -m ocr_system
+   ```

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -54,7 +54,7 @@ deploy/hubserving/ocr_system/
 The following steps take the 2-stage series service as an example. If only the detection service or recognition service is needed, replace the corresponding file path.
 
 ### 2.1 Prepare the environment
-```shell
+```bash
 # Install paddlehub
 # python>3.6.2 is required bt paddlehub
 pip3 install paddlehub==2.1.0 --upgrade -i https://pypi.tuna.tsinghua.edu.cn/simple
@@ -78,7 +78,7 @@ KIE(SER+RE): ./inference/re_vi_layoutxlm_xfund_infer/
 PaddleOCR provides 5 kinds of service modules, install the required modules according to your needs.
 
 * On Linux platform, the examples are as follows.
-```shell
+```bash
 # Install the text detection service module:
 hub install deploy/hubserving/ocr_det/
 
@@ -105,7 +105,7 @@ hub install deploy/hubserving/kie_ser_re/
 ```
 
 * On Windows platform, the examples are as follows.
-```shell
+```bash
 # Install the detection service module:
 hub install deploy\hubserving\ocr_det\
 
@@ -138,7 +138,7 @@ hub install deploy\hubserving\kie_ser_re\
 #### 2.4.1 Start with command line parameters (CPU only)
 
 **start command：**
-```shell
+```bash
 $ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
                     --port XXXX \
                     --use_multiprocess \
@@ -154,7 +154,7 @@ $ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
 |--workers|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|
 
 For example, start the 2-stage series service:
-```shell
+```bash
 hub serving start -m ocr_system
 ```
 
@@ -162,7 +162,7 @@ This completes the deployment of a service API, using the default port number 88
 
 #### 2.4.2 Start with configuration file（CPU、GPU）
 **start command：**
-```shell
+```bash
 hub serving start --config/-c config.json
 ```
 Wherein, the format of `config.json` is as follows:
@@ -192,14 +192,14 @@ Wherein, the format of `config.json` is as follows:
 - **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**
 
 For example, use GPU card No. 3 to start the 2-stage series service:
-```shell
+```bash
 export CUDA_VISIBLE_DEVICES=3
 hub serving start -c deploy/hubserving/ocr_system/config.json
 ```
 
 ## 3. Send prediction requests
 After the service starts, you can use the following command to send a prediction request to obtain the prediction result:
-```shell
+```bash
 python tools/test_hubserving.py --server_url=server_url --image_dir=image_path
 ```
 
@@ -222,7 +222,7 @@ For example, if using the configuration file to start the text angle classificat
 - **output**：The floder to save Visualization result, default value is `./hubserving_result`
 
 **Eg.**
-```shell
+```bash
 python tools/test_hubserving.py --server_url=http://127.0.0.1:8868/predict/ocr_system --image_dir=./doc/imgs/ --visualize=false`
 ```
 
@@ -259,21 +259,21 @@ The fields returned by different modules are different. For example, the results
 If you need to modify the service logic, the following steps are generally required (take the modification of `ocr_system` for example):
 
 - 1. Stop service
-```shell
+```bash
 hub serving stop --port/-p XXXX
 ```
-- 2. Modify the code in the corresponding files, like `module.py` and `params.py`, according to the actual needs.
+- 2. Modify the code in the@ deploy/hubserving/readme_en.md corresponding files, like `module.py` and `params.py`, according to the actual needs.
 For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`. Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation. It is suggested to run `module.py` directly for debugging after modification before starting the service test.
 **Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.
 - 3. Uninstall old service module
-```shell
+```bash
 hub uninstall ocr_system
 ```
 - 4. Install modified service module
-```shell
+```bash
 hub install deploy/hubserving/ocr_system/
 ```
 - 5. Restart service
-```shell
+```bash
 hub serving start -m ocr_system
 ```

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -206,7 +206,7 @@ The fields returned by different modules are different. For example, the results
 |---                    |---     |---     |---     |---        |---             |---              |---              |---     |---    |
 |angle                  |        |✔       |        |✔          |                |                 |                 |
 |text                   |        |        |✔       |✔          |                |✔                |                 |✔       |✔      |
-|confidence             |        |✔       |✔       |           |                |✔                |                 |✔       |✔      |
+|confidence             |        |✔       |✔       |✔          |                |✔                |                 |✔       |✔      |
 |text_region            |✔       |        |        |✔          |                |✔                |                 |✔       |✔      |
 |html                   |        |        |        |           |✔               |✔                |                 |        |       |
 |regions                |        |        |        |           |✔               |✔                |                 |        |       |

--- a/deploy/hubserving/readme_en.md
+++ b/deploy/hubserving/readme_en.md
@@ -18,9 +18,9 @@ PaddleOCR provides 2 service deployment methods:
 - Based on **PaddleHub Serving**: Code path is "`./deploy/hubserving`". Please follow this tutorial.
 - Based on **PaddleServing**: Code path is "`./deploy/pdserving`". Please refer to the [tutorial](../../deploy/pdserving/README.md) for usage.
 
-# Service deployment based on PaddleHub Serving  
+# Service deployment based on PaddleHub Serving
 
-The hubserving service deployment directory includes seven service packages: text detection, text angle class, text recognition, text detection+text angle class+text recognition three-stage series connection, layout analysis, table recognition and PP-Structure. Please select the corresponding service package to install and start service according to your needs. The directory is as follows:  
+The hubserving service deployment directory includes seven service packages: text detection, text angle class, text recognition, text detection+text angle class+text recognition three-stage series connection, layout analysis, table recognition and PP-Structure. Please select the corresponding service package to install and start service according to your needs. The directory is as follows:
 ```
 deploy/hubserving/
   └─  ocr_det     text detection module service package
@@ -34,7 +34,7 @@ deploy/hubserving/
   └─  kie_ser_re  KIE(SER+RE) service package
 ```
 
-Each service pack contains 3 files. Take the 2-stage series connection service package as an example, the directory is as follows:  
+Each service pack contains 3 files. Take the 2-stage series connection service package as an example, the directory is as follows:
 ```
 deploy/hubserving/ocr_system/
   └─  __init__.py    Empty file, required
@@ -55,13 +55,13 @@ The following steps take the 2-stage series service as an example. If only the d
 
 ### 2.1 Prepare the environment
 ```shell
-# Install paddlehub  
+# Install paddlehub
 # python>3.6.2 is required bt paddlehub
 pip3 install paddlehub==2.1.0 --upgrade -i https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ### 2.2 Download inference model
-Before installing the service module, you need to prepare the inference model and put it in the correct path. By default, the PP-OCRv3 models are used, and the default model path is:  
+Before installing the service module, you need to prepare the inference model and put it in the correct path. By default, the PP-OCRv3 models are used, and the default model path is:
 ```
 text detection model: ./inference/ch_PP-OCRv3_det_infer/
 text recognition model: ./inference/ch_PP-OCRv3_rec_infer/
@@ -70,7 +70,7 @@ layout parse model: ./inference/picodet_lcnet_x1_0_fgd_layout_infer/
 tanle recognition: ./inference/ch_ppstructure_mobile_v2.0_SLANet_infer/
 KIE(SER): ./inference/ser_vi_layoutxlm_xfund_infer/
 KIE(SER+RE): ./inference/re_vi_layoutxlm_xfund_infer/
-```  
+```
 
 **The model path can be found and modified in `params.py`.** More models provided by PaddleOCR can be obtained from the [model library](../../doc/doc_en/models_list_en.md). You can also use models trained by yourself.
 
@@ -137,34 +137,34 @@ hub install deploy\hubserving\kie_ser_re\
 ### 2.4 Start service
 #### 2.4.1 Start with command line parameters (CPU only)
 
-**start command：**  
+**start command：**
 ```shell
 $ hub serving start --modules [Module1==Version1, Module2==Version2, ...] \
                     --port XXXX \
                     --use_multiprocess \
                     --workers \
-```  
-**parameters：**  
+```
+**parameters：**
 
-|parameters|usage|  
-|---|---|  
+|parameters|usage|
+|---|---|
 |--modules/-m|PaddleHub Serving pre-installed model, listed in the form of multiple Module==Version key-value pairs<br>*`When Version is not specified, the latest version is selected by default`*|
-|--port/-p|Service port, default is 8866|  
+|--port/-p|Service port, default is 8866|
 |--use_multiprocess|Enable concurrent mode, the default is single-process mode, this mode is recommended for multi-core CPU machines<br>*`Windows operating system only supports single-process mode`*|
-|--workers|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|  
+|--workers|The number of concurrent tasks specified in concurrent mode, the default is `2*cpu_count-1`, where `cpu_count` is the number of CPU cores|
 
-For example, start the 2-stage series service:  
+For example, start the 2-stage series service:
 ```shell
 hub serving start -m ocr_system
-```  
+```
 
-This completes the deployment of a service API, using the default port number 8866.  
+This completes the deployment of a service API, using the default port number 8866.
 
 #### 2.4.2 Start with configuration file（CPU、GPU）
-**start command：**  
+**start command：**
 ```shell
 hub serving start --config/-c config.json
-```  
+```
 Wherein, the format of `config.json` is as follows:
 ```python
 {
@@ -186,36 +186,36 @@ Wherein, the format of `config.json` is as follows:
 - The configurable parameters in `init_args` are consistent with the `_initialize` function interface in `module.py`. Among them, **when `use_gpu` is `true`, it means that the GPU is used to start the service**.
 - The configurable parameters in `predict_args` are consistent with the `predict` function interface in `module.py`.
 
-**Note:**  
+**Note:**
 - When using the configuration file to start the service, other parameters will be ignored.
 - If you use GPU prediction (that is, `use_gpu` is set to `true`), you need to set the environment variable CUDA_VISIBLE_DEVICES before starting the service, such as: ```export CUDA_VISIBLE_DEVICES=0```, otherwise you do not need to set it.
-- **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**  
+- **`use_gpu` and `use_multiprocess` cannot be `true` at the same time.**
 
 For example, use GPU card No. 3 to start the 2-stage series service:
 ```shell
 export CUDA_VISIBLE_DEVICES=3
 hub serving start -c deploy/hubserving/ocr_system/config.json
-```  
+```
 
 ## 3. Send prediction requests
-After the service starts, you can use the following command to send a prediction request to obtain the prediction result:  
+After the service starts, you can use the following command to send a prediction request to obtain the prediction result:
 ```shell
 python tools/test_hubserving.py --server_url=server_url --image_dir=image_path
-```  
+```
 
 Two parameters need to be passed to the script:
 - **server_url**：service address，format of which is
-`http://[ip_address]:[port]/predict/[module_name]`  
+`http://[ip_address]:[port]/predict/[module_name]`
 For example, if using the configuration file to start the text angle classification, text detection, text recognition, detection+classification+recognition 3 stages, table recognition and PP-Structure service, then the `server_url` to send the request will be:
 
-`http://127.0.0.1:8865/predict/ocr_det`  
-`http://127.0.0.1:8866/predict/ocr_cls`  
-`http://127.0.0.1:8867/predict/ocr_rec`  
-`http://127.0.0.1:8868/predict/ocr_system`  
-`http://127.0.0.1:8869/predict/structure_table`  
-`http://127.0.0.1:8870/predict/structure_system`  
-`http://127.0.0.1:8870/predict/structure_layout`  
-`http://127.0.0.1:8871/predict/kie_ser`  
+`http://127.0.0.1:8865/predict/ocr_det`
+`http://127.0.0.1:8866/predict/ocr_cls`
+`http://127.0.0.1:8867/predict/ocr_rec`
+`http://127.0.0.1:8868/predict/ocr_system`
+`http://127.0.0.1:8869/predict/structure_table`
+`http://127.0.0.1:8870/predict/structure_system`
+`http://127.0.0.1:8870/predict/structure_layout`
+`http://127.0.0.1:8871/predict/kie_ser`
 `http://127.0.0.1:8872/predict/kie_ser_re`
 - **image_dir**：Test image path, can be a single image path or an image directory path
 - **visualize**：Whether to visualize the results, the default value is False
@@ -262,8 +262,8 @@ If you need to modify the service logic, the following steps are generally requi
 ```shell
 hub serving stop --port/-p XXXX
 ```
-- 2. Modify the code in the corresponding files, like `module.py` and `params.py`, according to the actual needs.  
-For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`. Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation. It is suggested to run `module.py` directly for debugging after modification before starting the service test.  
+- 2. Modify the code in the corresponding files, like `module.py` and `params.py`, according to the actual needs.
+For example, if you need to replace the model used by the deployed service, you need to modify model path parameters `det_model_dir` and `rec_model_dir` in `params.py`. If you want to turn off the text direction classifier, set the parameter `use_angle_cls` to `False`. Of course, other related parameters may need to be modified at the same time. Please modify and debug according to the actual situation. It is suggested to run `module.py` directly for debugging after modification before starting the service test.
 **Note** The image input shape used by the PPOCR-v3 recognition model is `3, 48, 320`, so you need to modify `cfg.rec_image_shape = "3, 48, 320"` in `params.py`, if you do not use the PPOCR-v3 recognition model, then there is no need to modify this parameter.
 - 3. Uninstall old service module
 ```shell

--- a/deploy/pdserving/README_CN.md
+++ b/deploy/pdserving/README_CN.md
@@ -106,13 +106,13 @@ python3 -m paddle_serving_client.convert --dirname ./ch_PP-OCRv3_rec_infer/ \
 检测模型转换完成后，会在当前文件夹多出`ppocr_det_v3_serving` 和`ppocr_det_v3_client`的文件夹，具备如下格式：
 ```
 |- ppocr_det_v3_serving/
-  |- __model__  
+  |- __model__
   |- __params__
-  |- serving_server_conf.prototxt  
+  |- serving_server_conf.prototxt
   |- serving_server_conf.stream.prototxt
 
 |- ppocr_det_v3_client
-  |- serving_client_conf.prototxt  
+  |- serving_client_conf.prototxt
   |- serving_client_conf.stream.prototxt
 
 ```
@@ -232,6 +232,7 @@ cp -rf general_detection_op.cpp Serving/core/general-server/op
     # 启动服务，运行日志保存在log.txt
     python3 -m paddle_serving_server.serve --model ppocr_det_v3_serving ppocr_rec_v3_serving --op GeneralDetectionOp GeneralInferOp --port 8181 &>log.txt &
     ```
+
     成功启动服务后，log.txt中会打印类似如下日志
     ![](./imgs/start_server.png)
 

--- a/doc/doc_ch/models_list.md
+++ b/doc/doc_ch/models_list.md
@@ -101,6 +101,7 @@ PaddleOCR提供的可下载模型包括`推理模型`、`训练模型`、`预训
 |en_number_mobile_slim_v2.0_rec|slim裁剪量化版超轻量模型，支持英文、数字识别|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)| 2.7M | [推理模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_infer.tar) / [训练模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_train.tar) |
 |en_number_mobile_v2.0_rec|原始超轻量模型，支持英文、数字识别|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)|2.6M|[推理模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_infer.tar) / [训练模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_train.tar) |
 
+**注意：** 所有英文识别模型的字典文件均为`ppocr/utils/en_dict.txt`
 
 <a name="多语言识别模型"></a>
 ### 2.3 多语言识别模型（更多语言持续更新中...）
@@ -146,3 +147,4 @@ Paddle-Lite 是一个高性能、轻量级、灵活性强且易于扩展的深�
 |PP-OCRv2(slim)|蒸馏版超轻量中文OCR移动端模型|4.9M|[下载地址](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_det_slim_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_cls_slim_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_slim_opt.nb)|v2.9|
 |V2.0|ppocr_v2.0超轻量中文OCR移动端模型|7.8M|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_det_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_cls_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_rec_opt.nb)|v2.9|
 |V2.0(slim)|ppocr_v2.0超轻量中文OCR移动端模型|3.3M|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_det_slim_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_cls_slim_opt.nb)|[下载地址](https://paddleocr.bj.bcebos.com/dygraph_v2.0/lite/ch_ppocr_mobile_v2.0_rec_slim_opt.nb)|v2.9|
+

--- a/doc/doc_en/models_list_en.md
+++ b/doc/doc_en/models_list_en.md
@@ -1,8 +1,8 @@
 # OCR Model List（V3, updated on 2022.4.28）
 > **Note**
-> 1. Compared with the model v2, the 3rd version of the detection model has a improvement in accuracy, and the 2.1 version of the recognition model has optimizations in accuracy and speed with CPU.
+> 1. Compared with model v2, the 3rd version of the detection model has an improvement in accuracy, and the 2.1 version of the recognition model has optimizations in accuracy and speed with CPU.
 > 2. Compared with [models 1.1](https://github.com/PaddlePaddle/PaddleOCR/blob/develop/doc/doc_en/models_list_en.md), which are trained with static graph programming paradigm, models 2.0 or higher are the dynamic graph trained version and achieve close performance.
-> 3. All models in this tutorial are all ppocr-series models, for more introduction of algorithms and models based on public dataset, you can refer to [algorithm overview tutorial](./algorithm_overview_en.md).
+> 3. All models in this tutorial are from the PaddleOCR series, for more introduction to algorithms and models based on the public dataset, you can refer to [algorithm overview tutorial](./algorithm_overview_en.md).
 
 - [OCR Model List（V3, updated on 2022.4.28）]()
   - [1. Text Detection Model](#1-text-detection-model)
@@ -16,15 +16,15 @@
   - [3. Text Angle Classification Model](#3-text-angle-classification-model)
   - [4. Paddle-Lite Model](#4-paddle-lite-model)
 
-The downloadable models provided by PaddleOCR include `inference model`, `trained model`, `pre-trained model` and `nb model`. The differences between the models are as follows:
+The downloadable models provided by PaddleOCR include the `inference model`, `trained model`, `pre-trained model` and `nb model`. The differences between the models are as follows:
 
 |model type|model format|description|
 |--- | --- | --- |
 |inference model|inference.pdmodel、inference.pdiparams|Used for inference based on Paddle inference engine，[detail](./inference_ppocr_en.md)|
-|trained model, pre-trained model|\*.pdparams、\*.pdopt、\*.states |The checkpoints model saved in the training process, which stores the parameters of the model, mostly used for model evaluation and continuous training.|
+|trained model, pre-trained model|\*.pdparams、\*.pdopt、\*.states |The checkpoints model saved in the training process, which stores the parameters of the model, is mostly used for model evaluation and continuous training.|
 |nb model|\*.nb| Model optimized by Paddle-Lite, which is suitable for mobile-side deployment scenarios (Paddle-Lite is needed for nb model deployment). |
 
-Relationship of the above models is as follows.
+The relationship of the above models is as follows.
 
 ![](../imgs_en/model_prod_flow_en.png)
 
@@ -51,10 +51,10 @@ Relationship of the above models is as follows.
 
 |model name|description|config|model size|download|
 | --- | --- | --- | --- | --- |
-|en_PP-OCRv3_det_slim | [New] Slim qunatization with distillation lightweight detection model, supporting English | [ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml) | 1.1M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_distill_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_infer.nb) |
+|en_PP-OCRv3_det_slim | [New] Slim quantization with distillation lightweight detection model, supporting English | [ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml) | 1.1M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_distill_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_slim_infer.nb) |
 |en_PP-OCRv3_det | [New] Original lightweight detection model, supporting English |[ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml)| 3.8M | [inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_det_distill_train.tar) |
 
-* Note: English configuration file is same as Chinese except training data, here we only provide one configuration file.
+* Note: English configuration file is the same as Chinese except for training data, here we only provide one configuration file.
 
 <a name="1.3"></a>
 
@@ -62,10 +62,10 @@ Relationship of the above models is as follows.
 
 |model name|description|config|model size|download|
 | --- | --- | --- | --- | --- |
-| ml_PP-OCRv3_det_slim | [New] Slim qunatization with distillation lightweight detection model, supporting English | [ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml) | 1.1M | [inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_infer.tar) / [trained model ](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_distill_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_infer.nb) |
+| ml_PP-OCRv3_det_slim | [New] Slim quantization with distillation lightweight detection model, supporting English | [ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml) | 1.1M | [inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_infer.tar) / [trained model ](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_distill_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_slim_infer.nb) |
 | ml_PP-OCRv3_det |[New] Original lightweight detection model, supporting English | [ch_PP-OCRv3_det_cml.yml](../../configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml)| 3.8M | [inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/Multilingual_PP-OCRv3_det_distill_train.tar) |
 
-* Note: English configuration file is same as Chinese except training data, here we only provide one configuration file.
+* Note: English configuration file is the same as Chinese except for training data, here we only provide one configuration file.
 
 <a name="Recognition"></a>
 ## 2. Text Recognition Model
@@ -75,28 +75,28 @@ Relationship of the above models is as follows.
 
 |model name|description|config|model size|download|
 | --- | --- | --- | --- | --- |
-|ch_PP-OCRv3_rec_slim | [New] Slim qunatization with distillation lightweight model, supporting Chinese, English text recognition |[ch_PP-OCRv3_rec_distillation.yml](../../configs/rec/PP-OCRv3/ch_PP-OCRv3_rec_distillation.yml)| 4.9M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_infer.nb) |
+|ch_PP-OCRv3_rec_slim | [New] Slim quantization with distillation lightweight model, supporting Chinese, English text recognition |[ch_PP-OCRv3_rec_distillation.yml](../../configs/rec/PP-OCRv3/ch_PP-OCRv3_rec_distillation.yml)| 4.9M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_slim_infer.nb) |
 |ch_PP-OCRv3_rec| [New] Original lightweight model, supporting Chinese, English, multilingual text recognition |[ch_PP-OCRv3_rec_distillation.yml](../../configs/rec/PP-OCRv3/ch_PP-OCRv3_rec_distillation.yml)| 12.4M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/chinese/ch_PP-OCRv3_rec_train.tar) |
-|ch_PP-OCRv2_rec_slim| Slim qunatization with distillation lightweight model, supporting Chinese, English text recognition|[ch_PP-OCRv2_rec.yml](../../configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml)| 9.0M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_slim_quant_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_slim_quant_train.tar) |
-|ch_PP-OCRv2_rec| Original lightweight model, supporting Chinese, English, multilingual text recognition |[ch_PP-OCRv2_rec_distillation.yml](../../configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec_distillation.yml)|8.5M|[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_train.tar) |
+|ch_PP-OCRv2_rec_slim| Slim quantization with distillation lightweight model, supporting Chinese, English text recognition|[ch_PP-OCRv2_rec.yml](../../configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec.yml)| 9.0M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_slim_quant_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_slim_quant_train.tar) |
+|ch_PP-OCRv2_rec| Original lightweight model, supporting Chinese, English, and multilingual text recognition |[ch_PP-OCRv2_rec_distillation.yml](../../configs/rec/ch_PP-OCRv2/ch_PP-OCRv2_rec_distillation.yml)|8.5M|[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv2/chinese/ch_PP-OCRv2_rec_train.tar) |
 |ch_ppocr_mobile_slim_v2.0_rec|Slim pruned and quantized lightweight model, supporting Chinese, English and number recognition|[rec_chinese_lite_train_v2.0.yml](../../configs/rec/ch_ppocr_v2.0/rec_chinese_lite_train_v2.0.yml)| 6.0M | [inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_slim_train.tar) |
 |ch_ppocr_mobile_v2.0_rec|Original lightweight model, supporting Chinese, English and number recognition|[rec_chinese_lite_train_v2.0.yml](../../configs/rec/ch_ppocr_v2.0/rec_chinese_lite_train_v2.0.yml)|5.2M|[inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_train.tar) / [pre-trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_pre.tar) |
 |ch_ppocr_server_v2.0_rec|General model, supporting Chinese, English and number recognition|[rec_chinese_common_train_v2.0.yml](../../configs/rec/ch_ppocr_v2.0/rec_chinese_common_train_v2.0.yml)|94.8M|[inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_server_v2.0_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_server_v2.0_rec_train.tar) / [pre-trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_server_v2.0_rec_pre.tar) |
 
 
-**Note:** The `trained model` is fine-tuned on the `pre-trained model` with real data and synthesized vertical text data, which achieved better performance in real scene. The `pre-trained model` is directly trained on the full amount of real data and synthesized data, which is more suitable for fine-tune on your own dataset.
+**Note:** The `trained model` is fine-tuned on the `pre-trained model` with real data and synthesized vertical text data, which achieved better performance in the real scene. The `pre-trained model` is directly trained on the full amount of real data and synthesized data, which is more suitable for fine-tuning your dataset.
 
 <a name="English"></a>
 ### 2.2 English Recognition Model
 
 |model name|description|config|model size|download|
 | --- | --- | --- | --- | --- |
-|en_PP-OCRv3_rec_slim | [New] Slim qunatization with distillation lightweight model, supporting english, English text recognition |[en_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml)| 3.2M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_infer.nb) |
-|en_PP-OCRv3_rec| [New] Original lightweight model, supporting english, English, multilingual text recognition |[en_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml)| 9.6M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_train.tar) |
+|en_PP-OCRv3_rec_slim | [New] Slim quantization with distillation lightweight model, supporting English, English text recognition |[en_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml)| 3.2M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_train.tar) / [nb model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_slim_infer.nb) |
+|en_PP-OCRv3_rec| [New] Original lightweight model, supporting English, English, multilingual text recognition |[en_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml)| 9.6M |[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/english/en_PP-OCRv3_rec_train.tar) |
 |en_number_mobile_slim_v2.0_rec|Slim pruned and quantized lightweight model, supporting English and number recognition|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)| 2.7M | [inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_train.tar) |
 |en_number_mobile_v2.0_rec|Original lightweight model, supporting English and number recognition|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)|2.6M|[inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_train.tar) |
 
-**Note:** Dictionary file of all english recognition models is `ppocr/utils/en_dict.txt`.
+**Note:** Dictionary file of all English recognition models is `ppocr/utils/en_dict.txt`.
 
 <a name="Multilingual"></a>
 ### 2.3 Multilingual Recognition Model（Updating...）
@@ -114,7 +114,7 @@ Relationship of the above models is as follows.
 | cyrillic_PP-OCRv3_rec | ppocr/utils/dict/cyrillic_dict.txt | Lightweight model for cyrillic recognition  | [cyrillic_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/multi_language/cyrillic_PP-OCRv3_rec.yml) |9.6M|[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/cyrillic_PP-OCRv3_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/cyrillic_PP-OCRv3_rec_train.tar) |
 | devanagari_PP-OCRv3_rec | ppocr/utils/dict/devanagari_dict.txt | Lightweight model for devanagari recognition | [devanagari_PP-OCRv3_rec.yml](../../configs/rec/PP-OCRv3/multi_language/devanagari_PP-OCRv3_rec.yml) |9.9M|[inference model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/devanagari_PP-OCRv3_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/PP-OCRv3/multilingual/devanagari_PP-OCRv3_rec_train.tar) |
 
-For a complete list of languages ​​and tutorials, please refer to : [Multi-language model](./multi_languages_en.md)
+For a complete list of languages ​​and tutorials, please refer to [Multi-language model](./multi_languages_en.md)
 
 <a name="Angle"></a>
 ## 3. Text Angle Classification Model
@@ -127,9 +127,9 @@ For a complete list of languages ​​and tutorials, please refer to : [Multi-l
 <a name="Paddle-Lite"></a>
 ## 4. Paddle-Lite Model
 
-Paddle Lite is an updated version of Paddle-Mobile, an open-open source deep learning framework designed to make it easy to perform inference on mobile, embeded, and IoT devices. It can further optimize the inference model and generate `nb model` used for edge devices. It's suggested to optimize the quantization model using Paddle-Lite because `INT8` format is used for the model storage and inference.
+Paddle Lite is an updated version of Paddle-Mobile, an open-open source deep learning framework designed to make it easy to perform inference on mobile, embedded, and IoT devices. It can further optimize the inference model and generate the `nb model` used for edge devices. It's suggested to optimize the quantization model using Paddle-Lite because the `INT8` format is used for the model storage and inference.
 
-This chapter lists OCR nb models with PP-OCRv2 or earlier versions. You can access to the latest nb models from the above tables.
+This chapter lists OCR nb models with PP-OCRv2 or earlier versions. You can access the latest nb models from the above tables.
 
 |Version|Introduction|Model size|Detection model|Text Direction model|Recognition model|Paddle-Lite branch|
 |---|---|---|---|---|---|---|

--- a/doc/doc_en/models_list_en.md
+++ b/doc/doc_en/models_list_en.md
@@ -96,6 +96,8 @@ Relationship of the above models is as follows.
 |en_number_mobile_slim_v2.0_rec|Slim pruned and quantized lightweight model, supporting English and number recognition|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)| 2.7M | [inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/en/en_number_mobile_v2.0_rec_slim_train.tar) |
 |en_number_mobile_v2.0_rec|Original lightweight model, supporting English and number recognition|[rec_en_number_lite_train.yml](../../configs/rec/multi_language/rec_en_number_lite_train.yml)|2.6M|[inference model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_infer.tar) / [trained model](https://paddleocr.bj.bcebos.com/dygraph_v2.0/multilingual/en_number_mobile_v2.0_rec_train.tar) |
 
+**Note:** Dictionary file of all english recognition models is `ppocr/utils/en_dict.txt`.
+
 <a name="Multilingual"></a>
 ### 2.3 Multilingual Recognition Model（Updating...）
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     version=VERSION,
     install_requires=load_requirements(['requirements.txt', 'ppstructure/recovery/requirements.txt']),
     license='Apache License 2.0',
-    description='Awesome OCR toolkits based on PaddlePaddle （8.6M ultra-lightweight pre-trained model, support training and deployment among server, mobile, embeded and IoT devices',
+    description='Awesome OCR toolkits based on PaddlePaddle （8.6M ultra-lightweight pre-trained model, support training and deployment among server, mobile, embedded and IoT devices',
     long_description=readme(),
     long_description_content_type='text/markdown',
     url='https://github.com/PaddlePaddle/PaddleOCR',


### PR DESCRIPTION
## `deploy/hubserving/readme.md`
- 指出可能需要删除`__pycache__`后对`params.py`的更改才能通过`hub install`生效（不然只会安装`__pycache__`中的修改前版本）
- 提示如何重命名模块
- 以及其他大量markdown格式改进
## `doc/doc_ch/models_list.md`
- 指出所有英文识别模型的字典文件均为`ppocr/utils/en_dict.txt`而不是中文模型中的`ppocr/utils/ppocr_keys_v1.txt`