### PR TITLE
fix bug when layout_predictor is None

### DIFF
--- a/ppstructure/predict_system.py
+++ b/ppstructure/predict_system.py
@@ -121,7 +121,7 @@ class StructureSystem(object):
                 time_dict["layout"] += elapse
             else:
                 h, w = ori_im.shape[:2]
-                layout_res = [dict(bbox=None, label="table")]
+                layout_res = [dict(bbox=None, label="table", score=0.0)]
 
             # As reported in issues such as #10270 and #11665, the old
             # implementation, which recognizes texts from the layout regions,


### PR DESCRIPTION
```Python
from paddleocr import PPStructure

table_ocr = PPStructure(
    use_pdserving=False, use_gpu=False, lang="en", layout=False, show_log=False
)

result = table_ocr(
    "./data/paddle.png", return_ocr_result_in_table=True
)

```

```
  File "/Users/wangxin/repos/PaddleOCR/paddleocr.py", line 855, in __call__
    res, _ = super().__call__(img, return_ocr_result_in_table, img_idx=img_idx)
  File "/Users/wangxin/repos/PaddleOCR/ppstructure/predict_system.py", line 172, in __call__
    "score": region["score"],
KeyError: 'score'

```

- #13068