### PR TITLE
在 Loss 配置中增加 out_channel， 方便自定义数据训练

### DIFF
--- a/configs/rec/rec_d28_can.yml
+++ b/configs/rec/rec_d28_can.yml
@@ -63,6 +63,7 @@ Architecture:
    
 Loss:
   name: CANLoss
+  out_channel: 111
 
 PostProcess:
   name: CANLabelDecode

--- a/ppocr/losses/rec_can_loss.py
+++ b/ppocr/losses/rec_can_loss.py
@@ -28,7 +28,7 @@ class CANLoss(nn.Layer):
         counting_loss: counting loss of every symbol
     '''
 
-    def __init__(self, out_channel):
+    def __init__(self, out_channel=111):
         super(CANLoss, self).__init__()
 
         self.use_label_mask = False

--- a/ppocr/losses/rec_can_loss.py
+++ b/ppocr/losses/rec_can_loss.py
@@ -28,11 +28,11 @@ class CANLoss(nn.Layer):
         counting_loss: counting loss of every symbol
     '''
 
-    def __init__(self):
+    def __init__(self, out_channel):
         super(CANLoss, self).__init__()
 
         self.use_label_mask = False
-        self.out_channel = 111
+        self.out_channel = out_channel
         self.cross = nn.CrossEntropyLoss(
             reduction='none') if self.use_label_mask else nn.CrossEntropyLoss()
         self.counting_loss = nn.SmoothL1Loss(reduction='mean')


### PR DESCRIPTION
在 公式识别[CAN](https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.6/doc/doc_ch/algorithm_rec_can.md) 中
发现自定义数据集训练的时候，当词表数量变化、修改对应 Architecture 下的 out_channel、word_num、counting_decoder_out_channel 会导致维度不匹配，查看源码发现 Loss 中的 out_channel 的写死的

在 CAN 算法的配置文件 Loss 下增加  out_channel 字段，同时修改 Loss 代码使用配置信息