### PR TITLE
fix: layout recovery image:xxx.png,err msg: list index out of range

### DIFF
--- a/ppstructure/recovery/table_process.py
+++ b/ppstructure/recovery/table_process.py
@@ -253,18 +253,18 @@ class HtmlToDocx(HTMLParser):
             cols = get_table_columns(row)
             cell_col = 0
             for col in cols:
+                if cell_col >= cols_len:
+                    break
+
                 colspan = int(col.attrs.get('colspan', 1))
                 rowspan = int(col.attrs.get('rowspan', 1))
-
                 cell_html = get_cell_html(col)
                 if col.name == 'th':
                     cell_html = "<b>%s</b>" % cell_html
 
                 docx_cell = table.cell(cell_row, cell_col)
-
-                while docx_cell.text != '':  # Skip the merged cell
-                    cell_col += 1
-                    docx_cell = table.cell(cell_row, cell_col)
+                if (cell_col + colspan -1) >= cols_len:
+                    colspan -= 1
 
                 cell_to_merge = table.cell(cell_row + rowspan - 1,
                                            cell_col + colspan - 1)


### PR DESCRIPTION
### PR 类型 PR types
fix #10649

### PR 变化内容类型 PR changes
Others

### 描述 Description
版面恢复时，对表格的html取到的列大于表格总列数的情况进行处理

### 提PR之前的检查 Check-list

- [ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [ ] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [ ] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
