### PR TITLE
Fixing emptystring when appending `paddleocr.py` directory  to PYTHONPATH

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -16,7 +16,7 @@ import os
 import sys
 import importlib
 
-__dir__ = os.path.dirname(__file__)
+__dir__ = os.path.dirname(os.path.abspath(__file__))
 
 import paddle
 


### PR DESCRIPTION
## Problem
I was trying to use paddleocr within my bazel monorepository. As bazel working directory is different than directory of `__file__` I was experiencing error same as in #1024. No `tools.infer` module was found. I noticed that `os.path.dirname(__file__)` returns empty string when `paddleocr.py` is executed  from parent directory. I believe the intention was to extend `PYTHONPATH` with absolute path of `paddleocr.py` directory.

## Fix 
Modify `__dir__` variable to be absolute path, not relative one. 
This will help to address issue #1024 as no real fix was applied so far. 