### PR TITLE
Added some information about quickstart

### DIFF
--- a/doc/doc_ch/quickstart.md
+++ b/doc/doc_ch/quickstart.md
@@ -40,10 +40,11 @@
 ### 1.2 安装PaddleOCR whl包
 
 ```bash
-pip install "paddleocr>=2.0.1" # 推荐使用2.0.1+版本
+pip install "paddleocr>=2.0.1" # 推荐使用2.0.1+版本,包含PP-OCRv3、PP-OCRv2、PP-OCR
 ```
 
 - 对于Windows环境用户：直接通过pip安装的shapely库可能出现`[winRrror 126] 找不到指定模块的问题`。建议从[这里](https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely)下载shapely安装包完成安装。
+- 对于需要使用PP-OCRv4版本的用户，请尝试安装最新版本。
 
 
 <a name="2"></a>
@@ -107,7 +108,8 @@ cd /path/to/ppocr_img
   ```
 
 **版本说明**
-paddleocr默认使用PP-OCRv4模型(`--ocr_version PP-OCRv4`)，如需使用其他版本可通过设置参数`--ocr_version`，具体版本说明如下：
+paddleocr默认使用PP-OCRv4模型(`--ocr_version PP-OCRv4`)，如需使用其他版本可通过设置参数`--ocr_version`。注意：如果使用的是"paddleocr=2.0.1"版本，不包含PP-OCRv4，请尝试更新paddleocr。
+具体版本说明如下：
 |  版本名称  |  版本说明 |
 |    ---    |   ---   |
 | PP-OCRv4 | 支持中、英文检测和识别，方向分类器，支持多语种识别 |

--- a/doc/doc_en/quickstart_en.md
+++ b/doc/doc_en/quickstart_en.md
@@ -44,12 +44,13 @@ For more software version requirements, please refer to the instructions in [Ins
 ### 1.2 Install PaddleOCR Whl Package
 
 ```bash
-pip install "paddleocr>=2.0.1" # Recommend to use version 2.0.1+
+pip install "paddleocr>=2.0.1" # Recommend to use version 2.0.1+,contain PP-OCRv3、PP-OCRv2、PP-OCR
 ```
 
 - **For windows users:** If you getting this error `OSError: [WinError 126] The specified module could not be found` when you install shapely on windows. Please try to download Shapely whl file [here](http://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely).
 
   Reference: [Solve shapely installation on windows](https://stackoverflow.com/questions/44398265/install-shapely-oserror-winerror-126-the-specified-module-could-not-be-found)
+- For users who need to use PP-OCRv4, try installing the latest version.
 
 <a name="2-easy-to-use"></a>
 
@@ -120,7 +121,8 @@ If you do not use the provided test image, you can replace the following `--imag
   ```
 
 **Version**
-paddleocr uses the PP-OCRv4 model by default(`--ocr_version PP-OCRv4`). If you want to use other versions, you can set the parameter `--ocr_version`, the specific version description is as follows:
+paddleocr uses the PP-OCRv4 model by default(`--ocr_version PP-OCRv4`). If you want to use other versions, you can set the parameter `--ocr_version`, Note: If you are using the "paddleocr=2.0.1" version, which does not include PP-OCRv4, try updating paddleocr.
+the specific version description is as follows:
 |  version name |  description |
 |    ---    |   ---   |
 | PP-OCRv4 | support Chinese and English detection and recognition, direction classifier, support multilingual recognition |


### PR DESCRIPTION
默认的pip install "paddleocr>=2.0.1"在windows平台下，会下载paddleocr=2.0.1，然而，在2.0.1版本中不包含PP-OCRv4，所以调整了部分表述，减少初学者的疑惑。
修改范围包含中文和英文版本的 quickstart.md

Default pip install "paddleocr>=2.0.1" in windows, paddleocr=2.0.1 will be downloaded, however, PP-OCRv4 is not included in the 2.0.1 version, so some of the expressions are adjusted to reduce the confusion of beginners.
The modification scope includes the Chinese and English versions of quickstart.md
