### PR TITLE
temporarily set numpy < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyclipper",
     "lmdb",
     "tqdm",
-    "numpy",
+    "numpy<2.0",
     "rapidfuzz",
     "opencv-python<=4.6.0.66",
     "opencv-contrib-python<=4.6.0.66",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imgaug
 pyclipper
 lmdb
 tqdm
-numpy
+numpy<2.0
 rapidfuzz
 opencv-python<=4.6.0.66
 opencv-contrib-python<=4.6.0.66


### PR DESCRIPTION
We need to remove imgaug, but it will take some time, so we will temporarily set numpy to < 2.0.