### PR TITLE
Update README.md, fixed broken quick start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ PaddleOCR 由 [PMC](https://github.com/PaddlePaddle/PaddleOCR/issues/12122) 监�
     <img src="./docs/images/ppocrv4.png">
 </div>
 
-## ⚡ [快速开始](https://paddlepaddle.github.io/PaddleOCR/quick_start.html)
+## ⚡ [快速开始](https://paddlepaddle.github.io/PaddleOCR/latest/quick_start.html)
 
-## 🔥 [一站式全流程开发](https://paddlepaddle.github.io/PaddleOCR/paddlex/overview.html)
+## 🔥 [一站式全流程开发](https://paddlepaddle.github.io/PaddleOCR/latest/paddlex/overview.html)
 
 ## 📝 文档
 


### PR DESCRIPTION
The former link in README.md for quick start is broken. I added _latest_ between PaddleOCR/ and quick_start.html to make the link work.