### PR TITLE
Fix QPointF IndexError: list index out of range

### DIFF
--- a/PPOCRLabel/libs/shape.py
+++ b/PPOCRLabel/libs/shape.py
@@ -18,6 +18,7 @@ import sys
 from PyQt5.QtCore import QPointF
 from PyQt5.QtGui import QColor, QPen, QPainterPath, QFont
 from libs.utils import distance
+from ppocr.utils.logging import get_logger
 
 DEFAULT_LINE_COLOR = QColor(0, 255, 0, 128)
 DEFAULT_FILL_COLOR = QColor(255, 0, 0, 128)
@@ -97,6 +98,10 @@ class Shape(object):
                               (self.points[0].y() + self.points[2].y()) / 2)
         except:
             self.center = None
+            logger = get_logger()
+            logger.warning(
+               'The XY coordinates of QPointF are not detectable!'
+            )
         self._closed = True
 
     def reachMaxPoints(self):

--- a/PPOCRLabel/libs/shape.py
+++ b/PPOCRLabel/libs/shape.py
@@ -92,8 +92,11 @@ class Shape(object):
         return pRes
 
     def close(self):
-        self.center = QPointF((self.points[0].x() + self.points[2].x()) / 2,
+        try:
+            self.center = QPointF((self.points[0].x() + self.points[2].x()) / 2,
                               (self.points[0].y() + self.points[2].y()) / 2)
+        except:
+            self.center = None
         self._closed = True
 
     def reachMaxPoints(self):


### PR DESCRIPTION
当QPointF 获取异常时，self.center  赋予默认值

### PR 类型 PR types
Bug fixes 

### PR 变化内容类型 PR changes
Others

### 描述 Description
操作矩形绘制时，有机会导致异常退出。增加异常处理机制。

异常信息：
”PPOCRLabel\libs\shape.py", line 95, in close
self.center = QPointF((self.points[0].x() + self.points[2].x()) / 2,
IndexError: list index out of range

### 提PR之前的检查 Check-list

- [ √ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [ √ ] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [ √ ] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
