### PR TITLE
声明的 PyMuPDF<1.21.0 版本兼容问题

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -90,7 +90,7 @@ def check_and_read(img_path):
         from PIL import Image
         imgs = []
         with fitz.open(img_path) as pdf:
-            for pg in range(0, pdf.pageCount):
+            for pg in range(0, pdf.page_count):
                 page = pdf[pg]
                 mat = fitz.Matrix(2, 2)
                 pm = page.getPixmap(matrix=mat, alpha=False)

--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -93,7 +93,7 @@ def check_and_read(img_path):
             for pg in range(0, pdf.page_count):
                 page = pdf[pg]
                 mat = fitz.Matrix(2, 2)
-                pm = page.getPixmap(matrix=mat, alpha=False)
+                pm = page.get_pixmap(matrix=mat, alpha=False)
 
                 # if width or height > 2000 pixels, don't enlarge the image
                 if pm.width > 2000 or pm.height > 2000:


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.6/requirements.txt

官方声明的依赖项： PyMuPDF<1.21.0 ，但是PyMuPDF在 1.20以上pageCount已经改为 page_count。