### PR TITLE
bug fix : gen rec labels split line

### DIFF
--- a/ppocr/utils/gen_label.py
+++ b/ppocr/utils/gen_label.py
@@ -20,8 +20,10 @@ def gen_rec_label(input_path, out_label):
     with open(out_label, 'w') as out_file:
         with open(input_path, 'r') as f:
             for line in f.readlines():
-                tmp = line.strip('\n').replace(" ", "").split(',')
-                img_path, label = tmp[0], tmp[1]
+                tmp = line.strip('\n').split(',',1)
+                img_path, label = tmp[0].lstrip(), tmp[1].lstrip()
+                
+                
                 label = label.replace("\"", "")
                 out_file.write(img_path + '\t' + label + '\n')
 


### PR DESCRIPTION
removing space from ground truth and splitting at first "," is actually removing after the comma.
example -
xyz.png,dhi,raj

here filename is "xyz.png"
and text is "dhi,raj"

but with current code it's only taking "dhi"
also why removing space from ground truth?