### PR TITLE
ci: Fix mike error

### DIFF
--- a/.github/workflows/build_publish_develop_docs.yml
+++ b/.github/workflows/build_publish_develop_docs.yml
@@ -27,5 +27,6 @@ jobs:
             mkdocs-material-
       - run: pip install mike mkdocs-material jieba mkdocs-git-revision-date-localized-plugin mkdocs-git-committers-plugin-2 mkdocs-static-i18n
       - run: |
+          git fetch origin gh-pages --depth=1
           mike deploy --push --update-aliases main latest
           mike set-default --push latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build_publish_develop_docs.yml` file. The change ensures that the latest `gh-pages` branch is fetched before deploying and setting the default documentation version.

* [`.github/workflows/build_publish_develop_docs.yml`](diffhunk://#diff-b6f5f260b0b6ea639f348696541c0db1f0ddddeb64e6419fdfa682440ad63340R30): Added a command to fetch the `gh-pages` branch with a depth of 1 before deploying and setting the default version using `mike`.