### PR TITLE
fix bug for table_master in tipc when running 'lite_train_lite_infer' mode

### DIFF
--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -243,6 +243,8 @@ if [ ${MODE} = "lite_train_lite_infer" ];then
     if [ ${model_name} == "table_master" ];then
         wget -nc -P ./pretrain_models/ https://paddleocr.bj.bcebos.com/ppstructure/models/tablemaster/table_structure_tablemaster_train.tar --no-check-certificate
         cd ./pretrain_models/ && tar xf table_structure_tablemaster_train.tar  && cd ../
+        wget -nc -P ./train_data/ https://paddleocr.bj.bcebos.com/dataset/StructureLabel_val_500.tar --no-check-certificate
+        cd ./train_data/ && tar xf StructureLabel_val_500.tar && cd ../
     fi
     rm -rf ./train_data/icdar2015
     rm -rf ./train_data/ic15_data


### PR DESCRIPTION
修复table_master模型在跑TIPC的lite_train_lite_infer模式时报错找不到数据的问题