### PR TITLE
add layout score return

### DIFF
--- a/ppstructure/predict_system.py
+++ b/ppstructure/predict_system.py
@@ -169,6 +169,7 @@ class StructureSystem(object):
                         "img": roi_img,
                         "res": res,
                         "img_idx": img_idx,
+                        "score": region["score"],
                     }
                 )
 


### PR DESCRIPTION
最近在使用paddleocr的版面分析功能，使用的pypi上下载的2.7.3最新版，发现PPStructure返回的result中的layout区块信息存在高iou但type不同的情况，
![高iou区块示例](https://github.com/PaddlePaddle/PaddleOCR/assets/11393164/eabaeb48-f6cd-4163-b5b7-560a7fcc6513)
[示例pdf页面](https://github.com/user-attachments/files/15831530/j.reprotox.2004.06.014.pdf)
之前用过其他的版面分析模型，会在返回的layout信息中提供每个layout_block的score信息，方便在后续处理的pipeline中对高iou的区块做低score区块移除处理。
看了最新的仓库代码（2.8.0版本），发现相较于2.7.3whl版本，PaddleOCR/ppocr/postprocess/picodet_postprocess.py
中已增加了layout的score返回，但是在PaddleOCR/ppstructure/predict_system.py 中，没有增加对应的返回参数
现已补全result中的layout score参数，便于后续pipeline的开发使用
