### PR TITLE
fix version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ Pillow
 pyyaml
 requests
 albumentations==1.4.10
+# to be compatible with albumentations
+albucore==0.0.13


### PR DESCRIPTION
albucore是albumentations的依赖项，近期albucore发布了新版本，但是albumentations 1.4.10并不兼容新版albucore，且albumentations 1.4.10未指定albucore的版本，因此在PaddleOCR中加以限制。