### PR TITLE
ci: Do not trigger CI when changing md files

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: ['main', 'release/*']
+  paths:
+    - '!**.md'
 
 jobs:
   check-code-style:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
     branches: ["main", "release/*"]
+  paths:
+    - '!**.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
#### 问题描述
当前CI流程逻辑下，任何文件改动的PR都会出发单元检测和格式检测。这有些多余了。

如果我只改动文档类文件，没有必要跑一遍单元测试和格式检测了。

#### 解决方案
在Action配置文件，添加后缀过滤规则，排除md文件，md文件改动时，不触发CI。
