### PR TITLE
remove un-used imported modules, so to avoid PyInstaller packaged binary runtime error

### DIFF
--- a/ppocr/data/imaug/ct_process.py
+++ b/ppocr/data/imaug/ct_process.py
@@ -20,7 +20,6 @@ import paddle
 
 import numpy as np
 import Polygon as plg
-import scipy.io as scio
 
 from PIL import Image
 import paddle.vision.transforms as transforms

--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-import imghdr
 import cv2
 import random
 import numpy as np


### PR DESCRIPTION
by current PR, remove un-used imported modules in code, so to avoid PyInstaller packaged binary 's py-script import them, which in fact is not included by pyinstaller when package. 

if not merge current PR , then PyInstaller should add parameter `--hidden-import imghdr --hidden-import scipy.io` and must add parameter `--collect-all  paddleocr` , but the previous parameter is not suggested to hidden-import un-used modules for package release. 

Previously there is a [commit](https://github.com/PaddlePaddle/PaddleOCR/commit/32fe3c9b07f125b0c2e47d6a47776d128ee6847b) has `Improve package import compatibility` of paddleocr.py file. but the pyinstaller packaged execution file runtime not found module issue still exists.

I had tried another PR https://github.com/PaddlePaddle/PaddleOCR/pull/10421 ,but that is not the root cause.

history:
1. the related issues ID #1024 #9355 #10398, #10340, #9951, #9723 #9694, #9944, #9408 , #7635, #4390
2. how to reproduce the above issue: https://github.com/kerneltravel/PaddleOCR_PR10421_reproduce/blob/1ed3c8211ca07f9779c10e07dfbfcf81466ddfd5/README.md


NOTE: those people who want to use pyinstaller  to package python-application with paddleocr may referer to [this](https://github.com/kerneltravel/PaddleOCR_PR10421_reproduce/commit/7ccfed344e88e371ee744a335e7dd4b3fff0ffca) to  append parameter `--collect-all paddleocr `  to pyinstaller . `--collect-all MODULE_NAMES` means `Collect all submodules, data files, and binaries from the specified package or module`.
