### PR TITLE
fix_config_file_about_dbnet_poly_detection

### DIFF
--- a/configs/det/det_r50_db++_icdar15.yml
+++ b/configs/det/det_r50_db++_icdar15.yml
@@ -54,7 +54,7 @@ PostProcess:
   box_thresh: 0.6
   max_candidates: 1000
   unclip_ratio: 1.5
-  det_box_type: 'quad' # 'quad' or 'poly'
+  box_type: 'quad' # 'quad' or 'poly'
 Metric:
   name: DetMetric
   main_indicator: hmean

--- a/configs/det/det_r50_db++_td_tr.yml
+++ b/configs/det/det_r50_db++_td_tr.yml
@@ -54,7 +54,7 @@ PostProcess:
   box_thresh: 0.5
   max_candidates: 1000
   unclip_ratio: 1.5
-  det_box_type: 'quad' # 'quad' or 'poly'
+  box_type: 'quad' # 'quad' or 'poly'
 Metric:
   name: DetMetric
   main_indicator: hmean


### PR DESCRIPTION
在使用多边形box格式进行文本检测时，仅仅修改配置文件中的det_box_type为poly是不生效的，排查发现db_postprocess类中关于输出box格式的字段定义为box_type，导致config中的配置无法传递，仅使用默认quad作为box输出。