### PR TITLE
[npu-tipc] update npu tipc scripts

### DIFF
--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -35,12 +35,18 @@ dataline=`cat $FILENAME`
 IFS=$'\n'
 lines=(${dataline})
 
+modelname=$(echo ${lines[1]} | cut -d ":" -f2)
+if  [ $modelname == "rec_r31_sar" ] || [ $modelname == "rec_mtb_nrtr" ]; then
+    sed -i "s/Global.epoch_num:lite_train_lite_infer=2/Global.epoch_num:lite_train_lite_infer=1/g" $FILENAME
+fi
+
 # replace training config file
 grep -n 'tools/.*yml' $FILENAME  | cut -d ":" -f 1 \
 | while read line_num ; do
     train_cmd=$(func_parser_value "${lines[line_num-1]}")
     trainer_config=$(func_parser_config ${train_cmd})
     sed -i 's/use_gpu/use_npu/g' "$REPO_ROOT_PATH/$trainer_config"
+    sed -i 's/use_sync_bn: True/use_sync_bn: False/g' "$REPO_ROOT_PATH/$trainer_config"
 done
 
 # change gpu to npu in execution script

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -38,6 +38,8 @@ lines=(${dataline})
 modelname=$(echo ${lines[1]} | cut -d ":" -f2)
 if  [ $modelname == "rec_r31_sar" ] || [ $modelname == "rec_mtb_nrtr" ]; then
     sed -i "s/Global.epoch_num:lite_train_lite_infer=2/Global.epoch_num:lite_train_lite_infer=1/g" $FILENAME
+    sed -i "s/gpu_list:0|0,1/gpu_list:0,1/g" $FILENAME
+    sed -i "s/Global.use_npu:True|True/Global.use_npu:True/g" $FILENAME
 fi
 
 # replace training config file


### PR DESCRIPTION
1. 将npu tipc中耗时较长的模型的epoch修改为1
2. npu目前不支持sync_bn，修改模型配置中的use_sync_bn=false