### PR TITLE
【OCR Issue No.2】修复训练过程中找不到對應模型和训练时计算精度报错

### DIFF
--- a/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
+++ b/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml
@@ -9,7 +9,7 @@ Global:
   eval_batch_step:
   - 0
   - 1000
-  cal_metric_during_train: true
+  cal_metric_during_train: false
   checkpoints: null
   pretrained_model: null
   save_inference_dir: null


### PR DESCRIPTION
#10685
            
修复训练过程中找不到對應模型和训练时计算精度报错
模型名称有出入
PaddleOCR用的是PPLCNetV3而非PPLCNetNewV3
解决方案：
在Backbone下把PPLCNetNew改成PPLCNetV3，在添加一行det: true
![image](https://github.com/PaddlePaddle/PaddleOCR/assets/102272920/6cb2986e-2df1-4c2b-a2ed-05316ff3bbde)
训练时计算精度报错
发现shappe_list是一个 batch_size * 640(height) *640(width) 的数组， 显然下标访问后取值无法返回src_h, src_w, ratio_h, ratio_w
解决方案：
set: cal_metric_during_train: false可直接运行
...