### PR TITLE
Toward Devkit Consistency

### DIFF
--- a/deploy/slim/prune/export_prune_model.py
+++ b/deploy/slim/prune/export_prune_model.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(__dir__, '..', '..', '..'))
 sys.path.append(os.path.join(__dir__, '..', '..', '..', 'tools'))
 
 import paddle
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 
 from ppocr.postprocess import build_post_process
@@ -39,6 +39,7 @@ def main(config, device, logger, vdl_writer):
     global_config = config['Global']
 
     # build dataloader
+    set_signal_handlers()
     valid_dataloader = build_dataloader(config, 'Eval', device, logger)
 
     # build post process

--- a/deploy/slim/prune/sensitivity_anal.py
+++ b/deploy/slim/prune/sensitivity_anal.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(__dir__, '..', '..', '..', 'tools'))
 
 import paddle
 import paddle.distributed as dist
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.losses import build_loss
 from ppocr.optimizer import build_optimizer
@@ -57,6 +57,7 @@ def main(config, device, logger, vdl_writer):
     global_config = config['Global']
 
     # build dataloader
+    set_signal_handlers()
     train_dataloader = build_dataloader(config, 'Train', device, logger)
     if config['Eval']:
         valid_dataloader = build_dataloader(config, 'Eval', device, logger)

--- a/deploy/slim/quantization/export_model.py
+++ b/deploy/slim/quantization/export_model.py
@@ -34,7 +34,7 @@ from tools.program import load_config, merge_config, ArgsParser
 from ppocr.metrics import build_metric
 import tools.program as program
 from paddleslim.dygraph.quant import QAT
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from tools.export_model import export_single_model
 
 
@@ -134,6 +134,7 @@ def main():
     eval_class = build_metric(config['Metric'])
 
     # build dataloader
+    set_signal_handlers()
     valid_dataloader = build_dataloader(config, 'Eval', device, logger)
 
     use_srn = config['Architecture']['algorithm'] == "SRN"

--- a/deploy/slim/quantization/quant.py
+++ b/deploy/slim/quantization/quant.py
@@ -31,7 +31,7 @@ import paddle.distributed as dist
 
 paddle.seed(2)
 
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.losses import build_loss
 from ppocr.optimizer import build_optimizer
@@ -95,6 +95,7 @@ def main(config, device, logger, vdl_writer):
     global_config = config['Global']
 
     # build dataloader
+    set_signal_handlers()
     train_dataloader = build_dataloader(config, 'Train', device, logger)
     if config['Eval']:
         valid_dataloader = build_dataloader(config, 'Eval', device, logger)

--- a/deploy/slim/quantization/quant_kl.py
+++ b/deploy/slim/quantization/quant_kl.py
@@ -31,7 +31,7 @@ import paddle.distributed as dist
 
 paddle.seed(2)
 
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.losses import build_loss
 from ppocr.optimizer import build_optimizer
@@ -117,6 +117,7 @@ def main(config, device, logger, vdl_writer):
     global_config = config['Global']
 
     # build dataloader
+    set_signal_handlers()
     config['Train']['loader']['num_workers'] = 0
     is_layoutxlm_ser =  config['Architecture']['model_type'] =='kie' and config['Architecture']['Backbone']['name'] == 'LayoutXLMForSer'
     train_dataloader = build_dataloader(config, 'Train', device, logger)

--- a/ppocr/data/__init__.py
+++ b/ppocr/data/__init__.py
@@ -39,7 +39,7 @@ from ppocr.data.pgnet_dataset import PGDataSet
 from ppocr.data.pubtab_dataset import PubTabDataSet
 from ppocr.data.multi_scale_sampler import MultiScaleSampler
 
-__all__ = ['build_dataloader', 'transform', 'create_operators']
+__all__ = ['build_dataloader', 'transform', 'create_operators', 'set_signal_handlers']
 
 
 def term_mp(sig_num, frame):
@@ -49,6 +49,12 @@ def term_mp(sig_num, frame):
     pgid = os.getpgid(os.getpid())
     print("main proc {} exit, kill process group " "{}".format(pid, pgid))
     os.killpg(pgid, signal.SIGKILL)
