### PR TITLE
Fix exception when make_border_map

### DIFF
--- a/ppocr/data/imaug/make_border_map.py
+++ b/ppocr/data/imaug/make_border_map.py
@@ -78,7 +78,10 @@ class MakeBorderMap(object):
         padding = pyclipper.PyclipperOffset()
         padding.AddPath(subject, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
 
-        padded_polygon = np.array(padding.Execute(distance)[0])
+        try:
+            padded_polygon = np.array(padding.Execute(distance)[0])
+        except:
+            return
         cv2.fillPoly(mask, [padded_polygon.astype(np.int32)], 1.0)
 
         xmin = padded_polygon[:, 0].min()


### PR DESCRIPTION
Fix the exception "IndexError: list index out of range"  that can happen during training detection model

Reference:
https://github.com/WenmuZhou/PytorchOCR/commit/85acb9e4571b9af4de59774ffd6f2a90b9231828
https://github.com/PaddlePaddle/PaddleOCR/pull/8744