### PR TITLE
bug fix for PPOCRLabel.exportJSON NameError: name 'null' is not defined

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2469,6 +2469,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
+                        label = label.replace('null', 'Null')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2469,7 +2469,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
-                        label = label.replace('null', 'Null')
+                        label = label.replace('null', 'None')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []

--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2615,6 +2615,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
+                        label = label.replace('null', 'None')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []


### PR DESCRIPTION
解决识别文本概率出现null导致导出表格标注时闪退的问题
![223900129-8d80b9d9-2d82-4f1d-84b9-795f66600fc7](https://user-images.githubusercontent.com/65639657/231083799-d1ab3e8e-671f-4e49-b6cf-367e137d5c4d.png)