+
+
+def set_signal_handlers():
+    # support exit using ctrl+c
+    signal.signal(signal.SIGINT, term_mp)
+    signal.signal(signal.SIGTERM, term_mp)
 
 
 def build_dataloader(config, mode, device, logger, seed=None):
@@ -108,9 +114,5 @@ def build_dataloader(config, mode, device, logger, seed=None):
         return_list=True,
         use_shared_memory=use_shared_memory,
         collate_fn=collate_fn)
-
-    # support exit using ctrl+c
-    signal.signal(signal.SIGINT, term_mp)
-    signal.signal(signal.SIGTERM, term_mp)
 
     return data_loader

--- a/ppocr/data/__init__.py
+++ b/ppocr/data/__init__.py
@@ -52,9 +52,18 @@ def term_mp(sig_num, frame):
 
 
 def set_signal_handlers():
-    # support exit using ctrl+c
-    signal.signal(signal.SIGINT, term_mp)
-    signal.signal(signal.SIGTERM, term_mp)
+    pid = os.getpid()
+    pgid = os.getpgid(os.getpid())
+    # XXX: `term_mp` kills all processes in the process group, which in 
+    # some cases includes the parent process of current process and may 
+    # cause unexpected results. To solve this problem, we set signal 
+    # handlers only when current process is the group leader. In the 
+    # future, it would be better to consider killing only descendants of 
+    # the current process.
+    if pid == pgid:
+        # support exit using ctrl+c
+        signal.signal(signal.SIGINT, term_mp)
+        signal.signal(signal.SIGTERM, term_mp)
 
 
 def build_dataloader(config, mode, device, logger, seed=None):

