### PR TITLE
修改数据增强个数及顺序DSR报错

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,10 @@
--   repo: https://github.com/PaddlePaddle/mirrors-yapf.git
-    sha: 0d79c0c469bab64f7229c9aca2b1186ef47f0e37
-    hooks:
-    -   id: yapf
-        files: \.py$
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: a11d9314b22d8f8c7556443875b731ef05965464
+    rev: v3.2.0
     hooks:
-    -   id: check-merge-conflict
-    -   id: check-symlinks
-    -   id: detect-private-key
-        files: (?!.*paddle)^.*$
-    -   id: end-of-file-fixer
-        files: \.md$
     -   id: trailing-whitespace
-        files: \.md$
--   repo: https://github.com/Lucas-C/pre-commit-hooks
-    sha: v1.0.1
-    hooks:
-    -   id: forbid-crlf
-        files: \.md$
-    -   id: remove-crlf
-        files: \.md$
-    -   id: forbid-tabs
-        files: \.md$
-    -   id: remove-tabs
-        files: \.md$
--   repo: local
-    hooks:
-    -   id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat
-        entry: bash .clang_format.hook -i
-        language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|cuh|proto)$
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -61,12 +61,12 @@ class SimpleDataSet(Dataset):
     def set_epoch_as_seed(self, seed, dataset_config):
         if self.mode == 'train':
             try:
-                border_map_id = [index 
-                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                border_map_id = [index
+                    for index, dictionary in enumerate(dataset_config['transforms'])
                     if 'MakeBorderMap' in dictionary
                     ][0]
-                shrink_map_id = [index 
-                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                shrink_map_id = [index
+                    for index, dictionary in enumerate(dataset_config['transforms'])
                     if 'MakeShrinkMap' in dictionary
                     ][0]
                 dataset_config['transforms'][border_map_id]['MakeBorderMap'][

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -61,9 +61,17 @@ class SimpleDataSet(Dataset):
     def set_epoch_as_seed(self, seed, dataset_config):
         if self.mode == 'train':
             try:
-                dataset_config['transforms'][5]['MakeBorderMap'][
+                border_map_id = [index 
+                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                    if 'MakeBorderMap' in dictionary
+                    ][0]
+                shrink_map_id = [index 
+                    for index, dictionary in enumerate(dataset_config['transforms']) 
+                    if 'MakeShrinkMap' in dictionary
+                    ][0]
+                dataset_config['transforms'][border_map_id]['MakeBorderMap'][
                     'epoch'] = seed if seed is not None else 0
-                dataset_config['transforms'][6]['MakeShrinkMap'][
+                dataset_config['transforms'][shrink_map_id]['MakeShrinkMap'][
                     'epoch'] = seed if seed is not None else 0
             except Exception as E:
                 print(E)


### PR DESCRIPTION
由于在修改了dbnet数据增强的个数及顺序后，会导致ocrv4新增加的dsr增强失效，因此将其从固定索引改为检索索引，可以避免增加或减少数据增强后的错误