### PR TITLE
Zxdev 2.6

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -471,7 +471,7 @@ def draw_box_txt_fine(img_size, box, txt, font_path="./doc/fonts/simfang.ttf"):
 def create_font(txt, sz, font_path="./doc/fonts/simfang.ttf"):
     font_size = int(sz[1] * 0.99)
     font = ImageFont.truetype(font_path, font_size, encoding="utf-8")
-    length = font.getsize(txt)[0]
+    length = font.getbbox(txt)[2]
     if length > sz[0]:
         font_size = int(font_size * sz[0] / length)
         font = ImageFont.truetype(font_path, font_size, encoding="utf-8")


### PR DESCRIPTION
PILLOW no longer supports ImageFont.getsize(), changed to getbbox()