### PR TITLE
fix: Correct misuse of `try_import` from `paddle.utils`

### DIFF
--- a/ppocr/utils/utility.py
+++ b/ppocr/utils/utility.py
@@ -120,7 +120,7 @@ def check_and_read(img_path):
     elif os.path.basename(img_path)[-3:].lower() == "pdf":
         from paddle.utils import try_import
 
-        try_import("fitz")
+        fitz = try_import("fitz")
         from PIL import Image
 
         imgs = []

--- a/ppstructure/pdf2word/pdf2word.py
+++ b/ppstructure/pdf2word/pdf2word.py
@@ -21,10 +21,9 @@ import functools
 import cv2
 import platform
 import numpy as np
-import fitz
 from paddle.utils import try_import
 
-try_import("fitz")
+fitz = try_import("fitz")
 from PIL import Image
 from pdf2docx.converter import Converter
 from qtpy.QtWidgets import (


### PR DESCRIPTION
### PR 类型 PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR 变化内容类型 PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### 描述 Description

This pull request addresses the incorrect usage of the `try_import` function from `paddle.utils` in both `ppocr/utils/utility.py` and `ppstructure/pdf2word/pdf2word.py` (#11808).

此 PR 解决了 `ppocr/utils/utility.py` 与 `ppstructure/pdf2word/pdf2word.py` 中误用 `paddle.utils` 中的 `try_import` 函数的问题（#11808）。

### 提PR之前的检查 Check-list

- [x] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [ ] 这个PR已经经过本地测试。This PR can be covered by existing tests or locally verified. 
