### PR TITLE
fix: release memory after predict

### DIFF
--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -525,7 +525,6 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = {"predict": outputs[2]}
-                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "SAR":
                 valid_ratios = np.concatenate(valid_ratios)
                 inputs = [
@@ -553,7 +552,6 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs[0]
-                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "RobustScanner":
                 valid_ratios = np.concatenate(valid_ratios)
                 word_positions_list = np.concatenate(word_positions_list)
@@ -579,7 +577,6 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs[0]
-                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "CAN":
                 norm_img_mask_batch = np.concatenate(norm_img_mask_batch)
                 word_label_list = np.concatenate(word_label_list)
@@ -607,7 +604,6 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs
-                    self.predictor.try_shrink_memory()
             else:
                 if self.use_onnx:
                     input_dict = {}

--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -525,6 +525,7 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = {"predict": outputs[2]}
+                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "SAR":
                 valid_ratios = np.concatenate(valid_ratios)
                 inputs = [
@@ -552,6 +553,7 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs[0]
+                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "RobustScanner":
                 valid_ratios = np.concatenate(valid_ratios)
                 word_positions_list = np.concatenate(word_positions_list)
@@ -577,6 +579,7 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs[0]
+                    self.predictor.try_shrink_memory()
             elif self.rec_algorithm == "CAN":
                 norm_img_mask_batch = np.concatenate(norm_img_mask_batch)
                 word_label_list = np.concatenate(word_label_list)
@@ -604,6 +607,7 @@ class TextRecognizer(object):
                     if self.benchmark:
                         self.autolog.times.stamp()
                     preds = outputs
+                    self.predictor.try_shrink_memory()
             else:
                 if self.use_onnx:
                     input_dict = {}
@@ -624,6 +628,7 @@ class TextRecognizer(object):
                         preds = outputs
                     else:
                         preds = outputs[0]
+                    self.predictor.try_shrink_memory()
             rec_result = self.postprocess_op(preds)
             for rno in range(len(rec_result)):
                 rec_res[indices[beg_img_no + rno]] = rec_result[rno]


### PR DESCRIPTION
# What?
I have the problem running OCR with CPU/GPU that I run through both AWS EC2 instance and my local machine (CPU) and see memory increase infinitely.
There are some issues like me such as:
- https://github.com/PaddlePaddle/PaddleOCR/issues/7823
- https://github.com/PaddlePaddle/PaddleOCR/issues/4452
- https://github.com/PaddlePaddle/PaddleOCR/issues/7155

# How? 
After tracing, I see `predict_rec.py` not release memory when predicted. I add `self.predictor.try_shrink_memory()` like in `predict_cls.py` and it works.