### PR TITLE
Fix the error of token_list formatting only taking the first digit when the number of cells across rows or columns is greater than 10.

### DIFF
--- a/PPOCRLabel/libs/utils.py
+++ b/PPOCRLabel/libs/utils.py
@@ -209,10 +209,10 @@ def convert_token(html_list):
                 token_list.append("<td")
                 if 'colspan' in col:
                     _, n = col.split('colspan=')
-                    token_list.append(" colspan=\"{}\"".format(n[0]))
+                    token_list.append(" colspan=\"{}\"".format(str(int(n))))
                 if 'rowspan' in col:
                     _, n = col.split('rowspan=')
-                    token_list.append(" rowspan=\"{}\"".format(n[0]))
+                    token_list.append(" rowspan=\"{}\"".format(str(int(n))))
                 token_list.extend([">", "</td>"])
         token_list.append("</tr>")
     token_list.append("</tbody>")


### PR DESCRIPTION
### PR 类型 PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR 变化内容类型 PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
PPOCRLabel/libs/utils.py 文件中
### 描述 Description
<!-- Describe what this PR does -->
在PPOCRLabel/libs/utils.py文件中，convert_token函数，会将HTML格式转换为标签。有如下代码：
```
if 'colspan' in col:
    _, n = col.split('colspan=')
    token_list.append(" colspan=\"{}\"".format(n[0]))
if 'rowspan' in col:
    _, n = col.split('rowspan=')
    token_list.append(" rowspan=\"{}\"".format(n[0]))
```
这里对HTML格式中跨行或者跨列单元格的格式进行format。在实际应用中，会存在一些比较极端的例子，比如某个单元格合并超过10行或者10列。因此只对n的第一位进行取值，显然不正确。如下边的例子：
![image](https://github.com/PaddlePaddle/PaddleOCR/assets/47658498/3e9d51c9-4172-498c-9daa-74b2454c68eb)
因此，将代码修改为下面形式，即可解决问题，并且在实际使用中没有发现问题
```
if 'colspan' in col:
    _, n = col.split('colspan=')
    token_list.append(" colspan=\"{}\"".format(str(int(n))))
if 'rowspan' in col:
    _, n = col.split('rowspan=')
    token_list.append(" rowspan=\"{}\"".format(str(int(n))))
```
### 提PR之前的检查 Check-list

- [ ] 这个 PR 是提交到dygraph分支或者是一个cherry-pick，否则请先提交到dygarph分支。
      This PR is pushed to the dygraph branch or cherry-picked from the dygraph branch. Otherwise, please push your changes to the dygraph branch.
- [x] 这个PR清楚描述了功能，帮助评审能提升效率。This PR have fully described what it does such that reviewers can speedup.
- [x] 这个PR已经经过本地测试。This PR can be covered by existing tests or locally verified. 
