### PR TITLE
修复动态图O2模型修改为promote策略后引起的性能下降问题

### DIFF
--- a/configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yml
+++ b/configs/kie/vi_layoutxlm/ser_vi_layoutxlm_xfund_zh.yml
@@ -21,6 +21,7 @@ Global:
   save_res_path: ./output/ser/xfund_zh/res
   kie_rec_model_dir: 
   kie_det_model_dir:
+  amp_custom_white_list: ['scale', 'concat', 'elementwise_add']
 
 Architecture:
   model_type: kie

--- a/configs/table/SLANet.yml
+++ b/configs/table/SLANet.yml
@@ -22,6 +22,7 @@ Global:
   use_sync_bn: True
   save_res_path: 'output/infer'
   d2s_train_image_shape: [3, -1, -1]
+  amp_custom_white_list: ['concat', 'elementwise_sub', 'set_value']
 
 Optimizer:
   name: Adam

--- a/test_tipc/configs/slanet/SLANet.yml
+++ b/test_tipc/configs/slanet/SLANet.yml
@@ -22,6 +22,7 @@ Global:
   use_sync_bn: True
   save_res_path: 'output/infer'
   d2s_train_image_shape: [3, -1, -1]
+  amp_custom_white_list: ['concat', 'elementwise_sub', 'set_value']
 
 Optimizer:
   name: Adam

--- a/tools/program.py
+++ b/tools/program.py
@@ -188,7 +188,8 @@ def train(config,
           log_writer=None,
           scaler=None,
           amp_level='O2',
-          amp_custom_black_list=[]):
+          amp_custom_black_list=[],
+          amp_custom_white_list=[]):
     cal_metric_during_train = config['Global'].get('cal_metric_during_train',
                                                    False)
     calc_epoch_interval = config['Global'].get('calc_epoch_interval', 1)
@@ -277,7 +278,8 @@ def train(config,
             if scaler:
                 with paddle.amp.auto_cast(
                         level=amp_level,
-                        custom_black_list=amp_custom_black_list):
+                        custom_black_list=amp_custom_black_list,
+                        custom_white_list=amp_custom_white_list):
                     if model_type == 'table' or extra_input:
                         preds = model(images, data=batch[1:])
                     elif model_type in ["kie"]:

--- a/tools/train.py
+++ b/tools/train.py
@@ -148,6 +148,7 @@ def main(config, device, logger, vdl_writer):
     use_amp = config["Global"].get("use_amp", False)
     amp_level = config["Global"].get("amp_level", 'O2')
     amp_custom_black_list = config['Global'].get('amp_custom_black_list', [])
+    amp_custom_white_list = config['Global'].get('amp_custom_white_list', [])
     if use_amp:
         AMP_RELATED_FLAGS_SETTING = {'FLAGS_max_inplace_grad_add': 8, }
         if paddle.is_compiled_with_cuda():
@@ -181,7 +182,7 @@ def main(config, device, logger, vdl_writer):
     program.train(config, train_dataloader, valid_dataloader, device, model,
                   loss_class, optimizer, lr_scheduler, post_process_class,
                   eval_class, pre_best_model_dict, logger, vdl_writer, scaler,
-                  amp_level, amp_custom_black_list)
+                  amp_level, amp_custom_black_list, amp_custom_white_list)
 
 
 def test_reader(config, device, logger):


### PR DESCRIPTION
O2下因改为promote策略，会有一些算子原来使用fp16计算，在策略更新后选择了fp32计算，导致性能下降。

通过加入自定义白名单，模型算子运行的数量和类型和AMP升级前可达到一致，同时恢复到原始性能