### PR TITLE
fix `cls_x` and `bbox_x` is possibly unbound

### DIFF
--- a/ppocr/modeling/heads/table_master_head.py
+++ b/ppocr/modeling/heads/table_master_head.py
@@ -90,11 +90,13 @@ class TableMasterHead(nn.Layer):
             x = layer(x, feature, src_mask, tgt_mask)
 
         # cls head
+        cls_x = x
         for layer in self.cls_layer:
             cls_x = layer(x, feature, src_mask, tgt_mask)
         cls_x = self.norm(cls_x)
 
         # bbox head
+        bbox_x = x
         for layer in self.bbox_layer:
             bbox_x = layer(x, feature, src_mask, tgt_mask)
         bbox_x = self.norm(bbox_x)


### PR DESCRIPTION
在循环次数为 0 时，`cls_x` 和 `bbox_x` 是不存在的，因此是有风险的，也会导致动转静 PaddleSOT 报错