### PR TITLE
fix AttributeError

### DIFF
--- a/StyleText/engine/text_drawers.py
+++ b/StyleText/engine/text_drawers.py
@@ -58,7 +58,7 @@ class StdTextDrawer(object):
             i = 0
             while i < len(corpus):
                 char_i = corpus[i]
-                char_size = font.getsize(char_i)[0]
+                char_size = font.getbbox(char_i)[2]
                 # split when char_x exceeds char size and index is not 0 (at least 1 char should be wroten on the image)
                 if char_x + char_size >= width and i != 0:
                     text_input = np.array(bg).astype(np.uint8)


### PR DESCRIPTION
### PR 类型 PR types
Bug fixes

### PR 变化内容类型 PR changes
Others

### 描述 Description
<!-- Describe what this PR does -->

`getsize` is deprecated and will be removed in Pillow 10 (2023-07-01). Use `getbbox` or `getlength` instead.

```shell
cd StyleText
python tools/synth_dataset.py -c configs/dataset_config.yml
```

```
AttributeError: 'FreeTypeFont' object has no attribute 'getsize'
```
### 提PR之前的检查 Check-list

- [ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be convered by current tests or already test locally by you.
