### PR TITLE
fix SAR inference, when batch size>1, norm_img_batch and valid_ratios…

### DIFF
--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -584,7 +584,7 @@ class TextRecognizer(object):
                 inputs = [
                     norm_img_batch,
                     np.array(
-                        [valid_ratios], dtype=np.float32),
+                        [valid_ratios], dtype=np.float32).T,
                 ]
                 if self.use_onnx:
                     input_dict = {}


### PR DESCRIPTION
… shapes do not match

### PR 类型 PR types
Bug fixes

### PR 变化内容类型 PR changes
APIs

### 描述 Description
Fix SAR inference bug in tools/infer/predict_rec.py. 
When SAR model inferencing with rec_batch_num size>1, an error occured,
`ValueError: (InvalidArgument) The 0-th dimension of input[0] and input[1] is expected to be equal.But received input[0]'s shape = [1, 1, 512], input[1]'s shape = [16, 30, 512].
  [Hint: Expected inputs_dims[0][j] == inputs_dims[i][j], but received inputs_dims[0][j]:1 != inputs_dims[i][j]:16.] (at /paddle/paddle/phi/kernels/funcs/concat_funcs.h:83)`
It cased by `valid_ratios `'s incorrect shape.This PR aims to fix this bug.

### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
