### PR TITLE
Fix for Ambiguous Boolean Evaluation Error in PaddleOCR with Python 3.11

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -690,7 +690,7 @@ class PaddleOCR(predict_system.TextSystem):
             for idx, img in enumerate(imgs):
                 img = preprocess_image(img)
                 dt_boxes, elapse = self.text_detector(img)
-                if not dt_boxes:
+                if dt_boxes.size == 0:
                     ocr_res.append(None)
                     continue
                 tmp_res = [box.tolist() for box in dt_boxes]


### PR DESCRIPTION
This commit resolves the issue where `dt_boxes` was evaluated as a boolean in Python 3.11, leading to a ValueError. The condition `if not dt_boxes:` is replaced with `if dt_boxes.size == 0:` to explicitly check for an empty array, ensuring compatibility with Python 3.11 and maintaining the intended functionality.

### PR 类型 PR types
Bug Fixes

### PR 变化内容类型 PR changes
Others

### 描述 Description
#### Issue:
When using PaddleOCR in a Python 3.11 environment, an error is encountered during text detection only mode (`det=True, rec=False`). The error arises from the evaluation of `dt_boxes` as a boolean condition in an `if not dt_boxes:` statement. This behavior leads to a `ValueError` due to the ambiguous boolean evaluation of a NumPy array with more than one element. 

#### Python Version Affected:
Python 3.11

#### Error Message:
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

#### Proposed Solution:
The issue can be resolved by modifying the conditional check for `dt_boxes`. Instead of using `if not dt_boxes:`, it is recommended to check if the array is empty by evaluating its size.

#### Suggested Change:
In the file where the error occurs, replace the following line:

```python
if not dt_boxes:
    ocr_res.append(None)
    continue
```

with:

```python
if dt_boxes.size == 0:
    ocr_res.append(None)
    continue
```

#### Rationale:
Using `dt_boxes.size == 0` provides a clear and unambiguous method to check if `dt_boxes` is empty. This change ensures compatibility across different Python versions, particularly with the stricter boolean evaluation in Python 3.11.

### Impact:
This change will prevent the `ValueError` and ensure that the text detection functionality of PaddleOCR works as intended in Python 3.11 environments.


### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
