### PR TITLE
fixbug: change DetOp.postprocess's result from string(ndarray) to string(list)

### DIFF
--- a/deploy/pdserving/web_service_det.py
+++ b/deploy/pdserving/web_service_det.py
@@ -61,8 +61,8 @@ class DetOp(Op):
         ]
         dt_boxes_list = self.post_func(det_out, [ratio_list])
         dt_boxes = self.filter_func(dt_boxes_list[0], [self.ori_h, self.ori_w])
-        out_dict = {"dt_boxes": str(dt_boxes)}
-
+        # convert ndarray to string may cause problem, so change to list
+        out_dict = {"dt_boxes": str(dt_boxes.tolist())}
         return out_dict, None, ""
 
 


### PR DESCRIPTION
![image](https://github.com/PaddlePaddle/PaddleOCR/assets/58394908/d7d1ac88-a6d6-45b7-96d4-66dce80eb888)
In web_service_det.py, DetOp.postprocess function, I find dt_boxes is a ndarray and it is converted to string, but the string representation 'str(a)' of a numpy array "a" is not sufficient to exactly restore the original array, particularly for arrays with many elements. This is because the string representation may truncate large arrays for brevity. So I change it to a list converted to string.