### PR TITLE
解決recognition的train test分割程式執行後的文檔每行間多出一行空格

### DIFF
--- a/PPOCRLabel/gen_ocr_train_val_test.py
+++ b/PPOCRLabel/gen_ocr_train_val_test.py
@@ -45,15 +45,15 @@ def splitTrainVal(root, abs_train_root_path, abs_val_root_path, abs_test_root_pa
             if cur_ratio < train_ratio:
                 image_copy_path = os.path.join(abs_train_root_path, image_name)
                 shutil.copy(image_path, image_copy_path)
-                train_txt.write("{}\t{}\n".format(image_copy_path, image_label))
+                train_txt.write("{}\t{}".format(image_copy_path, image_label))
             elif cur_ratio >= train_ratio and cur_ratio < val_ratio:
                 image_copy_path = os.path.join(abs_val_root_path, image_name)
                 shutil.copy(image_path, image_copy_path)
-                val_txt.write("{}\t{}\n".format(image_copy_path, image_label))
+                val_txt.write("{}\t{}".format(image_copy_path, image_label))
             else:
                 image_copy_path = os.path.join(abs_test_root_path, image_name)
                 shutil.copy(image_path, image_copy_path)
-                test_txt.write("{}\t{}\n".format(image_copy_path, image_label))
+                test_txt.write("{}\t{}".format(image_copy_path, image_label))
 
 
 # 删掉存在的文件


### PR DESCRIPTION
使用gen_ocr_train_val_test.py分割recognition data後產生的train.txt、val.txt和test.txt每行label間多出一行空格行(\n)，導致訓練時出現異常，移除換行\n後便可正常運行。

因多出一行空格行，導致以下error。
`[2023/11/21 09:58:27] ppocr ERROR: When parsing line D:\PaddleOCR\train_data\rec\train\FAB06_input_Win 2000_crop_1.jpg l
, error happened with msg: Traceback (most recent call last):
  File "D:\PaddleOCR\ppocr\data\simple_dataset.py", line 252, in __getitem__
    data['ext_data'] = self.get_ext_data()
  File "D:\PaddleOCR\ppocr\data\simple_dataset.py", line 124, in get_ext_data
    label = substr[1]
IndexError: list index out of range`