### PR TITLE
fix the error of `np.int`

### DIFF
--- a/benchmark/PaddleOCR_DBNet/post_processing/seg_detector_representer.py
+++ b/benchmark/PaddleOCR_DBNet/post_processing/seg_detector_representer.py
@@ -179,10 +179,10 @@ class SegDetectorRepresenter:
     def box_score_fast(self, bitmap, _box):
         h, w = bitmap.shape[:2]
         box = _box.copy()
-        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int), 0, w - 1)
-        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int), 0, w - 1)
-        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int), 0, h - 1)
-        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int), 0, h - 1)
+        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int32), 0, w - 1)
+        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int32), 0, w - 1)
+        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int32), 0, h - 1)
+        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int32), 0, h - 1)
 
         mask = np.zeros((ymax - ymin + 1, xmax - xmin + 1), dtype=np.uint8)
         box[:, 0] = box[:, 0] - xmin

--- a/benchmark/PaddleOCR_DBNet/utils/ocr_metric/icdar2015/quad_metric.py
+++ b/benchmark/PaddleOCR_DBNet/utils/ocr_metric/icdar2015/quad_metric.py
@@ -61,7 +61,7 @@ class QuadMetric:
                 for i in range(pred_polygons.shape[0]):
                     if pred_scores[i] >= box_thresh:
                         # print(pred_polygons[i,:,:].tolist())
-                        pred.append(dict(points=pred_polygons[i, :, :].astype(np.int)))
+                        pred.append(dict(points=pred_polygons[i, :, :].astype(np.int32)))
                 # pred = [dict(points=pred_polygons[i,:,:].tolist()) if pred_scores[i] >= box_thresh for i in range(pred_polygons.shape[0])]
             results.append(self.evaluator.evaluate_image(gt, pred))
         return results

--- a/benchmark/PaddleOCR_DBNet/utils/ocr_metric/icdar2015/quad_metric.py
+++ b/benchmark/PaddleOCR_DBNet/utils/ocr_metric/icdar2015/quad_metric.py
@@ -61,7 +61,9 @@ class QuadMetric:
                 for i in range(pred_polygons.shape[0]):
                     if pred_scores[i] >= box_thresh:
                         # print(pred_polygons[i,:,:].tolist())
-                        pred.append(dict(points=pred_polygons[i, :, :].astype(np.int32)))
+                        pred.append(
+                            dict(points=pred_polygons[i, :, :].astype(np.int32))
+                        )
                 # pred = [dict(points=pred_polygons[i,:,:].tolist()) if pred_scores[i] >= box_thresh for i in range(pred_polygons.shape[0])]
             results.append(self.evaluator.evaluate_image(gt, pred))
         return results


### PR DESCRIPTION
numpy升级时，np.int已经不受支持，需要将框架中使用的np.int升级为np.int8/int32/int64。

本PR清理了剩余的一些np.int。

- https://github.com/PaddlePaddle/PaddleOCR/issues/8743
- https://github.com/PaddlePaddle/PaddleOCR/issues/11906