### PR TITLE
setup a workflow for publishing package to pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,41 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        pip install setuptools
+        pip install wheel
+    - name: Build package
+      run: python setup.py bdist_wheel
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/paddleocr.py
+++ b/paddleocr.py
@@ -61,7 +61,7 @@ __all__ = [
 ]
 
 SUPPORT_DET_MODEL = ['DB']
-VERSION = '2.7.0.2'
+VERSION = '2.8.0'
 SUPPORT_REC_MODEL = ['CRNN', 'SVTR_LCNet']
 BASE_DIR = os.path.expanduser("~/.paddleocr/")
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,14 @@
 
 from setuptools import setup
 from io import open
-from paddleocr import VERSION
+import sys
+import subprocess
+
+# get version by matchiing, so will not need to setup complex env in github aciton
+p = subprocess.Popen("grep ^VERSION ./paddleocr.py | cut -d\\' -f 2", stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, shell=True)
+raw_VERSION, _ = p.communicate()
+VERSION = raw_VERSION.decode().strip()
 
 def load_requirements(file_list=None):
     if file_list is None:


### PR DESCRIPTION
this is cherry-pick of recent commits: c306d288 8a99bc93 d28d9e70 89e0a15c landed in release/2.7 branch. In the future, when we create a release, we can use .github/workflows/python-publish.yml to publish package automatically to pypi. 

Some thing we can improve:
- use a pyproject.toml file in this project, which is the recommended way for python packaging, see details here: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/. By doing so, we can use `python -m build` to build and package this project, which is more modern way for python packaging.

- dynamic versioning, get version of this package by using `paddleocr.VERSION` requires complex env setup (see paddleocr.py), we may need a better mechanism for doing this. To avoid changing paddleocr.py, a trick is used in setup.py. 

P.S.: to use github action for pypi package uploading, a repository secret is installed. (https://github.com/PaddlePaddle/PaddleOCR/settings/secrets/actions, repository admin privilege is required).
