### PR TITLE
Fix numpy.bool deprecation problem

### DIFF
--- a/ppocr/data/imaug/label_ops.py
+++ b/ppocr/data/imaug/label_ops.py
@@ -64,7 +64,7 @@ class DetLabelEncode(object):
             return None
         boxes = self.expand_points_num(boxes)
         boxes = np.array(boxes, dtype=np.float32)
-        txt_tags = np.array(txt_tags, dtype=np.bool)
+        txt_tags = np.array(txt_tags, dtype=bool)
 
         data['polys'] = boxes
         data['texts'] = txts
@@ -218,7 +218,7 @@ class E2ELabelEncodeTest(BaseRecLabelEncode):
             else:
                 txt_tags.append(False)
         boxes = np.array(boxes, dtype=np.float32)
-        txt_tags = np.array(txt_tags, dtype=np.bool)
+        txt_tags = np.array(txt_tags, dtype=bool)
         data['polys'] = boxes
         data['ignore_tags'] = txt_tags
         temp_texts = []
@@ -254,7 +254,7 @@ class E2ELabelEncodeTrain(object):
             else:
                 txt_tags.append(False)
         boxes = np.array(boxes, dtype=np.float32)
-        txt_tags = np.array(txt_tags, dtype=np.bool)
+        txt_tags = np.array(txt_tags, dtype=bool)
 
         data['polys'] = boxes
         data['texts'] = txts


### PR DESCRIPTION
Change `np.bool` to `bool` since `np.bool` was originally deprecated in NumPy 1.20.