### PR TITLE
修改数据增强个数及顺序时DSR不报错

### DIFF
--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -61,9 +61,20 @@ class SimpleDataSet(Dataset):
     def set_epoch_as_seed(self, seed, dataset_config):
         if self.mode == 'train':
             try:
-                dataset_config['transforms'][5]['MakeBorderMap'][
+
+                border_map_id = [index 
+                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                    if 'MakeBorderMap' in dictionary
+                    ][0]
+
+                shrink_map_id = [index 
+                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                    if 'MakeShrinkMap' in dictionary
+                    ][0]
+
+                dataset_config['transforms'][border_map_id]['MakeBorderMap'][
                     'epoch'] = seed if seed is not None else 0
-                dataset_config['transforms'][6]['MakeShrinkMap'][
+                dataset_config['transforms'][shrink_map_id]['MakeShrinkMap'][
                     'epoch'] = seed if seed is not None else 0
             except Exception as E:
                 print(E)

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -61,7 +61,6 @@ class SimpleDataSet(Dataset):
     def set_epoch_as_seed(self, seed, dataset_config):
         if self.mode == 'train':
             try:
-
                 border_map_id = [index 
                     for index, dictionary in enumerate(dataset_config['transforms']) 
                     if 'MakeBorderMap' in dictionary
@@ -71,7 +70,6 @@ class SimpleDataSet(Dataset):
                     for index, dictionary in enumerate(dataset_config['transforms']) 
                     if 'MakeShrinkMap' in dictionary
                     ][0]
-
                 dataset_config['transforms'][border_map_id]['MakeBorderMap'][
                     'epoch'] = seed if seed is not None else 0
                 dataset_config['transforms'][shrink_map_id]['MakeShrinkMap'][


### PR DESCRIPTION
由于在修改了dbnet数据增强的个数及顺序后，会导致ocrv4新增加的dsr增强失效，因此将其从固定索引改为检索索引，可以避免增加或减少数据增强后的错误