### PR TITLE
lazy import PyMuPDF

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -107,7 +107,8 @@ def check_and_read(img_path):
         imgvalue = frame[:, :, ::-1]
         return imgvalue, True, False
     elif os.path.basename(img_path)[-3:].lower() == 'pdf':
-        import fitz
+        from paddle.utils import try_import
+        try_import('fitz')
         from PIL import Image
         imgs = []
         with fitz.open(img_path) as pdf:

--- a/ppstructure/pdf2word/pdf2word.py
+++ b/ppstructure/pdf2word/pdf2word.py
@@ -22,6 +22,8 @@ import cv2
 import platform
 import numpy as np
 import fitz
+from paddle.utils import try_import
+try_import('fitz')
 from PIL import Image
 from pdf2docx.converter import Converter
 from qtpy.QtWidgets import QApplication, QWidget, QPushButton, QProgressBar, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,5 @@ lxml
 premailer
 openpyxl
 attrdict
-PyMuPDF<1.21.0
 Pillow>=10.0.0
 pyyaml


### PR DESCRIPTION
To address the compatibility issues caused by PyMuPDF dependency. 
- license compatibility: #11634, ##8873 
- env compatibility: #11119,#7934, #11662 
- and you can see more discussions by searing PyMuPDF in issues.

This pull request proposes a lazy import for PyMuPDF. This means:

- No PyMuPDF dependency: PyMuPDF will be removed from the requirements.txt file.
- Error handling: An informative error message will guide the user to install PyMuPDF if it's not already present in their environment. This error will only occur when PyMuPDF functionality is actually required.

Additionally, if this PR is accepted, the following actions will be necessary:

- Release a new version of PaddleOCR.
- Update relevant documentation within this repository.

I've used `addle.util.try_import` in the implementation, we can also discuss on this implementation.


### PR 类型 PR types
Others

### PR 变化内容类型 PR changes
Others

### 描述 Description
see above

### 提PR之前的检查 Check-list

- [ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [ ] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [ ] 这个PR已经经过本地测试。This PR can be covered by existing tests or locally verified. 
