### PR TITLE
Fix two common PPOCRLabel crash issues on Windows (temporary solution)

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -1422,7 +1422,10 @@ class MainWindow(QMainWindow):
     def scrollRequest(self, delta, orientation):
         units = - delta / (8 * 15)
         bar = self.scrollBars[orientation]
-        bar.setValue(bar.value() + bar.singleStep() * units)
+        # bar.setValue(bar.value() + bar.singleStep() * units)
+        val = bar.value() + bar.singleStep() * units
+        if isinstance(val, float):
+            bar.setValue(int(val))
 
     def setZoom(self, value):
         self.actions.fitWidth.setChecked(False)

--- a/PPOCRLabel/libs/canvas.py
+++ b/PPOCRLabel/libs/canvas.py
@@ -593,8 +593,8 @@ class Canvas(QWidget):
             p.setPen(self.drawingRectColor)
             brush = QBrush(Qt.BDiagPattern)
             p.setBrush(brush)
-            p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
-
+            # p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
+            p.drawRect(int(leftTop.x()), int(leftTop.y()), int(rectWidth), int(rectHeight))
 
         # ADD：
         if (


### PR DESCRIPTION
### PR 类型 PR types
Bug fixes 

### PR 变化内容类型 PR changes
Others

### 描述 Description
解决了PPOCRLabel在运行时的两个闪退问题：

（1）TypeError: setValue(self, a0: int): argument 1 has unexpected type 'float'
解决办法：定位到"xxx/PPOCRLabel/PPOCRLabel.py"第1425行，将：
bar.setValue(bar.value() + bar.singleStep() * units)
修改为：
val = bar.value() + bar.singleStep() * units
if isinstance(val, float):
    bar.setValue(int(val))

（2）drawRect(self, r: QRect): argument 1 has unexpected type 'float'
解决办法：定位到"xxx/PPOCRLabel/libs/canvas.py" 文件中第596行，将：
p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
修改为：
p.drawRect(int(leftTop.x()), int(leftTop.y()), int(rectWidth), int(rectHeight))

### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
