### PR TITLE
fix "No module named xxx" error after built target executable file by Pyinstaller and run.

### DIFF
--- a/ppocr/data/__init__.py
+++ b/ppocr/data/__init__.py
@@ -32,11 +32,11 @@ import copy
 from paddle.io import Dataset, DataLoader, BatchSampler, DistributedBatchSampler
 import paddle.distributed as dist
 
-from ppocr.data.imaug import transform, create_operators
-from ppocr.data.simple_dataset import SimpleDataSet
-from ppocr.data.lmdb_dataset import LMDBDataSet, LMDBDataSetSR
-from ppocr.data.pgnet_dataset import PGDataSet
-from ppocr.data.pubtab_dataset import PubTabDataSet
+from paddleocr.ppocr.data.imaug import transform, create_operators
+from paddleocr.ppocr.data.simple_dataset import SimpleDataSet
+from paddleocr.ppocr.data.lmdb_dataset import LMDBDataSet, LMDBDataSetSR
+from paddleocr.ppocr.data.pgnet_dataset import PGDataSet
+from paddleocr.ppocr.data.pubtab_dataset import PubTabDataSet
 
 __all__ = ['build_dataloader', 'transform', 'create_operators']
 

--- a/ppocr/data/imaug/__init__.py
+++ b/ppocr/data/imaug/__init__.py
@@ -42,7 +42,7 @@ from .table_ops import *
 
 from .vqa import *
 
-from .fce_aug import *
+from paddleocr.ppocr.data.imaug.fce_aug import *
 from .fce_targets import FCENetTargets
 from .ct_process import *
 from .drrg_targets import DRRGTargets

--- a/ppocr/data/imaug/copy_paste.py
+++ b/ppocr/data/imaug/copy_paste.py
@@ -18,9 +18,9 @@ import numpy as np
 from PIL import Image
 from shapely.geometry import Polygon
 
-from ppocr.data.imaug.iaa_augment import IaaAugment
-from ppocr.data.imaug.random_crop_data import is_poly_outside_rect
-from tools.infer.utility import get_rotate_crop_image
+from paddleocr.ppocr.data.imaug.iaa_augment import IaaAugment
+from paddleocr.ppocr.data.imaug.random_crop_data import is_poly_outside_rect
+from paddleocr.tools.infer.utility import get_rotate_crop_image
 
 
 class CopyPaste(object):

--- a/ppocr/data/imaug/fce_aug.py
+++ b/ppocr/data/imaug/fce_aug.py
@@ -20,7 +20,7 @@ from PIL import Image, ImageDraw
 import cv2
 from shapely.geometry import Polygon
 import math
-from ppocr.utils.poly_nms import poly_intersection
+from paddleocr.ppocr.utils.poly_nms import poly_intersection
 
 
 class RandomScaling:

--- a/ppocr/data/imaug/label_ops.py
+++ b/ppocr/data/imaug/label_ops.py
@@ -25,8 +25,8 @@ import json
 import copy
 from random import sample
 
-from ppocr.utils.logging import get_logger
-from ppocr.data.imaug.vqa.augment import order_by_tbyx
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.data.imaug.vqa.augment import order_by_tbyx
 
 
 class ClsLabelEncode(object):
@@ -950,7 +950,7 @@ class VQATokenLabelEncode(object):
                  **kwargs):
         super(VQATokenLabelEncode, self).__init__()
         from paddlenlp.transformers import LayoutXLMTokenizer, LayoutLMTokenizer, LayoutLMv2Tokenizer
