### PR TITLE
fix layout recovery error: list index out of range

### DIFF
--- a/ppstructure/recovery/table_process.py
+++ b/ppstructure/recovery/table_process.py
@@ -249,6 +249,9 @@ class HtmlToDocx(HTMLParser):
         table = doc.add_table(len(rows), cols_len)
         table.style = doc.styles["Table Grid"]
 
+        num_rows = len(table.rows)
+        num_cols = len(table.columns)
+
         cell_row = 0
         for index, row in enumerate(rows):
             cols = get_table_columns(row)
@@ -260,6 +263,9 @@ class HtmlToDocx(HTMLParser):
                 cell_html = get_cell_html(col)
                 if col.name == "th":
                     cell_html = "<b>%s</b>" % cell_html
+
+                if cell_row >= num_rows or cell_col >= num_cols:
+                    continue
 
                 docx_cell = table.cell(cell_row, cell_col)
 


### PR DESCRIPTION
```
paddleocr --image_dir=Snipaste_2024-05-29_19-56-45.png --type=structure --recovery=True
```

- before fix:

```
[2024/05/29 19:57:16] ppocr INFO: processing 1/1 page:
[2024/05/29 19:57:17] ppocr DEBUG: dt_boxes num : 44, elapsed : 0.46419310569763184
[2024/05/29 19:57:20] ppocr DEBUG: rec_res num  : 44, elapsed : 3.558274745941162
[2024/05/29 19:57:21] ppocr DEBUG: dt_boxes num : 44, elapse : 0.4544041156768799
[2024/05/29 19:57:25] ppocr DEBUG: rec_res num  : 44, elapse : 3.340306043624878
[2024/05/29 19:57:25] ppocr ERROR: error in layout recovery image:Snipaste_2024-05-29_19-56-45, err msg: list index out of range
```

- after fix:

```
[2024/05/29 20:06:55] ppocr INFO: processing 1/1 page:
[2024/05/29 20:06:56] ppocr DEBUG: dt_boxes num : 44, elapsed : 0.46018409729003906
[2024/05/29 20:06:59] ppocr DEBUG: rec_res num  : 44, elapsed : 3.5144450664520264
[2024/05/29 20:07:00] ppocr DEBUG: dt_boxes num : 44, elapse : 0.457050085067749
[2024/05/29 20:07:04] ppocr DEBUG: rec_res num  : 44, elapse : 3.328582763671875
[2024/05/29 20:07:04] ppocr INFO: docx save to ./output/Snipaste_2024-05-29_19-56-45_ocr.docx
[2024/05/29 20:07:04] ppocr INFO: {'type': 'table', 'bbox': [36, 1, 1206, 928], 'img_idx': 0, 'layout': 'single'}
```

- test image 1:

![334352202-c065007d-96b3-4a30-ab4d-42be47ec3ee8](https://github.com/PaddlePaddle/PaddleOCR/assets/17264618/60f5c90e-5899-4f7e-bf9b-57606aaed420)


- test image 2:

<img width="629" alt="Snipaste_2024-05-29_19-56-45" src="https://github.com/PaddlePaddle/PaddleOCR/assets/17264618/a8192cd9-ebe5-4def-83aa-cc8c101080e1">
