### PR TITLE
根据推理对三通道的图像需求，以及opencv中imread参数说明IMREAD_COLOR(If set, always convert …

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -513,7 +513,7 @@ def get_model_config(type, version, model_type, lang):
 
 def img_decode(content: bytes):
     np_arr = np.frombuffer(content, dtype=np.uint8)
-    return cv2.imdecode(np_arr, cv2.IMREAD_UNCHANGED)
+    return cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
 
 
 def check_img(img):


### PR DESCRIPTION
根据推理对三通道的图像需求，以及opencv中imread参数说明IMREAD_COLOR(If set, always convert image to the 3 channel BGR color image.)，因此修改该读取参数，以解决后续通道不匹配问题。
链接[问题](https://github.com/PaddlePaddle/PaddleOCR/issues/10748)