### PR TITLE
paddle support stride, fix dy2st check

### DIFF
--- a/ppocr/modeling/heads/rec_robustscanner_head.py
+++ b/ppocr/modeling/heads/rec_robustscanner_head.py
@@ -99,10 +99,11 @@ class DotProductAttentionLayer(nn.Layer):
         logits = paddle.reshape(logits, [n, c, h, w])
         if valid_ratios is not None:
             # cal mask of attention weight
-            for i, valid_ratio in enumerate(valid_ratios):
-                valid_width = min(w, int(w * valid_ratio + 0.5))
-                if valid_width < w:
-                    logits[i, :, :, valid_width:] = float('-inf')
+            with paddle.fluid.framework._stride_in_no_check_dy2st_diff():
+                for i, valid_ratio in enumerate(valid_ratios):
+                    valid_width = min(w, int(w * valid_ratio + 0.5))
+                    if valid_width < w:
+                        logits[i, :, :, valid_width:] = float('-inf')
 
         # reshape to (n, c, h, w)
         logits = paddle.reshape(logits, [n, c, t])


### PR DESCRIPTION
Paddle支持stride后，需要检查动转静不一致的情况。但检查难度大，简单的检查会有误报，但这种方式获得评审会的同意。通过with可以避免误报。