### PR TITLE
[Fix] errors due to updated PyMuPDF name conventions

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -90,14 +90,14 @@ def check_and_read(img_path):
         from PIL import Image
         imgs = []
         with fitz.open(img_path) as pdf:
-            for pg in range(0, pdf.pageCount):
+            for pg in range(0, pdf.page_count):
                 page = pdf[pg]
                 mat = fitz.Matrix(2, 2)
-                pm = page.getPixmap(matrix=mat, alpha=False)
+                pm = page.get_pixmap(matrix=mat, alpha=False)
 
                 # if width or height > 2000 pixels, don't enlarge the image
                 if pm.width > 2000 or pm.height > 2000:
-                    pm = page.getPixmap(matrix=fitz.Matrix(1, 1), alpha=False)
+                    pm = page.get_pixmap(matrix=fitz.Matrix(1, 1), alpha=False)
 
                 img = Image.frombytes("RGB", [pm.width, pm.height], pm.samples)
                 img = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)

--- a/ppstructure/pdf2word/pdf2word.py
+++ b/ppstructure/pdf2word/pdf2word.py
@@ -102,7 +102,7 @@ def readImage(image_file) -> list:
     if os.path.basename(image_file)[-3:] == 'pdf':
         imgs = []
         with fitz.open(image_file) as pdf:
-            for pg in range(0, pdf.pageCount):
+            for pg in range(0, pdf.page_count):
                 page = pdf[pg]
                 mat = fitz.Matrix(2, 2)
                 pm = page.getPixmap(matrix=mat, alpha=False)


### PR DESCRIPTION
This solves this issue: #9046 