-        from ppocr.utils.utility import load_vqa_bio_label_maps
+        from paddleocr.ppocr.utils.utility import load_vqa_bio_label_maps
         tokenizer_dict = {
             'LayoutXLM': {
                 'class': LayoutXLMTokenizer,

--- a/ppocr/data/imaug/pg_process.py
+++ b/ppocr/data/imaug/pg_process.py
@@ -16,7 +16,7 @@ import math
 import cv2
 import numpy as np
 from skimage.morphology._skeletonize import thin
-from ppocr.utils.e2e_utils.extract_textpoint_fast import sort_and_expand_with_direction_v2
+from paddleocr.ppocr.utils.e2e_utils.extract_textpoint_fast import sort_and_expand_with_direction_v2
 
 __all__ = ['PGProcessTrain']
 

--- a/ppocr/postprocess/fce_postprocess.py
+++ b/ppocr/postprocess/fce_postprocess.py
@@ -20,7 +20,7 @@ import cv2
 import paddle
 import numpy as np
 from numpy.fft import ifft
-from ppocr.utils.poly_nms import poly_nms, valid_boundary
+from paddleocr.ppocr.utils.poly_nms import poly_nms, valid_boundary
 
 
 def fill_hole(input_mask):

--- a/ppocr/postprocess/pg_postprocess.py
+++ b/ppocr/postprocess/pg_postprocess.py
@@ -22,7 +22,7 @@ import sys
 __dir__ = os.path.dirname(__file__)
 sys.path.append(__dir__)
 sys.path.append(os.path.join(__dir__, '..'))
-from ppocr.utils.e2e_utils.pgnet_pp_utils import PGNet_PostProcess
+from paddleocr.ppocr.utils.e2e_utils.pgnet_pp_utils import PGNet_PostProcess
 
 
 class PGPostProcess(object):

--- a/ppocr/postprocess/pse_postprocess/pse_postprocess.py
+++ b/ppocr/postprocess/pse_postprocess/pse_postprocess.py
@@ -25,7 +25,7 @@ import cv2
 import paddle
 from paddle.nn import functional as F
 
-from ppocr.postprocess.pse_postprocess.pse import pse
+from paddleocr.ppocr.postprocess.pse_postprocess.pse import pse
 
 
 class PSEPostProcess(object):

--- a/ppocr/postprocess/vqa_token_ser_layoutlm_postprocess.py
+++ b/ppocr/postprocess/vqa_token_ser_layoutlm_postprocess.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import numpy as np
 import paddle
-from ppocr.utils.utility import load_vqa_bio_label_maps
+from paddleocr.ppocr.utils.utility import load_vqa_bio_label_maps
 
 
 class VQASerTokenLayoutLMPostProcess(object):

--- a/ppocr/utils/e2e_metric/Deteval.py
+++ b/ppocr/utils/e2e_metric/Deteval.py
@@ -16,7 +16,7 @@ import json
 import numpy as np
 import scipy.io as io
 import Polygon as plg
-from ppocr.utils.e2e_metric.polygon_fast import iod, area_of_intersection, area
+from paddleocr.ppocr.utils.e2e_metric.polygon_fast import iod, area_of_intersection, area
 
 
 def get_socre_A(gt_dir, pred_dict):

--- a/ppocr/utils/e2e_utils/pgnet_pp_utils.py
+++ b/ppocr/utils/e2e_utils/pgnet_pp_utils.py
@@ -22,8 +22,8 @@ import sys
 __dir__ = os.path.dirname(__file__)
 sys.path.append(__dir__)
 sys.path.append(os.path.join(__dir__, '..'))
-from extract_textpoint_slow import *
-from extract_textpoint_fast import generate_pivot_list_fast, restore_poly
+from paddleocr.ppocr.utils.e2e_utils.extract_textpoint_slow import *
+from paddleocr.ppocr.utils.e2e_utils.extract_textpoint_fast import generate_pivot_list_fast, restore_poly
 
 
 class PGNet_PostProcess(object):

--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -18,7 +18,7 @@ import tarfile
 import requests
 from tqdm import tqdm
 
-from ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.logging import get_logger
 
 
 def download_with_progressbar(url, save_path):

--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -23,7 +23,7 @@ import six
 
 import paddle
 
-from ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.logging import get_logger
 
 __all__ = ['load_model']
 

--- a/ppstructure/kie/predict_kie_token_ser.py
+++ b/ppstructure/kie/predict_kie_token_ser.py
@@ -25,13 +25,13 @@ import json
 import numpy as np
 import time
 
-import tools.infer.utility as utility
-from ppocr.data import create_operators, transform
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.visual import draw_ser_results
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppstructure.utility import parse_args
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.data import create_operators, transform
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.visual import draw_ser_results
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppstructure.utility import parse_args
 
 from paddleocr import PaddleOCR
 

--- a/ppstructure/kie/predict_kie_token_ser_re.py
+++ b/ppstructure/kie/predict_kie_token_ser_re.py
@@ -25,14 +25,14 @@ import json
 import numpy as np
 import time
 
-import tools.infer.utility as utility
-from tools.infer_kie_token_ser_re import make_input
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.visual import draw_ser_results, draw_re_results
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppstructure.utility import parse_args
-from ppstructure.kie.predict_kie_token_ser import SerPredictor
+import paddleocr.tools.infer.utility as utility
+from paddleocr.tools.infer_kie_token_ser_re import make_input
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.visual import draw_ser_results, draw_re_results
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppstructure.utility import parse_args
+from paddleocr.ppstructure.kie.predict_kie_token_ser import SerPredictor
 
 logger = get_logger()
 

--- a/ppstructure/layout/predict_layout.py
+++ b/ppstructure/layout/predict_layout.py
@@ -24,13 +24,13 @@ import cv2
 import numpy as np
 import time
 
-import tools.infer.utility as utility
-from ppocr.data import create_operators, transform
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppstructure.utility import parse_args
-from picodet_postprocess import PicoDetPostProcess
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.data import create_operators, transform
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppstructure.utility import parse_args
+from paddleocr.ppocr.postprocess.picodet_postprocess import PicoDetPostProcess
 
 logger = get_logger()
 

--- a/ppstructure/pdf2word/pdf2word.py
+++ b/ppstructure/pdf2word/pdf2word.py
@@ -34,10 +34,10 @@ root = os.path.abspath(os.path.join(file, '../../'))
 sys.path.append(file)
 sys.path.insert(0, root)
 
-from ppstructure.predict_system import StructureSystem, save_structure_res
-from ppstructure.utility import parse_args, draw_structure_result
-from ppocr.utils.network import download_with_progressbar
-from ppstructure.recovery.recovery_to_doc import sorted_layout_boxes, convert_info_docx
+from paddleocr.ppstructure.predict_system import StructureSystem, save_structure_res
+from paddleocr.ppstructure.utility import parse_args, draw_structure_result
+from paddleocr.ppocr.utils.network import download_with_progressbar
+from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes, convert_info_docx
 # from ScreenShotWidget import ScreenShotWidget
 
 __APPNAME__ = "pdf2word"

--- a/ppstructure/predict_system.py
+++ b/ppstructure/predict_system.py
@@ -28,13 +28,13 @@ import time
 import logging
 from copy import deepcopy
 
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.utils.logging import get_logger
-from ppocr.utils.visual import draw_ser_results, draw_re_results
-from tools.infer.predict_system import TextSystem
-from ppstructure.layout.predict_layout import LayoutPredictor
-from ppstructure.table.predict_table import TableSystem, to_excel
-from ppstructure.utility import parse_args, draw_structure_result
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.visual import draw_ser_results, draw_re_results
+from paddleocr.tools.infer.predict_system import TextSystem
+from paddleocr.ppstructure.layout.predict_layout import LayoutPredictor
+from paddleocr.ppstructure.table.predict_table import TableSystem, to_excel
+from paddleocr.ppstructure.utility import parse_args, draw_structure_result
 
 logger = get_logger()
 
@@ -76,7 +76,7 @@ class StructureSystem(object):
                     self.table_system = TableSystem(args)
 
         elif self.mode == 'kie':
-            from ppstructure.kie.predict_kie_token_ser_re import SerRePredictor
+            from paddleocr.ppstructure.kie.predict_kie_token_ser_re import SerRePredictor
             self.kie_predictor = SerRePredictor(args)
 
     def __call__(self, img, return_ocr_result_in_table=False, img_idx=0):
@@ -282,7 +282,7 @@ def main(args):
                 cv2.imwrite(img_save_path, draw_img)
                 logger.info('result save to {}'.format(img_save_path))
             if args.recovery and res != []:
-                from ppstructure.recovery.recovery_to_doc import sorted_layout_boxes, convert_info_docx
+                from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes, convert_info_docx
                 h, w, _ = img.shape
                 res = sorted_layout_boxes(res, w)
                 all_res += res

--- a/ppstructure/recovery/recovery_to_doc.py
+++ b/ppstructure/recovery/recovery_to_doc.py
@@ -22,9 +22,9 @@ from docx.enum.section import WD_SECTION
 from docx.oxml.ns import qn
 from docx.enum.table import WD_TABLE_ALIGNMENT
 
-from ppstructure.recovery.table_process import HtmlToDocx
+from paddleocr.ppstructure.recovery.table_process import HtmlToDocx
 
-from ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.logging import get_logger
 logger = get_logger()
 
 

--- a/ppstructure/table/eval_table.py
+++ b/ppstructure/table/eval_table.py
@@ -23,10 +23,10 @@ import cv2
 import pickle
 import paddle
 from tqdm import tqdm
-from ppstructure.table.table_metric import TEDS
-from ppstructure.table.predict_table import TableSystem
-from ppstructure.utility import init_args
-from ppocr.utils.logging import get_logger
+from paddleocr.ppstructure.table.table_metric import TEDS
+from paddleocr.ppstructure.table.predict_table import TableSystem
+from paddleocr.ppstructure.utility import init_args
+from paddleocr.ppocr.utils.logging import get_logger
 
 logger = get_logger()
 

--- a/ppstructure/table/matcher.py
+++ b/ppstructure/table/matcher.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import numpy as np
-from ppstructure.table.table_master_match import deal_eb_token, deal_bb
+from paddleocr.ppstructure.table.table_master_match import deal_eb_token, deal_bb
 
 
 def distance(box_1, box_2):

--- a/ppstructure/table/predict_structure.py
+++ b/ppstructure/table/predict_structure.py
@@ -25,13 +25,13 @@ import numpy as np
 import time
 import json
 
-import tools.infer.utility as utility
-from ppocr.data import create_operators, transform
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.utils.visual import draw_rectangle
-from ppstructure.utility import parse_args
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.data import create_operators, transform
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.utils.visual import draw_rectangle
+from paddleocr.ppstructure.utility import parse_args
 
 logger = get_logger()
 

--- a/ppstructure/table/predict_table.py
+++ b/ppstructure/table/predict_table.py
@@ -26,16 +26,16 @@ import copy
 import logging
 import numpy as np
 import time
-import tools.infer.predict_rec as predict_rec
-import tools.infer.predict_det as predict_det
-import tools.infer.utility as utility
-from tools.infer.predict_system import sorted_boxes
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.utils.logging import get_logger
-from ppstructure.table.matcher import TableMatch
-from ppstructure.table.table_master_match import TableMasterMatcher
-from ppstructure.utility import parse_args
-import ppstructure.table.predict_structure as predict_strture
+import paddleocr.tools.infer.predict_rec as predict_rec
+import paddleocr.tools.infer.predict_det as predict_det
+import paddleocr.tools.infer.utility as utility
+from paddleocr.tools.infer.predict_system import sorted_boxes
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppstructure.table.matcher import TableMatch
+from paddleocr.ppstructure.table.table_master_match import TableMasterMatcher
+from paddleocr.ppstructure.utility import parse_args
+import paddleocr.ppstructure.table.predict_structure as predict_strture
 
 logger = get_logger()
 

--- a/ppstructure/utility.py
+++ b/ppstructure/utility.py
@@ -15,7 +15,7 @@ import random
 import ast
 from PIL import Image, ImageDraw, ImageFont
 import numpy as np
-from tools.infer.utility import draw_ocr_box_txt, str2bool, init_args as infer_args
+from paddleocr.tools.infer.utility import draw_ocr_box_txt, str2bool, init_args as infer_args
 
 
 def init_args():

--- a/tools/infer/predict_cls.py
+++ b/tools/infer/predict_cls.py
@@ -27,10 +27,10 @@ import math
 import time
 import traceback
 
-import tools.infer.utility as utility
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
 
 logger = get_logger()
 

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -25,11 +25,11 @@ import numpy as np
 import time
 import sys
 
-import tools.infer.utility as utility
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.data import create_operators, transform
-from ppocr.postprocess import build_post_process
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.data import create_operators, transform
+from paddleocr.ppocr.postprocess import build_post_process
 import json
 logger = get_logger()
 

--- a/tools/infer/predict_e2e.py
+++ b/tools/infer/predict_e2e.py
@@ -25,11 +25,11 @@ import numpy as np
 import time
 import sys
 
-import tools.infer.utility as utility
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.data import create_operators, transform
-from ppocr.postprocess import build_post_process
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.data import create_operators, transform
+from paddleocr.ppocr.postprocess import build_post_process
 
 logger = get_logger()
 

--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -27,10 +27,10 @@ import time
 import traceback
 import paddle
 
-import tools.infer.utility as utility
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
 
 logger = get_logger()
 

--- a/tools/infer/predict_sr.py
+++ b/tools/infer/predict_sr.py
@@ -27,10 +27,10 @@ import time
 import traceback
 import paddle
 
-import tools.infer.utility as utility
-from ppocr.postprocess import build_post_process
-from ppocr.utils.logging import get_logger
-from ppocr.utils.utility import get_image_file_list, check_and_read
+import paddleocr.tools.infer.utility as utility
+from paddleocr.ppocr.postprocess import build_post_process
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
 
 logger = get_logger()
 

--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -28,13 +28,13 @@ import json
 import time
 import logging
 from PIL import Image
-import tools.infer.utility as utility
-import tools.infer.predict_rec as predict_rec
-import tools.infer.predict_det as predict_det
-import tools.infer.predict_cls as predict_cls
-from ppocr.utils.utility import get_image_file_list, check_and_read
-from ppocr.utils.logging import get_logger
-from tools.infer.utility import draw_ocr_box_txt, get_rotate_crop_image, get_minarea_rect_crop
+import paddleocr.tools.infer.utility as utility
+import paddleocr.tools.infer.predict_rec as predict_rec
+import paddleocr.tools.infer.predict_det as predict_det
+import paddleocr.tools.infer.predict_cls as predict_cls
+from paddleocr.ppocr.utils.utility import get_image_file_list, check_and_read
+from paddleocr.ppocr.utils.logging import get_logger
+from paddleocr.tools.infer.utility import draw_ocr_box_txt, get_rotate_crop_image, get_minarea_rect_crop
 logger = get_logger()
 
 

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -24,7 +24,7 @@ import math
 from paddle import inference
 import time
 import random
-from ppocr.utils.logging import get_logger
+from paddleocr.ppocr.utils.logging import get_logger
 
 
 def str2bool(v):


### PR DESCRIPTION
fix "No module named xxx" error after built target executable file by Pyinstaller and run. the related issue ID is #10398, #10340, #9951, #9723 #9694. according to the suggestion from issue #9408.