### PR TITLE
Fix cpp_infer "--enable_mkldnn=false" not effective

### DIFF
--- a/deploy/cpp_infer/src/ocr_cls.cpp
+++ b/deploy/cpp_infer/src/ocr_cls.cpp
@@ -128,6 +128,9 @@ void Classifier::LoadModel(const std::string &model_dir) {
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
     }
+    else {
+      config.DisableMKLDNN();
+    }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);
   }
 

--- a/deploy/cpp_infer/src/ocr_cls.cpp
+++ b/deploy/cpp_infer/src/ocr_cls.cpp
@@ -127,8 +127,7 @@ void Classifier::LoadModel(const std::string &model_dir) {
     config.DisableGpu();
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
-    }
-    else {
+    } else {
       config.DisableMKLDNN();
     }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);

--- a/deploy/cpp_infer/src/ocr_det.cpp
+++ b/deploy/cpp_infer/src/ocr_det.cpp
@@ -46,6 +46,9 @@ void DBDetector::LoadModel(const std::string &model_dir) {
       // cache 10 different shapes for mkldnn to avoid memory leak
       config.SetMkldnnCacheCapacity(10);
     }
+    else {
+      config.DisableMKLDNN();
+    }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);
   }
   // use zero_copy_run as default

--- a/deploy/cpp_infer/src/ocr_det.cpp
+++ b/deploy/cpp_infer/src/ocr_det.cpp
@@ -45,8 +45,7 @@ void DBDetector::LoadModel(const std::string &model_dir) {
       config.EnableMKLDNN();
       // cache 10 different shapes for mkldnn to avoid memory leak
       config.SetMkldnnCacheCapacity(10);
-    }
-    else {
+    } else {
       config.DisableMKLDNN();
     }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);

--- a/deploy/cpp_infer/src/ocr_rec.cpp
+++ b/deploy/cpp_infer/src/ocr_rec.cpp
@@ -158,8 +158,7 @@ void CRNNRecognizer::LoadModel(const std::string &model_dir) {
       config.EnableMKLDNN();
       // cache 10 different shapes for mkldnn to avoid memory leak
       config.SetMkldnnCacheCapacity(10);
-    }
-    else {
+    } else {
       config.DisableMKLDNN();
     }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);

--- a/deploy/cpp_infer/src/ocr_rec.cpp
+++ b/deploy/cpp_infer/src/ocr_rec.cpp
@@ -159,6 +159,9 @@ void CRNNRecognizer::LoadModel(const std::string &model_dir) {
       // cache 10 different shapes for mkldnn to avoid memory leak
       config.SetMkldnnCacheCapacity(10);
     }
+    else {
+      config.DisableMKLDNN();
+    }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);
   }
 

--- a/deploy/cpp_infer/src/structure_layout.cpp
+++ b/deploy/cpp_infer/src/structure_layout.cpp
@@ -130,8 +130,7 @@ void StructureLayoutRecognizer::LoadModel(const std::string &model_dir) {
     config.DisableGpu();
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
-    }
-    else {
+    } else {
       config.DisableMKLDNN();
     }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);

--- a/deploy/cpp_infer/src/structure_layout.cpp
+++ b/deploy/cpp_infer/src/structure_layout.cpp
@@ -131,6 +131,9 @@ void StructureLayoutRecognizer::LoadModel(const std::string &model_dir) {
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
     }
+    else {
+      config.DisableMKLDNN();
+    }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);
   }
 

--- a/deploy/cpp_infer/src/structure_table.cpp
+++ b/deploy/cpp_infer/src/structure_table.cpp
@@ -144,6 +144,9 @@ void StructureTableRecognizer::LoadModel(const std::string &model_dir) {
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
     }
+    else {
+      config.DisableMKLDNN();
+    }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);
   }
 

--- a/deploy/cpp_infer/src/structure_table.cpp
+++ b/deploy/cpp_infer/src/structure_table.cpp
@@ -143,8 +143,7 @@ void StructureTableRecognizer::LoadModel(const std::string &model_dir) {
     config.DisableGpu();
     if (this->use_mkldnn_) {
       config.EnableMKLDNN();
-    }
-    else {
+    } else {
       config.DisableMKLDNN();
     }
     config.SetCpuMathLibraryNumThreads(this->cpu_math_library_num_threads_);


### PR DESCRIPTION
When using the --enable_mkldnn command line option, MKLDNN should be enabled when set to true and disabled when set to false. But, using the PaddlePaddle v3.0.0-beta1 inference library, the --enable_mkldnn=false option did not work as expected, causing MKLDNN to remain enabled regardless of the setting.
﻿
This commit adds a call to `config.DisableMKLDNN()` in the else branch to explicitly disable MKLDNN when `--enable_mkldnn=false` is set.

---

正常情况下，命令行指令 `--enable_mkldnn=false` 会关闭mkl加速。

使用旧版推理库（PaddlePaddle v2.3.2）时，如果不执行 `config.EnableMKLDNN();` ，那么mkl默认是关闭的，指令没问题。

但是，使用新版推理库（PaddlePaddle v3.0.0-beta1）时，就算不执行 `config.EnableMKLDNN();` ，mkl也是默认开启的。

这就导致 `--enable_mkldnn=false` 指令失效了。无论设置什么，mkl都是开启状态。

此PR增加了显式调用 `config.DisableMKLDNN()` 的代码，使得 `--enable_mkldnn=false` 时，可以正确地关闭mkl加速。

测试环境：
- 推理库(3.0.0-beta1 , MKL) https://paddle-inference-lib.bj.bcebos.com/3.0.0-beta1/cxx_c/Windows/CPU/x86-64_avx-mkl-vs2019/paddle_inference.zip
- Win 11
- VS 2022