### PR TITLE
Error with pyclipper inhomogeneous expanded array

### DIFF
--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -142,7 +142,7 @@ class DBPostProcess(object):
 
             box = self.unclip(points, self.unclip_ratio)
             if len(box) > 1:
-                    continue
+                continue
             box = np.array(box).reshape(-1, 1, 2)
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:

--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -89,7 +89,9 @@ class DBPostProcess(object):
                     continue
             else:
                 continue
-            box = box.reshape(-1, 2)
+            box = np.array(box).reshape(-1, 2)
+            if len(box) == 0:
+                continue
 
             _, sside = self.get_mini_boxes(box.reshape((-1, 1, 2)))
             if sside < self.min_size + 2:
@@ -142,7 +144,7 @@ class DBPostProcess(object):
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue
-            box = np.array(box).array(box)
+            box = box.array(box)
 
             box[:, 0] = np.clip(np.round(box[:, 0] / width * dest_width), 0, dest_width)
             box[:, 1] = np.clip(

--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -144,7 +144,7 @@ class DBPostProcess(object):
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue
-            box = box.array(box)
+            box = np.array(box)
 
             box[:, 0] = np.clip(np.round(box[:, 0] / width * dest_width), 0, dest_width)
             box[:, 1] = np.clip(

--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -142,7 +142,7 @@ class DBPostProcess(object):
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue
-            box = np.array(box)
+            box = np.array(box).array(box)
 
             box[:, 0] = np.clip(np.round(box[:, 0] / width * dest_width), 0, dest_width)
             box[:, 1] = np.clip(
@@ -157,7 +157,7 @@ class DBPostProcess(object):
         distance = poly.area * unclip_ratio / poly.length
         offset = pyclipper.PyclipperOffset()
         offset.AddPath(box, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
-        expanded = np.array(offset.Execute(distance))
+        expanded = offset.Execute(distance)
         return expanded
 
     def get_mini_boxes(self, contour):

--- a/ppocr/postprocess/db_postprocess.py
+++ b/ppocr/postprocess/db_postprocess.py
@@ -140,7 +140,10 @@ class DBPostProcess(object):
             if self.box_thresh > score:
                 continue
 
-            box = self.unclip(points, self.unclip_ratio).reshape(-1, 1, 2)
+            box = self.unclip(points, self.unclip_ratio)
+            if len(box) > 1:
+                    continue
+            box = np.array(box).reshape(-1, 1, 2)
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -178,7 +178,15 @@ class TextDetector(object):
         rect[1] = tmp[np.argmin(diff)]
         rect[3] = tmp[np.argmax(diff)]
         return rect
-
+        
+    def pad_polygons(self, polygon, max_points):
+        padding_size = max_points - len(polygon)
+        if padding_size == 0:
+            return polygon
+        last_point = polygon[-1]
+        padding = np.repeat([last_point], padding_size, axis=0)
+        return np.vstack([polygon, padding])
+        
     def clip_det_res(self, points, img_height, img_width):
         for pno in range(points.shape[0]):
             points[pno, 0] = int(min(max(points[pno, 0], 0), img_width - 1))
@@ -209,6 +217,11 @@ class TextDetector(object):
                 box = np.array(box)
             box = self.clip_det_res(box, img_height, img_width)
             dt_boxes_new.append(box)
+            
+        if len(dt_boxes_new) > 0:
+            max_points = max(len(polygon) for polygon in dt_boxes_new)
+            dt_boxes_new = [self.pad_polygons(polygon, max_points) for polygon in dt_boxes_new]
+            
         dt_boxes = np.array(dt_boxes_new)
         return dt_boxes
 

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -178,7 +178,7 @@ class TextDetector(object):
         rect[1] = tmp[np.argmin(diff)]
         rect[3] = tmp[np.argmax(diff)]
         return rect
-        
+
     def pad_polygons(self, polygon, max_points):
         padding_size = max_points - len(polygon)
         if padding_size == 0:
@@ -186,7 +186,7 @@ class TextDetector(object):
         last_point = polygon[-1]
         padding = np.repeat([last_point], padding_size, axis=0)
         return np.vstack([polygon, padding])
-        
+
     def clip_det_res(self, points, img_height, img_width):
         for pno in range(points.shape[0]):
             points[pno, 0] = int(min(max(points[pno, 0], 0), img_width - 1))
@@ -217,11 +217,13 @@ class TextDetector(object):
                 box = np.array(box)
             box = self.clip_det_res(box, img_height, img_width)
             dt_boxes_new.append(box)
-            
+
         if len(dt_boxes_new) > 0:
             max_points = max(len(polygon) for polygon in dt_boxes_new)
-            dt_boxes_new = [self.pad_polygons(polygon, max_points) for polygon in dt_boxes_new]
-            
+            dt_boxes_new = [
+                self.pad_polygons(polygon, max_points) for polygon in dt_boxes_new
+            ]
+
         dt_boxes = np.array(dt_boxes_new)
         return dt_boxes
 


### PR DESCRIPTION
In case of ` det_box_type='poly'`, for some images, `np.array(offset.Execute(distance))` can result in inhomogeneous part of the detection box list, which cannot be casted into numpy array directly. Due to this the following error occurs:
```
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\paddleocr.py", line 670, in ocr
    dt_boxes, rec_res, _ = self.__call__(img, max_dt_boxes, cls)
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\tools\infer\predict_system.py", line 76, in __call__
    dt_boxes, elapse = self.text_detector(binarize_img(img))
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\tools\infer\predict_det.py", line 318, in __call__
    post_result = self.postprocess_op(preds, shape_list)
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\ppocr\postprocess\db_postprocess.py", line 239, in __call__
    boxes, scores = self.polygons_from_bitmap(pred[batch_index],
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\ppocr\postprocess\db_postprocess.py", line 84, in polygons_from_bitmap
    box = self.unclip(points, self.unclip_ratio)
  File "C:\Users\ekser\OneDrive\Documents\OCR\cwat-integrator\venv_new\lib\site-packages\paddleocr\ppocr\postprocess\db_postprocess.py", line 159, in unclip
    return np.array(expanded)
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```
This is because the `expanded` list from `pyclipper`'s `offset.Execute` is an inhomogeneous list. For example, in the case of the following image:
![image_8](https://github.com/PaddlePaddle/PaddleOCR/assets/37138338/41fab9c6-9476-4eb9-a23b-44e55772fd89)

the `expanded` list (before converting to numpy array) is as follows:
`[[[47, 79], [45, 79], [46, 78]], [[56, 78], [58, 78], [59, 79], [55, 79]]]` which is an inhomogeneous list and cannot be cast directly to the numpy array. Such `expanded` lists generally represent the detections with very small area thus resembling lines instead of polygons. Thus, it is better to eliminate such detections.