### PR TITLE
fix dataset problems release 2.7

### DIFF
--- a/ppocr/modeling/necks/db_fpn.py
+++ b/ppocr/modeling/necks/db_fpn.py
@@ -29,7 +29,7 @@ sys.path.append(__dir__)
 sys.path.insert(0, os.path.abspath(os.path.join(__dir__, '../../..')))
 
 from ppocr.modeling.backbones.det_mobilenet_v3 import SEModule
-
+import numbers
 
 class DSConv(nn.Layer):
     def __init__(self,
@@ -237,6 +237,10 @@ class RSEFPN(nn.Layer):
             self.incl3 = IntraCLBlock(self.out_channels // 4, reduce_factor=2)
             self.incl4 = IntraCLBlock(self.out_channels // 4, reduce_factor=2)
 
+        # TODO (yiakwy) : modify
+        if isinstance(in_channels, numbers.Number):
+            in_channels = [in_channels]
+            
         for i in range(len(in_channels)):
             self.ins_conv.append(
                 RSELayer(

--- a/ppocr/modeling/necks/db_fpn.py
+++ b/ppocr/modeling/necks/db_fpn.py
@@ -237,7 +237,6 @@ class RSEFPN(nn.Layer):
             self.incl3 = IntraCLBlock(self.out_channels // 4, reduce_factor=2)
             self.incl4 = IntraCLBlock(self.out_channels // 4, reduce_factor=2)
 
-        # TODO (yiakwy) : modify
         if isinstance(in_channels, numbers.Number):
             in_channels = [in_channels]
             
@@ -309,6 +308,9 @@ class LKPAN(nn.Layer):
             raise ValueError(
                 "mode can only be one of ['lite', 'large'], but received {}".
                 format(mode))
+
+        if isinstance(in_channels, numbers.Number):
+            in_channels = [in_channels]
 
         for i in range(len(in_channels)):
             self.ins_conv.append(

--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -75,6 +75,9 @@ def maybe_download_params(model_path):
     else:
         url = model_path
     tmp_path = os.path.join(MODELS_DIR, url.split('/')[-1])
+    if os.path.exists(tmp_path) and os.path.isfile(tmp_path):
+        print(f'[network::maybe_download_params] models has been downloaded to {tmp_path}')
+        return tmp_path
     print('download {} to {}'.format(url, tmp_path))
     os.makedirs(MODELS_DIR, exist_ok=True)
     download_with_progressbar(url, tmp_path)


### PR DESCRIPTION
### PR 类型 PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR 变化内容类型 PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Dataset, preprocessing :

- remove duplicated data loads of simple dataset
- handling detection task for CTW dataset where annotation polyline data contains more than 4 points (otherwise, resulting forever loop in dataset)
- handling inChannels scalars 
- fasten data loading
- improve model loading

### 描述 Description
<!-- Describe what this PR does -->
improve codes stability and fix bugs when training with cn_PP_OCR_v4 detection model.

I identified failures of dataset infinite loading problem when reproducing a OCR dec in local env. My team is using this model to generate high quality data for Multi-Modal LLM. After this fix , dec can be trained very quickly for a few epochs :

<img width="970" alt="截屏2024-02-29 15 09 45" src="https://github.com/PaddlePaddle/PaddleOCR/assets/89890040/2fd19733-51b3-43c5-b936-b3fb0876e8ad">

**SimpleDataset forever loop** : 

> for dataset such as **ctw1500**, each annotation of points of which contains more than 4 points to detect location of arbitrary text in the image. The points may be of the shape **[2\/*the number of annotation in this image\*/, 14\/*number of points\*/, 2\/*2d coordinates\*/]**.

The utility function should also be adapted to process the annotation data instead of throwing them away or raising an exception.

Note by default, "CopyPaste" for **imgaug** method is chosen. That means arbitrary of two images are selected and paired. However get_ext_data always read a new image from the dataset, which is very inefficient.

### 提PR之前的检查 Check-list

- [ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be covered by existing tests or locally verified. 
