### PR TITLE
Fix index variable in for loop in paddlestructure.cpp

### DIFF
--- a/deploy/cpp_infer/src/paddlestructure.cpp
+++ b/deploy/cpp_infer/src/paddlestructure.cpp
@@ -144,7 +144,7 @@ PaddleStructure::rebuild_table(std::vector<std::string> structure_html_tags,
     std::vector<std::vector<float>> dis_list(structure_boxes.size(),
                                              std::vector<float>(3, 100000.0));
     for (int j = 0; j < structure_boxes.size(); j++) {
-      if (structure_boxes[i].size() == 8) {
+      if (structure_boxes[j].size() == 8) {
         structure_box = Utility::xyxyxyxy2xyxy(structure_boxes[j]);
       } else {
         structure_box = structure_boxes[j];


### PR DESCRIPTION
PaddleStructure::rebuild_table函数中`structure_boxes`的索引用错了，可能导致dis和iou无法正确计算。
原代码段：
```
    for (int j = 0; j < structure_boxes.size(); j++) {
      if (structure_boxes[i].size() == 8) {
        structure_box = Utility::xyxyxyxy2xyxy(structure_boxes[j]);
      } else {
        structure_box = structure_boxes[j];
      }
      dis_list[j][0] = this->dis(ocr_box, structure_box);
      dis_list[j][1] = 1 - Utility::iou(ocr_box, structure_box);
      dis_list[j][2] = j;
    }
```

应改为：
```
    for (int j = 0; j < structure_boxes.size(); j++) {
      if (structure_boxes[j].size() == 8) {
        structure_box = Utility::xyxyxyxy2xyxy(structure_boxes[j]);
      } else {
        structure_box = structure_boxes[j];
      }
      dis_list[j][0] = this->dis(ocr_box, structure_box);
      dis_list[j][1] = 1 - Utility::iou(ocr_box, structure_box);
      dis_list[j][2] = j;
    }
```