### PR TITLE
kie推理增加cls可选项

### DIFF
--- a/ppocr/data/imaug/label_ops.py
+++ b/ppocr/data/imaug/label_ops.py
@@ -1201,7 +1201,7 @@ class VQATokenLabelEncode(object):
 
     def _load_ocr_info(self, data):
         if self.infer_mode:
-            ocr_result = self.ocr_engine.ocr(data['image'], cls=False)[0]
+            ocr_result = self.ocr_engine.ocr(data['image'], cls=data['cls'])[0]
             ocr_info = []
             for res in ocr_result:
                 ocr_info.append({

--- a/ppstructure/kie/predict_kie_token_ser.py
+++ b/ppstructure/kie/predict_kie_token_ser.py
@@ -98,9 +98,9 @@ class SerPredictor(object):
         self.predictor, self.input_tensor, self.output_tensors, self.config = \
             utility.create_predictor(args, 'ser', logger)
 
-    def __call__(self, img):
+    def __call__(self, img, cls=False):
         ori_im = img.copy()
-        data = {'image': img}
+        data = {'image': img, 'cls': cls}
         data = transform(data, self.preprocess_op)
         if data[0] is None:
             return None, 0


### PR DESCRIPTION
卡证类信息提取经常会有翻转180°、270°识别的场景，增加cls可选项提高识别准确率。