### PR TITLE
fix(PPOCRLabel): fix null

### DIFF
--- a/PPOCRLabel/PPOCRLabel.py
+++ b/PPOCRLabel/PPOCRLabel.py
@@ -2469,6 +2469,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace('false', 'False')
                         label = label.replace('true', 'True')
+                        label = label.replace('null', 'None')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []


### PR DESCRIPTION
### PR 类型 PR types

Bug fixes

### PR 变化内容类型 PR changes

PPOCRLabel

### 描述 Description

当 label 的值为 null 时，会异常。示例如下：

![image](https://github.com/PaddlePaddle/PaddleOCR/assets/14297703/4271cfb0-f312-41a8-9bec-e50e510cc712)

![image](https://github.com/PaddlePaddle/PaddleOCR/assets/14297703/c21074e4-4735-473d-88f7-e41634cac69c)

### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
