### PR TITLE
fix imagePath join error in non Windows

### DIFF
--- a/PPOCRLabel/gen_ocr_train_val_test.py
+++ b/PPOCRLabel/gen_ocr_train_val_test.py
@@ -39,7 +39,7 @@ def splitTrainVal(root, absTrainRootPath, absValRootPath, absTestRootPath, train
         if flag == "det":
             imagePath = os.path.join(dataAbsPath, imageName)
         elif flag == "rec":
-            imagePath = os.path.join(dataAbsPath, "{}\\{}".format(args.recImageDirName, imageName))
+            imagePath = os.path.join(dataAbsPath, args.recImageDirName, imageName)
 
         # 按预设的比例划分训练集、验证集、测试集
         trainValTestRatio = args.trainValTestRatio.split(":")


### PR DESCRIPTION
linux/mac 下`imagePath`拼接路径分隔符问题导致文件不存在