### PR TITLE
v4 det cml configs

### DIFF
--- a/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
+++ b/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
@@ -9,7 +9,7 @@ Global:
   eval_batch_step:
   - 0
   - 1000
-  cal_metric_during_train: true
+  cal_metric_during_train: false
   checkpoints: null
   pretrained_model: null
   save_inference_dir: null
@@ -27,9 +27,10 @@ Architecture:
       algorithm: DB
       Transform: null
       Backbone:
-        name: PPLCNetNew
+        name: PPLCNetV3
         scale: 0.75
         pretrained: false
+        det: true
       Neck:
         name: RSEFPN
         out_channels: 96
@@ -43,9 +44,10 @@ Architecture:
       algorithm: DB
       Transform: null
       Backbone:
-        name: PPLCNetNew
+        name: PPLCNetV3
         scale: 0.75
         pretrained: true
+        det: true
       Neck:
         name: RSEFPN
         out_channels: 96
@@ -208,7 +210,9 @@ Eval:
         img_mode: BGR
         channel_first: false
     - DetLabelEncode: null
-    - DetResizeForTest: null
+    - DetResizeForTest: 
+        limit_side_len: 960
+        limit_type: max
     - NormalizeImage:
         scale: 1./255.
         mean:

--- a/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
+++ b/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
@@ -9,7 +9,7 @@ Global:
   eval_batch_step:
   - 0
   - 1000
-  cal_metric_during_train: false
+  cal_metric_during_train: true
   checkpoints: null
   pretrained_model: null
   save_inference_dir: null


### PR DESCRIPTION
### PR 类型 PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR 变化内容类型 PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### 描述 Description
<!-- Describe what this PR does -->
1. 修复了找不到模型的问题，原因是PPLCNetNew不在可选模型名称的列表内，将PPLCNetNew改为PPLCNetV3；
2. 修复了db_fpn.py解析in_channels的报错问题，db_fpn.py中按序列解析in_channels，而lcnetv3.py中det为false时输出是数值，为true才返回序列。在两个student模型的backbone中添加"det: true"；
3. 修复了训练过程中eval时的显存溢出问题。通过限制过大的测试数据可解决该问题，具体调整是，在eval→DetResizeForTest的配置中增加"limit_side_len: 960,limit_type: max"。
### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
