### PR TITLE
handle contour with zero area exceptions

### DIFF
--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -87,7 +87,9 @@ class DBPostProcess(object):
             else:
                 continue
             box = box.reshape(-1, 2)
-
+            if len(box) == 0:
+                continue
+                
             _, sside = self.get_mini_boxes(box.reshape((-1, 1, 2)))
             if sside < self.min_size + 2:
                 continue


### PR DESCRIPTION
In case the contour is very small (like a single pixel contour), it will make a line instead of polygonal detection region. Thus, when creating polygon from that contour, the area of the polygon (and thus distance) will be zero, resulting in an empty box. This results the following error during minimum area calculation:
```
bounding_box = cv2.minAreaRect(contour)
cv2.error: OpenCV(4.6.0) D:\a\opencv-python\opencv-python\opencv\modules\imgproc\src\convhull.cpp:143: error: (-215:Assertion failed) total >= 0 && (depth == CV_32F || depth == CV_32S) in function 'cv::convexHull'
```

This error was found specifically with `det_box_type='poly'`, but it may also occur in the case of `det_box_type='quad'`. Here is the figure to replicate the error.
![poly_zero_area](https://github.com/PaddlePaddle/PaddleOCR/assets/37138338/d4be89fc-13e4-448d-a614-20cb8a037ad5)
 
For privacy reasons, I have to erase few areas in this image. The erroneous detection region coordinates are:
`[[909 353], [908 353], [907 352], [906 352], [905 353], [901 353], [901 354], [902 353], [907 353], [908 354]]`

The contour made by these coordinates is shown below (by red line).
![image_with_polygons](https://github.com/PaddlePaddle/PaddleOCR/assets/37138338/5676584b-59dd-496e-96e3-dc8db9bc4f70)
