### PR TITLE
change num worker to 16 for better

### DIFF
--- a/configs/kie/layoutlm_series/ser_layoutlm_xfund_zh.yml
+++ b/configs/kie/layoutlm_series/ser_layoutlm_xfund_zh.yml
@@ -83,7 +83,7 @@ Train:
     shuffle: True
     drop_last: False
     batch_size_per_card: 8
-    num_workers: 4
+    num_workers: 16
 
 Eval:
   dataset:

--- a/test_tipc/configs/layoutxlm_ser/ser_layoutxlm_xfund_zh.yml
+++ b/test_tipc/configs/layoutxlm_ser/ser_layoutxlm_xfund_zh.yml
@@ -84,7 +84,7 @@ Train:
     shuffle: True
     drop_last: False
     batch_size_per_card: 8
-    num_workers: 4
+    num_workers: 16
 
 Eval:
   dataset:


### PR DESCRIPTION
- N1C1 num_worker = 16 can gain better performance
- N1C8 may still need debugging for better performance
- The former PR https://github.com/PaddlePaddle/PaddleOCR/pull/9173 only adjust the tipc config