### PR TITLE
fix the issue of repeatedly downloading pretrained model

### DIFF
--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -24,6 +24,8 @@ MODELS_DIR = os.path.expanduser("~/.paddleocr/models/")
 
 
 def download_with_progressbar(url, save_path):
+    if save_path and os.path.exists(save_path):
+        return
     logger = get_logger()
     response = requests.get(url, stream=True)
     if response.status_code == 200:

--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -24,9 +24,10 @@ MODELS_DIR = os.path.expanduser("~/.paddleocr/models/")
 
 
 def download_with_progressbar(url, save_path):
-    if save_path and os.path.exists(save_path):
-        return
     logger = get_logger()
+    if save_path and os.path.exists(save_path):
+        logger.info(f"Path {save_path} already exists. Skipping...")
+        return
     response = requests.get(url, stream=True)
     if response.status_code == 200:
         total_size_in_bytes = int(response.headers.get("content-length", 1))


### PR DESCRIPTION
当配置文件中指定了 `pretrained`，每次训练时都会重复下载模型，而不是先检查是否存在此模型。

https://github.com/PaddlePaddle/PaddleOCR/blob/960243862f6c6833f58e39f3b74864cba15edfeb/configs/det/ch_PP-OCRv4/ch_PP-OCRv4_det_cml.yml#L58-L60