--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -197,6 +197,11 @@ def save_model(model,
     """
     _mkdir_if_not_exist(model_path, logger)
     model_prefix = os.path.join(model_path, prefix)
+
+    if prefix == 'best_accuracy':
+        uapi_best_model_path = os.path.join(model_path, 'best_model')
+        _mkdir_if_not_exist(uapi_best_model_path, logger)
+
     paddle.save(optimizer.state_dict(), model_prefix + '.pdopt')
 
     is_nlp_model = config['Architecture']["model_type"] == 'kie' and config[
@@ -204,6 +209,11 @@ def save_model(model,
     if is_nlp_model is not True:
         paddle.save(model.state_dict(), model_prefix + '.pdparams')
         metric_prefix = model_prefix
+
+        if prefix == 'best_accuracy':
+            uapi_best_model_path = os.path.join(uapi_best_model_path, 'model')
+            paddle.save(model.state_dict(), uapi_best_model_path + ".pdparams")
+
     else:  # for kie system, we follow the save/load rules in NLP
         if config['Global']['distributed']:
             arch = model._layers
@@ -213,6 +223,11 @@ def save_model(model,
             arch = arch.Student
         arch.backbone.model.save_pretrained(model_prefix)
         metric_prefix = os.path.join(model_prefix, 'metric')
+
+        if prefix == 'best_accuracy':
+            uapi_best_model_path = os.path.join(uapi_best_model_path)
+            arch.backbone.model.save_pretrained(uapi_best_model_path)
+
     # save metric and config
     with open(metric_prefix + '.states', 'wb') as f:
         pickle.dump(kwargs, f, protocol=2)

--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -199,13 +199,13 @@ def save_model(model,
     model_prefix = os.path.join(model_path, prefix)
 
     if prefix == 'best_accuracy':
-        uapi_best_model_path = os.path.join(model_path, 'best_model')
-        _mkdir_if_not_exist(uapi_best_model_path, logger)
+        best_model_path = os.path.join(model_path, 'best_model')
+        _mkdir_if_not_exist(best_model_path, logger)
 
     paddle.save(optimizer.state_dict(), model_prefix + '.pdopt')
     if prefix == 'best_accuracy':
         paddle.save(optimizer.state_dict(),
-                    os.path.join(uapi_best_model_path, 'model.pdopt'))
+                    os.path.join(best_model_path, 'model.pdopt'))
 
     is_nlp_model = config['Architecture']["model_type"] == 'kie' and config[
         "Architecture"]["algorithm"] not in ["SDMGR"]
@@ -215,7 +215,7 @@ def save_model(model,
 
         if prefix == 'best_accuracy':
             paddle.save(model.state_dict(),
-                        os.path.join(uapi_best_model_path, 'model.pdparams'))
+                        os.path.join(best_model_path, 'model.pdparams'))
 
     else:  # for kie system, we follow the save/load rules in NLP
         if config['Global']['distributed']:
@@ -228,7 +228,7 @@ def save_model(model,
         metric_prefix = os.path.join(model_prefix, 'metric')
 
         if prefix == 'best_accuracy':
-            arch.backbone.model.save_pretrained(uapi_best_model_path)
+            arch.backbone.model.save_pretrained(best_model_path)
 
     # save metric and config
     with open(metric_prefix + '.states', 'wb') as f:

--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -203,6 +203,9 @@ def save_model(model,
         _mkdir_if_not_exist(uapi_best_model_path, logger)
 
     paddle.save(optimizer.state_dict(), model_prefix + '.pdopt')
+    if prefix == 'best_accuracy':
+        paddle.save(optimizer.state_dict(),
+                    os.path.join(uapi_best_model_path, 'model.pdopt'))
 
     is_nlp_model = config['Architecture']["model_type"] == 'kie' and config[
         "Architecture"]["algorithm"] not in ["SDMGR"]
@@ -211,8 +214,8 @@ def save_model(model,
         metric_prefix = model_prefix
 
         if prefix == 'best_accuracy':
-            uapi_best_model_path = os.path.join(uapi_best_model_path, 'model')
-            paddle.save(model.state_dict(), uapi_best_model_path + ".pdparams")
+            paddle.save(model.state_dict(),
+                        os.path.join(uapi_best_model_path, 'model.pdparams'))
 
     else:  # for kie system, we follow the save/load rules in NLP
         if config['Global']['distributed']:
@@ -225,7 +228,6 @@ def save_model(model,
         metric_prefix = os.path.join(model_prefix, 'metric')
 
         if prefix == 'best_accuracy':
-            uapi_best_model_path = os.path.join(uapi_best_model_path)
             arch.backbone.model.save_pretrained(uapi_best_model_path)
 
     # save metric and config

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -24,7 +24,7 @@ sys.path.insert(0, __dir__)
 sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '..')))
 
 import paddle
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.postprocess import build_post_process
 from ppocr.metrics import build_metric
@@ -35,6 +35,7 @@ import tools.program as program
 def main():
     global_config = config['Global']
     # build dataloader
+    set_signal_handlers()
     valid_dataloader = build_dataloader(config, 'Eval', device, logger)
 
     # build post process

--- a/tools/export_center.py
+++ b/tools/export_center.py
@@ -24,7 +24,7 @@ __dir__ = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(__dir__)
 sys.path.append(os.path.abspath(os.path.join(__dir__, '..')))
 
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.postprocess import build_post_process
 from ppocr.utils.save_load import load_model
@@ -40,6 +40,7 @@ def main():
         'data_dir']
     config['Eval']['dataset']['label_file_list'] = config['Train']['dataset'][
         'label_file_list']
+    set_signal_handlers()
     eval_dataloader = build_dataloader(config, 'Eval', device, logger)
 
     # build post process

--- a/tools/infer_det.py
+++ b/tools/infer_det.py
@@ -40,17 +40,16 @@ import tools.program as program
 
 
 def draw_det_res(dt_boxes, config, img, img_name, save_path):
-    if len(dt_boxes) > 0:
-        import cv2
-        src_im = img
-        for box in dt_boxes:
-            box = np.array(box).astype(np.int32).reshape((-1, 1, 2))
-            cv2.polylines(src_im, [box], True, color=(255, 255, 0), thickness=2)
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
-        save_path = os.path.join(save_path, os.path.basename(img_name))
-        cv2.imwrite(save_path, src_im)
-        logger.info("The detected Image saved in {}".format(save_path))
+    import cv2
+    src_im = img
+    for box in dt_boxes:
+        box = np.array(box).astype(np.int32).reshape((-1, 1, 2))
+        cv2.polylines(src_im, [box], True, color=(255, 255, 0), thickness=2)
+    if not os.path.exists(save_path):
+        os.makedirs(save_path)
+    save_path = os.path.join(save_path, os.path.basename(img_name))
+    cv2.imwrite(save_path, src_im)
+    logger.info("The detected Image saved in {}".format(save_path))
 
 
 @paddle.no_grad()

--- a/tools/program.py
+++ b/tools/program.py
@@ -683,7 +683,7 @@ def preprocess(is_train=False):
 
     if 'use_visualdl' in config['Global'] and config['Global']['use_visualdl']:
         save_model_dir = config['Global']['save_model_dir']
-        vdl_writer_path = '{}/vdl/'.format(save_model_dir)
+        vdl_writer_path = save_model_dir
         log_writer = VDLLogger(vdl_writer_path)
         loggers.append(log_writer)
     if ('use_wandb' in config['Global'] and

--- a/tools/train.py
+++ b/tools/train.py
@@ -27,7 +27,7 @@ import yaml
 import paddle
 import paddle.distributed as dist
 
-from ppocr.data import build_dataloader
+from ppocr.data import build_dataloader, set_signal_handlers
 from ppocr.modeling.architectures import build_model
 from ppocr.losses import build_loss
 from ppocr.optimizer import build_optimizer
@@ -49,6 +49,7 @@ def main(config, device, logger, vdl_writer):
     global_config = config['Global']
 
     # build dataloader
+    set_signal_handlers()
     train_dataloader = build_dataloader(config, 'Train', device, logger)
     if len(train_dataloader) == 0:
         logger.error(


### PR DESCRIPTION
## 目标

修改代码以提升PaddleCV套件一致性，同时适配X项目。修改后，套件应满足如下一致性要求：

1. 将训练过程中最优（一般是验证集上精度最高）的模型权重存储在输出目录的`best_model`子目录中，文件命名为`model.pdparams`。与之相配套的优化器参数（如果存储的话）文件命名为`model.pdopt`，也存储在该目录中。
2. 支持将训练、验证过程中VisualDL产生的.log格式日志文件保存在输出目录中（无嵌套子目录）。
3. 套件根目录存在`requirements.txt`文件，指定使用套件基础功能需要的依赖。在套件根目录可通过`pip install .`或`pip install -e .`方式（至少其中一种）安装套件核心库。
4. 对于模型导出功能，默认支持或通过命令行选项/配置文件等手段支持导出为FD格式。『FD格式』的导出结果通常包含如下文件：
- `inference.pdiparams`：保存权重参数。
- `inference.pdiparams.info`：保存与参数有关的额外信息。
- `inference.pdmodel`：保存模型结构描述信息。
- （可选）`inference.yml`：预处理配置文件。

## 代码变动

1. 【一致性提升】使训练时检查点存储位置满足一致性要求1。
2. 【一致性提升】【**不兼容升级**】修改VisualDL日志存储位置以满足一致性要求2。
3. 【功能增强】修改`tools/infer_det.py`中`raw_det_res`对『零目标框』情形的处理逻辑，在该情形下仍然存储图像（存的是原图），从而使用户在各种情况下均能获得输出图像，而无需关注目标框数量。
4. 【功能增强】调整signal handlers的设置时机。修改前，signal handlers在每次载入`ppocr.data`时自动设置，但这种做法有以下缺点：1) 用户在使用Python REPL或进行断点调试时经常需要输入Ctrl+C，而这将直接触发程序的终止，令用户感到疑惑和不便；2) 从调用关系的角度来看，作为callee，逻辑上来说应当尽可能减少对caller的影响，而目前的实现显然不满足这一点；3) 如果库在子进程中被调用，作为子进程，即使不考虑权限问题，只从资源回收的角度来看，试图通过`SIGKILL`杀死包括父进程以及其它旁支进程在内的整个进程组内的成员仍是危险的行为。修改后，signal handlers只在当前进程为进程组leader、且用户通过脚本执行（排除了REPL的情况）的情况下被设置。此做法仍有优化空间，详见`ppocr/data/__init__.py`中的注释。

## 遗留问题

1. 对于代码变动1和2，**尚未更新相关文档**。若此PR合入，可能需要套件同学进行更新。
2. 考虑到反向兼容性，本次改动未对PaddleOCR原本的最优模型存储机制进行变更，而只是追加了`best_model`目录。因此，输出目录中将存在`model.pdparams`和`model.pdopt`的两份拷贝。后续需考虑渐进地改动旧的存储机制，使最优模型只保留一份。