### PR TITLE
Fixed some bugs that caused PPOCRLabel to crash, added ability to expand checkboxes

### DIFF
--- a/PPOCRLabel/libs/canvas.py
+++ b/PPOCRLabel/libs/canvas.py
@@ -232,22 +232,24 @@ class Canvas(QWidget):
                 self.setStatusTip(self.toolTip())
                 self.update()
                 break
-            elif shape.containsPoint(pos):
-                if self.selectedVertex():
-                    self.hShape.highlightClear()
-                self.hVertex, self.hShape = None, shape
-                self.setToolTip(
-                    "Click & drag to move shape '%s'" % shape.label)
-                self.setStatusTip(self.toolTip())
-                self.overrideCursor(CURSOR_GRAB)
-                self.update()
-                break
-        else:  # Nothing found, clear highlights, reset state.
-            if self.hShape:
-                self.hShape.highlightClear()
-                self.update()
-            self.hVertex, self.hShape = None, None
-            self.overrideCursor(CURSOR_DEFAULT)
+            else:
+                for shape in reversed([s for s in self.shapes if self.isVisible(s)]):
+                    if shape.containsPoint(pos):
+                        if self.selectedVertex():
+                            self.hShape.highlightClear()
+                        self.hVertex, self.hShape = None, shape
+                        self.setToolTip(
+                            "Click & drag to move shape '%s'" % shape.label)
+                        self.setStatusTip(self.toolTip())
+                        self.overrideCursor(CURSOR_GRAB)
+                        self.update()
+                        break
+                else:  # Nothing found, clear highlights, reset state.
+                    if self.hShape:
+                        self.hShape.highlightClear()
+                        self.update()
+                    self.hVertex, self.hShape = None, None
+                    self.overrideCursor(CURSOR_DEFAULT)
 
     def mousePressEvent(self, ev):
         pos = self.transformPos(ev.pos())
@@ -593,7 +595,7 @@ class Canvas(QWidget):
             p.setPen(self.drawingRectColor)
             brush = QBrush(Qt.BDiagPattern)
             p.setBrush(brush)
-            p.drawRect(leftTop.x(), leftTop.y(), rectWidth, rectHeight)
+            p.drawRect(int(leftTop.x()), int(leftTop.y()), int(rectWidth), int(rectHeight))
 
 
         # ADD：
@@ -611,8 +613,8 @@ class Canvas(QWidget):
 
         if self.drawing() and not self.prevPoint.isNull() and not self.outOfPixmap(self.prevPoint):
             p.setPen(QColor(0, 0, 0))
-            p.drawLine(int(self.prevPoint.x()), 0, int(self.prevPoint.x()), self.pixmap.height())
-            p.drawLine(0, int(self.prevPoint.y()), self.pixmap.width(), int(self.prevPoint.y()))
+            p.drawLine(int(self.prevPoint.x()), 0, int(self.prevPoint.x()), int(self.pixmap.height()))
+            p.drawLine(0, int(self.prevPoint.y()), int(self.pixmap.width()), int(self.prevPoint.y()))
 
         self.setAutoFillBackground(True)
         if self.verified:

--- a/PPOCRLabel/libs/editinlist.py
+++ b/PPOCRLabel/libs/editinlist.py
@@ -24,6 +24,10 @@ class EditInList(QListWidget):
         pass
 
     def leaveEvent(self, event):
+        pass
+
+    def keyPressEvent(self, event) -> None:
         # close edit
-        for i in range(self.count()):
-            self.closePersistentEditor(self.item(i))
+        if event.key() in [16777220, 16777221]:
+            for i in range(self.count()):
+                self.closePersistentEditor(self.item(i))

--- a/PPOCRLabel/resources/strings/strings-en.properties
+++ b/PPOCRLabel/resources/strings/strings-en.properties
@@ -114,3 +114,5 @@ keyChange=Change Box Key
 TableRecognition=Table Recognition
 cellreRecognition=Cell Re-Recognition
 exportJSON=Export Table Label
+expandBox=Expand Box
+expandBoxDetail=Expand Box

--- a/PPOCRLabel/resources/strings/strings-zh-CN.properties
+++ b/PPOCRLabel/resources/strings/strings-zh-CN.properties
@@ -114,3 +114,5 @@ keyChange=更改Box关键字类别
 TableRecognition=表格识别
 cellreRecognition=单元格重识别
 exportJSON=导出表格标注
+expandBox=扩大框
+expandBoxDetail=扩大所选框

--- a/paddleocr.py
+++ b/paddleocr.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import base64
 from io import BytesIO
 from PIL import Image
+from tools.infer import predict_system
 
 
 def _import_file(module_name, file_path, make_importable=False):

--- a/ppstructure/utility.py
+++ b/ppstructure/utility.py
@@ -227,7 +227,7 @@ def cal_ocr_word_box(rec_str, box, rec_word_info):
         if len(cn_width_list) != 0:
             avg_char_width = np.mean(cn_width_list)
         else:
-g            avg_char_width = (bbox_x_end - bbox_x_start) / len(rec_str)
+            avg_char_width = (bbox_x_end - bbox_x_start) / len(rec_str)
         for center_idx in cn_col_list:
             center_x = (center_idx + 0.5) * cell_width
             cell_x_start = max(int(center_x - avg_char_width / 2),


### PR DESCRIPTION
### PR 类型 PR types
 [ New features | Bug fixes ]
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR 变化内容类型 PR changes
[ Models ]
<!-- One of [ Models | APIs | Docs | Others ] -->

### 描述 Description
1、PPOCRLabel现在支持从中文路径导入图片，原本导入含中文路径的图片会导致崩溃。
2、PPOCRLabel现在支持移动被其他框覆盖的锚点，原本无法移动被覆盖的锚点。
3、修复utility.py中误输入字符导致的语法错误。
4、修复setValue()应输入int，实际输入float导致的类型错误。
5、修复paddleocr中未import predict_system的错误。
6、修复canvas.py中部分输入参数类型错误
7、修复了LabelList不兼容搜狗输入法或win11输入法的问题。原本使用搜狗输入法修改标注数据时，仅输入一个字母就会失去焦点并提交数据变更，导致无法输入完整的汉字。现在将处理逻辑改为失去焦点时仍不提交数据变更，直到切换item或按下enter键才提交。
8、新增扩大选框的功能

1、PPOCRLabel now supports importing images from Chinese paths, originally importing images containing Chinese paths would cause a crash.
2、PPOCRLabel now supports moving anchor points that are covered by other boxes, originally it could not move the covered anchor points.
3、Fix the syntax error caused by mistakenly inputting characters in utility.py.
4、Repair the type error caused by inputting int but float in setValue().
5、Repair the error of not import predict_system in paddleocr.
6、Fix some input parameter type errors in canvas.py.
7、LabelList can't use Sogou Input Method or Win11 Input Method to input text.
8、Add function of expand box.
<!-- Describe what this PR does -->

### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
