### PR TITLE
Limit Pillow Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ premailer
 openpyxl
 attrdict
 PyMuPDF<1.21.0
+Pillow<=9.5.0


### PR DESCRIPTION
由于新版Pillow库去除了`FreeTypeFont.getsize`接口（[PaddleOCR中该API使用情况](https://github.com/search?q=repo%3APaddlePaddle%2FPaddleOCR%20getsize&type=code)），PaddleOCR无法在Pillow>9.5.0以上版本工作。因此，在依赖列表中限制Pillow版本。参见：
https://github.com/XingangPan/DragGAN/issues/152