### PR TITLE
🐞 fix(cpp_infer): 修复rebuild_table的bug

### DIFF
--- a/deploy/cpp_infer/src/paddlestructure.cpp
+++ b/deploy/cpp_infer/src/paddlestructure.cpp
@@ -144,7 +144,7 @@ PaddleStructure::rebuild_table(std::vector<std::string> structure_html_tags,
     std::vector<std::vector<float>> dis_list(structure_boxes.size(),
                                              std::vector<float>(3, 100000.0));
     for (int j = 0; j < structure_boxes.size(); j++) {
-      if (structure_boxes[i].size() == 8) {
+      if (structure_boxes[j].size() == 8) {
         structure_box = Utility::xyxyxyxy2xyxy(structure_boxes[j]);
       } else {
         structure_box = structure_boxes[j];


### PR DESCRIPTION
structure_boxes的索引用错了，导致dis和iou可能无法正确计算