### PR TITLE
improve amp training 

### DIFF
--- a/configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml
+++ b/configs/det/ch_PP-OCRv3/ch_PP-OCRv3_det_cml.yml
@@ -18,6 +18,7 @@ Global:
   save_res_path: ./checkpoints/det_db/predicts_db.txt
   distributed: true
   d2s_train_image_shape: [3, -1, -1]
+  amp_dtype: bfloat16
 
 Architecture:
   name: DistillationModel


### PR DESCRIPTION
背景：ch_PP-OCRv3_det 模型在amp fp16训练中，O1、O2都会出现nan，原因是模型中卷积层的数值范围极大，超出了fp16的表示范围，并不适合这种训练方式。我们尝试了amp bf16 训练，发现无需任何额外配置，模型未出现nan，精度和相同配置下的fp32训练可以对齐。

PR：为套件添加amp_dtype的选项，默认为float16，给ch_PP-OCRv3_det 模型配置为bfloat16