### PR TITLE
Save detection inference logs to file

### DIFF
--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -32,11 +32,9 @@ from ppocr.data import create_operators, transform
 from ppocr.postprocess import build_post_process
 import json
 
-logger = get_logger()
-
 
 class TextDetector(object):
-    def __init__(self, args):
+    def __init__(self, args, logger):
         self.args = args
         self.det_algorithm = args.det_algorithm
         self.use_onnx = args.use_onnx
@@ -158,7 +156,7 @@ class TextDetector(object):
                 model_precision=args.precision,
                 batch_size=1,
                 data_shape="dynamic",
-                save_path=None,
+                save_path=None,     # not used if logger is not None
                 inference_config=self.config,
                 pids=pid,
                 process_name=None,
@@ -383,10 +381,18 @@ class TextDetector(object):
 if __name__ == "__main__":
     args = utility.parse_args()
     image_file_list = get_image_file_list(args.image_dir)
-    text_detector = TextDetector(args)
     total_time = 0
     draw_img_save_dir = args.draw_img_save_dir
     os.makedirs(draw_img_save_dir, exist_ok=True)
+    
+    # logger
+    log_file = args.save_log_path
+    if os.path.isdir(args.save_log_path):
+        log_file = os.path.join(log_file, "benchmark_detection.log")
+    logger = get_logger(log_file=log_file)
+
+    # create text detector
+    text_detector = TextDetector(args, logger)
 
     if args.warmup:
         img = np.random.uniform(0, 255, [640, 640, 3]).astype(np.uint8)

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -156,7 +156,7 @@ class TextDetector(object):
                 model_precision=args.precision,
                 batch_size=1,
                 data_shape="dynamic",
-                save_path=None,     # not used if logger is not None
+                save_path=None,  # not used if logger is not None
                 inference_config=self.config,
                 pids=pid,
                 process_name=None,
@@ -384,10 +384,12 @@ if __name__ == "__main__":
     total_time = 0
     draw_img_save_dir = args.draw_img_save_dir
     os.makedirs(draw_img_save_dir, exist_ok=True)
-    
+
     # logger
     log_file = args.save_log_path
-    if os.path.isdir(args.save_log_path) or (not os.path.exists(args.save_log_path) and args.save_log_path.endswith("/")):
+    if os.path.isdir(args.save_log_path) or (
+        not os.path.exists(args.save_log_path) and args.save_log_path.endswith("/")
+    ):
         log_file = os.path.join(log_file, "benchmark_detection.log")
     logger = get_logger(log_file=log_file)
 

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -387,7 +387,7 @@ if __name__ == "__main__":
     
     # logger
     log_file = args.save_log_path
-    if os.path.isdir(args.save_log_path):
+    if os.path.isdir(args.save_log_path) or (not os.path.exists(args.save_log_path) and args.save_log_path.endswith("/")):
         log_file = os.path.join(log_file, "benchmark_detection.log")
     logger = get_logger(log_file=log_file)
 

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -34,7 +34,9 @@ import json
 
 
 class TextDetector(object):
-    def __init__(self, args, logger):
+    def __init__(self, args, logger=None):
+        if logger is None:
+            logger = get_logger()
         self.args = args
         self.det_algorithm = args.det_algorithm
         self.use_onnx = args.use_onnx


### PR DESCRIPTION
I added the possibility to save the detection logs to file.

The code was almost all there already, just some arguments weren't passed the right way in order to save the detection logs to file.

In case, we could also implement this feature for the other scripts in `tools/infer/`.