### PR TITLE
change num worker to 16 for better performance

### DIFF
--- a/test_tipc/configs/layoutxlm_ser/ser_layoutxlm_xfund_zh.yml
+++ b/test_tipc/configs/layoutxlm_ser/ser_layoutxlm_xfund_zh.yml
@@ -84,7 +84,7 @@ Train:
     shuffle: True
     drop_last: False
     batch_size_per_card: 8
-    num_workers: 4
+    num_workers: 16
 
 Eval:
   dataset:


### PR DESCRIPTION
# change num worker to 16 for better performance

- N1C1 num_worker = 16 can gain better performance
- N1C8 may still need debugging for better performance