### PR TITLE
fix(sec): upgrade fonttools to 4.43.0

### DIFF
--- a/ppstructure/recovery/requirements.txt
+++ b/ppstructure/recovery/requirements.txt
@@ -1,4 +1,4 @@
 python-docx
 beautifulsoup4
-fonttools>=4.24.0
+fonttools>=4.43.0
 fire>=0.3.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in fonttools 4.24.0
- [CVE-2023-45139](https://www.oscs1024.com/hd/CVE-2023-45139)


### What did I do？
Upgrade fonttools from 4.24.0 to 4.43.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS