### PR TITLE
pdf to markdown document

### DIFF
--- a/docs/ppstructure/quick_start.en.md
+++ b/docs/ppstructure/quick_start.en.md
@@ -85,6 +85,20 @@ Recovery by using OCR：
 paddleocr --image_dir=ppstructure/docs/table/1.png --type=structure --recovery=true --lang='en'
 ```
 
+#### 2.1.7 layout recovery(PDF to Markdown)
+
+Do not use LaTeXCOR model for formula recognition：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --recovery_to_markdown=true --lang='en'
+```
+
+Use LaTeXCOR model for formula recognition, where Chinese layout model must be used：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --formula=true --recovery_to_markdown=true --lang='ch'
+```
+
 ### 2.2 Use by python script
 
 #### 2.2.1 image orientation + layout analysis + table recognition
@@ -271,6 +285,35 @@ res = sorted_layout_boxes(result, w)
 convert_info_docx(img, res, save_folder, os.path.basename(img_path).split('.')[0])
 ```
 
+#### 2.2.7 layout recovery(PDF to Markdown)
+
+```python linenums="1"
+import os
+import cv2
+from paddleocr import PPStructure,save_structure_res
+from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes
+from paddleocr.ppstructure.recovery.recovery_to_markdown import convert_info_markdown
+
+# Chinese image
+table_engine = PPStructure(recovery=True)
+# English image
+# table_engine = PPStructure(recovery=True, lang='en')
+
+save_folder = './output'
+img_path = 'ppstructure/docs/table/1.png'
+img = cv2.imread(img_path)
+result = table_engine(img)
+save_structure_res(result, save_folder, os.path.basename(img_path).split('.')[0])
+
+for line in result:
+    line.pop('img')
+    print(line)
+
+h, w, _ = img.shape
+res = sorted_layout_boxes(result, w)
+convert_info_markdown(res, save_folder, os.path.basename(img_path).split('.')[0])
+```
+
 ### 2.3 Result description
 
 The return of PP-Structure is a list of dicts, the example is as follows:
@@ -311,28 +354,32 @@ Please refer to: [Key Information Extraction](../ppocr/model_train/kie.en.md) .
 
 ### 2.4 Parameter Description
 
-| field | description | default |
-|---|---|---|
-| output | result save path | ./output/table |
-| table_max_len | long side of the image resize in table structure model | 488 |
-| table_model_dir | Table structure model inference model path| None |
-| table_char_dict_path | The dictionary path of table structure model | ../ppocr/utils/dict/table_structure_dict.txt  |
-| merge_no_span_structure | In the table recognition model, whether to merge '\<td>' and '\</td>' | False |
-| layout_model_dir  | Layout analysis model inference model path| None |
-| layout_dict_path  | The dictionary path of layout analysis model| ../ppocr/utils/dict/layout_publaynet_dict.txt |
-| layout_score_threshold  | The box threshold path of layout analysis model| 0.5|
-| layout_nms_threshold  | The nms threshold path of layout analysis model| 0.5|
-| kie_algorithm  | kie model algorithm| LayoutXLM|
-| ser_model_dir  | Ser model inference model path| None|
-| ser_dict_path  | The dictionary path of Ser model| ../train_data/XFUND/class_list_xfun.txt|
-| mode | structure or kie  | structure   |
-| image_orientation | Whether to perform image orientation classification in forward  | False   |
-| layout | Whether to perform layout analysis in forward  | True   |
-| table  | Whether to perform table recognition in forward  | True   |
-| ocr    | Whether to perform ocr for non-table areas in layout analysis. When layout is False, it will be automatically set to False| True |
-| recovery    | Whether to perform layout recovery in forward| False |
-| save_pdf    | Whether to convert docx to pdf when recovery| False |
-| structure_version |  Structure version, optional PP-structure and PP-structurev2  | PP-structure |
+| field                   | description                                                                                                                | default |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------|---|
+| output                  | result save path                                                                                                           | ./output/table |
+| table_max_len           | long side of the image resize in table structure model                                                                     | 488 |
+| table_model_dir         | Table structure model inference model path                                                                                 | None |
+| table_char_dict_path    | The dictionary path of table structure model                                                                               | ../ppocr/utils/dict/table_structure_dict.txt  |
+| merge_no_span_structure | In the table recognition model, whether to merge '\<td>' and '\</td>'                                                      | False |
+| formula_model_dir       | Formula recognition model inference model path                                                                             | None                                          |
+| formula_char_dict_path  | The dictionary path of formula recognition model                                                                           | ../ppocr/utils/dict/latex_ocr_tokenizer.json |
+| layout_model_dir        | Layout analysis model inference model path                                                                                 | None |
+| layout_dict_path        | The dictionary path of layout analysis model                                                                               | ../ppocr/utils/dict/layout_publaynet_dict.txt |
+| layout_score_threshold  | The box threshold path of layout analysis model                                                                            | 0.5|
+| layout_nms_threshold    | The nms threshold path of layout analysis model                                                                            | 0.5|
+| kie_algorithm           | kie model algorithm                                                                                                        | LayoutXLM|
+| ser_model_dir           | Ser model inference model path                                                                                             | None|
+| ser_dict_path           | The dictionary path of Ser model                                                                                           | ../train_data/XFUND/class_list_xfun.txt|
+| mode                    | structure or kie                                                                                                           | structure   |
+| image_orientation       | Whether to perform image orientation classification in forward                                                             | False   |
+| layout                  | Whether to perform layout analysis in forward                                                                              | True   |
+| table                   | Whether to perform table recognition in forward                                                                            | True   | 
+| formula                 | Whether to perform formula recognition in forward                                                                          | False |
+| ocr                     | Whether to perform ocr for non-table areas in layout analysis. When layout is False, it will be automatically set to False | True |
+| recovery                | Whether to perform layout recovery in forward                                                                              | False |
+| recovery_to_markdown    | Whether to convert the layout recovery results into a markdown file                                                        | False |
+| save_pdf                | Whether to convert docx to pdf when recovery                                                                               | False |
+| structure_version       | Structure version, optional PP-structure and PP-structurev2                                                                | PP-structure |
 
 Most of the parameters are consistent with the PaddleOCR whl package, see [whl package documentation](../ppocr/blog/whl.en.md)
 

--- a/docs/ppstructure/quick_start.md
+++ b/docs/ppstructure/quick_start.md
@@ -103,6 +103,20 @@ paddleocr --image_dir=ppstructure/docs/table/1.png --type=structure --recovery=t
 paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --lang='en'
 ```
 
+#### 2.1.7 版面恢复+转换为markdown文件
+
+不使用LaTeXOCR模型进行公式识别：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --recovery_to_markdown=true --lang='en'
+```
+
+使用LaTeXOCR模型进行公式识别，其中必须使用中文layout模型：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --formula=true --recovery_to_markdown=true --lang='ch'
+```
+
 ### 2.2 Python脚本使用
 
 #### 2.2.1 图像方向分类+版面分析+表格识别
@@ -289,6 +303,35 @@ res = sorted_layout_boxes(result, w)
 convert_info_docx(img, res, save_folder, os.path.basename(img_path).split('.')[0])
 ```
 
+#### 2.2.7 版面恢复+转换为markdown文件
+
+```python linenums="1"
+import os
+import cv2
+from paddleocr import PPStructure,save_structure_res
+from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes
+from paddleocr.ppstructure.recovery.recovery_to_markdown import convert_info_markdown
+
+# 中文测试图
+table_engine = PPStructure(recovery=True)
+# 英文测试图
+# table_engine = PPStructure(recovery=True, lang='en')
+
+save_folder = './output'
+img_path = 'ppstructure/docs/table/1.png'
+img = cv2.imread(img_path)
+result = table_engine(img)
+save_structure_res(result, save_folder, os.path.basename(img_path).split('.')[0])
+
+for line in result:
+    line.pop('img')
+    print(line)
+
+h, w, _ = img.shape
+res = sorted_layout_boxes(result, w)
+convert_info_markdown(res, save_folder, os.path.basename(img_path).split('.')[0])
+```
+
 ### 2.3 返回结果说明
 
 PP-Structure的返回结果为一个dict组成的list，示例如下：
@@ -329,28 +372,32 @@ dict 里各个字段说明如下：
 
 ### 2.4 参数说明
 
-| 字段                    | 说明                                                                          | 默认值                                        |
-| ----- | ---- | ------ |
-| output                  | 结果保存地址                                                                  | ./output/table                                |
-| table_max_len           | 表格结构模型预测时，图像的长边resize尺度                                      | 488                                           |
-| table_model_dir         | 表格结构模型 inference 模型地址                                               | None                                          |
-| table_char_dict_path    | 表格结构模型所用字典地址                                                      | ../ppocr/utils/dict/table_structure_dict.txt  |
-| merge_no_span_structure | 表格识别模型中，是否对'\<td>'和'\</td>' 进行合并                              | False                                         |
-| layout_model_dir        | 版面分析模型 inference 模型地址                                               | None                                          |
-| layout_dict_path        | 版面分析模型字典                                                              | ../ppocr/utils/dict/layout_publaynet_dict.txt |
-| layout_score_threshold  | 版面分析模型检测框阈值                                                        | 0.5                                           |
-| layout_nms_threshold    | 版面分析模型nms阈值                                                           | 0.5                                           |
-| kie_algorithm           | kie模型算法                                                                   | LayoutXLM                                     |
-| ser_model_dir           | ser模型  inference 模型地址                                                   | None                                          |
-| ser_dict_path           | ser模型字典                                                                   | ../train_data/XFUND/class_list_xfun.txt       |
-| mode                    | structure or kie                                                              | structure                                     |
-| image_orientation       | 前向中是否执行图像方向分类                                                    | False                                         |
-| layout                  | 前向中是否执行版面分析                                                        | True                                          |
-| table                   | 前向中是否执行表格识别                                                        | True                                          |
+| 字段                      | 说明                                              | 默认值                                        |
+|-------------------------|-------------------------------------------------| ------ |
+| output                  | 结果保存地址                                          | ./output/table                                |
+| table_max_len           | 表格结构模型预测时，图像的长边resize尺度                         | 488                                           |
+| table_model_dir         | 表格结构模型 inference 模型地址                           | None                                          |
+| table_char_dict_path    | 表格结构模型所用字典地址                                    | ../ppocr/utils/dict/table_structure_dict.txt  |
+| merge_no_span_structure | 表格识别模型中，是否对'\<td>'和'\</td>' 进行合并                | False                                         |
+| formula_model_dir       | 公式识别模型 inference 模型地址                           | None                                          |
+| formula_char_dict_path  | 公式识别模型所用字典地址                                    | ../ppocr/utils/dict/latex_ocr_tokenizer.json |
+| layout_model_dir        | 版面分析模型 inference 模型地址                           | None                                          |
+| layout_dict_path        | 版面分析模型字典                                        | ../ppocr/utils/dict/layout_publaynet_dict.txt |
+| layout_score_threshold  | 版面分析模型检测框阈值                                     | 0.5                                           |
+| layout_nms_threshold    | 版面分析模型nms阈值                                     | 0.5                                           |
+| kie_algorithm           | kie模型算法                                         | LayoutXLM                                     |
+| ser_model_dir           | ser模型  inference 模型地址                           | None                                          |
+| ser_dict_path           | ser模型字典                                         | ../train_data/XFUND/class_list_xfun.txt       |
+| mode                    | structure or kie                                | structure                                     |
+| image_orientation       | 前向中是否执行图像方向分类                                   | False                                         |
+| layout                  | 前向中是否执行版面分析                                     | True                                          |
+| table                   | 前向中是否执行表格识别                                     | True                                          |
+| formula                 | 前向中是否执行公式识别                                     | False                                         |
 | ocr                     | 对于版面分析中的非表格区域，是否执行ocr。当layout为False时会被自动设置为False | True                                          |
-| recovery                | 前向中是否执行版面恢复                                                        | False                                         |
-| save_pdf                | 版面恢复导出docx文件的同时，是否导出pdf文件                                   | False                                         |
-| structure_version       | 模型版本，可选 PP-structure和PP-structurev2                                   | PP-structure                                  |
+| recovery                | 前向中是否执行版面恢复                                     | False                                         |
+| recovery_to_markdown    | 是否将版面恢复结果转换为markdown文件                        | False                                         |
+| save_pdf                | 版面恢复导出docx文件的同时，是否导出pdf文件                       | False                                         |
+| structure_version       | 模型版本，可选 PP-structure和PP-structurev2             | PP-structure                                  |
 
 大部分参数和PaddleOCR whl包保持一致，见 [whl包文档](../ppocr/blog/whl.md)
 

--- a/ppstructure/docs/quickstart_en.md
+++ b/ppstructure/docs/quickstart_en.md
@@ -9,6 +9,7 @@
     - [2.1.4 table recognition](#214-table-recognition)
     - [2.1.5 Key Information Extraction](#215-Key-Information-Extraction)
     - [2.1.6 layout recovery](#216-layout-recovery)
+    - [2.1.7 layout recovery(PDF to Markdown)](#217-layout-recoverypdf-to-markdown)
   - [2.2 Use by python script](#22-use-by-python-script)
     - [2.2.1 image orientation + layout analysis + table recognition](#221-image-orientation--layout-analysis--table-recognition)
     - [2.2.2 layout analysis + table recognition](#222-layout-analysis--table-recognition)
@@ -16,6 +17,7 @@
     - [2.2.4 table recognition](#224-table-recognition)
     - [2.2.5 Key Information Extraction](#225-Key-Information-Extraction)
     - [2.2.6 layout recovery](#226-layout-recovery)
+    - [2.2.7 layout recovery(PDF to Markdown)](#227-layout-recoverypdf-to-markdown)
   - [2.3 Result description](#23-result-description)
     - [2.3.1 layout analysis + table recognition](#231-layout-analysis--table-recognition)
     - [2.3.2 Key Information Extraction](#232-Key-Information-Extraction)
@@ -108,6 +110,21 @@ Recovery by using OCR：
 
 ```bash
 paddleocr --image_dir=ppstructure/docs/table/1.png --type=structure --recovery=true --lang='en'
+```
+
+<a name="217"></a>
+#### 2.1.7 layout recovery(PDF to Markdown)
+
+Do not use LaTeXCOR model for formula recognition：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --recovery_to_markdown=true --lang='en'
+```
+
+Use LaTeXCOR model for formula recognition, where Chinese layout model must be used：
+
+```bash linenums="1"
+paddleocr --image_dir=ppstructure/docs/recovery/UnrealText.pdf --type=structure --recovery=true --formula=true --recovery_to_markdown=true --lang='ch'
 ```
 
 <a name="22"></a>
@@ -303,6 +320,36 @@ res = sorted_layout_boxes(result, w)
 convert_info_docx(img, res, save_folder, os.path.basename(img_path).split('.')[0])
 ```
 
+<a name="227"></a>
+#### 2.2.7 layout recovery(PDF to Markdown)
+
+```python linenums="1"
+import os
+import cv2
+from paddleocr import PPStructure,save_structure_res
+from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes
+from paddleocr.ppstructure.recovery.recovery_to_markdown import convert_info_markdown
+
+# Chinese image
+table_engine = PPStructure(recovery=True)
+# English image
+# table_engine = PPStructure(recovery=True, lang='en')
+
+save_folder = './output'
+img_path = 'ppstructure/docs/table/1.png'
+img = cv2.imread(img_path)
+result = table_engine(img)
+save_structure_res(result, save_folder, os.path.basename(img_path).split('.')[0])
+
+for line in result:
+    line.pop('img')
+    print(line)
+
+h, w, _ = img.shape
+res = sorted_layout_boxes(result, w)
+convert_info_markdown(res, save_folder, os.path.basename(img_path).split('.')[0])
+```
+
 <a name="23"></a>
 ### 2.3 Result description
 
@@ -351,9 +398,11 @@ Please refer to: [Key Information Extraction](../kie/README.md) .
 | table_model_dir | Table structure model inference model path| None |
 | table_char_dict_path | The dictionary path of table structure model | ../ppocr/utils/dict/table_structure_dict.txt  |
 | merge_no_span_structure | In the table recognition model, whether to merge '\<td>' and '\</td>' | False |
+| formula_model_dir | Formula recognition model inference model path | None |
+| formula_char_dict_path | The dictionary path of formula recognition model | ../ppocr/utils/dict/latex_ocr_tokenizer.json |
 | layout_model_dir  | Layout analysis model inference model path| None |
 | layout_dict_path  | The dictionary path of layout analysis model| ../ppocr/utils/dict/layout_publaynet_dict.txt |
-| layout_score_threshold  | The box threshold path of layout analysis model| 0.5|
+| layout_score_threshold | The box threshold path of layout analysis model| 0.5|
 | layout_nms_threshold  | The nms threshold path of layout analysis model| 0.5|
 | kie_algorithm  | kie model algorithm| LayoutXLM|
 | ser_model_dir  | Ser model inference model path| None|
@@ -362,8 +411,10 @@ Please refer to: [Key Information Extraction](../kie/README.md) .
 | image_orientation | Whether to perform image orientation classification in forward  | False   |
 | layout | Whether to perform layout analysis in forward  | True   |
 | table  | Whether to perform table recognition in forward  | True   |
+| formula | Whether to perform formula recognition in forward | False |
 | ocr    | Whether to perform ocr for non-table areas in layout analysis. When layout is False, it will be automatically set to False| True |
 | recovery    | Whether to perform layout recovery in forward| False |
+| recovery_to_markdown | Whether to convert the layout recovery results into a markdown file | False |
 | save_pdf    | Whether to convert docx to pdf when recovery| False |
 | structure_version |  Structure version, optional PP-structure and PP-structurev2  | PP-structure |
 


### PR DESCRIPTION
## 补充pdf转换为markdown文件的文档

## 代码修改
paddleocr.py文件中class PPStructure适配了上个pr添加的公式识别；
paddleocr.py文件中添加了pdf转换为markdown文件的支持，方便命令行快速开始。

## 文档修改
文档修改如下四个文件:
ppstructure

PaddleOCR/ppstructure/docs/quickstart.md
PaddleOCR/ppstructure/docs/quickstart_en.md
docs

PaddleOCR/docs/ppstructure/quick_start.md
PaddleOCR/docs/ppstructure/quick_start.en.md

在以上四个文档中添加了pdf转换为markdown文件的快速开始，和必要的参数说明。