### PR TITLE
Allow `create_predictor` function to accept array of ONNX Execution Providers

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -147,6 +147,7 @@ def init_args():
 
     parser.add_argument("--show_log", type=str2bool, default=True)
     parser.add_argument("--use_onnx", type=str2bool, default=False)
+    parser.add_argument("--onnx_providers", nargs="+", type=str, default=False)
 
     # extended function
     parser.add_argument(
@@ -193,7 +194,10 @@ def create_predictor(args, mode, logger):
         model_file_path = model_dir
         if not os.path.exists(model_file_path):
             raise ValueError("not find model file path {}".format(model_file_path))
-        if args.use_gpu:
+
+        if args.onnx_providers and len(args.onnx_providers) > 0:
+            sess = ort.InferenceSession(model_file_path, providers=args.onnx_providers)
+        elif args.use_gpu:
             sess = ort.InferenceSession(
                 model_file_path,
                 providers=[

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -148,6 +148,7 @@ def init_args():
     parser.add_argument("--show_log", type=str2bool, default=True)
     parser.add_argument("--use_onnx", type=str2bool, default=False)
     parser.add_argument("--onnx_providers", nargs="+", type=str, default=False)
+    parser.add_argument("--onnx_sess_options", type=list, default=False)
 
     # extended function
     parser.add_argument(

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -195,8 +195,14 @@ def create_predictor(args, mode, logger):
         if not os.path.exists(model_file_path):
             raise ValueError("not find model file path {}".format(model_file_path))
 
+        sess_options = args.onnx_sess_options or None
+
         if args.onnx_providers and len(args.onnx_providers) > 0:
-            sess = ort.InferenceSession(model_file_path, providers=args.onnx_providers)
+            sess = ort.InferenceSession(
+                model_file_path,
+                providers=args.onnx_providers,
+                sess_options=sess_options,
+            )
         elif args.use_gpu:
             sess = ort.InferenceSession(
                 model_file_path,
@@ -206,10 +212,13 @@ def create_predictor(args, mode, logger):
                         {"device_id": args.gpu_id, "cudnn_conv_algo_search": "DEFAULT"},
                     )
                 ],
+                sess_options=sess_options,
             )
         else:
             sess = ort.InferenceSession(
-                model_file_path, providers=["CPUExecutionProvider"]
+                model_file_path,
+                providers=["CPUExecutionProvider"],
+                sess_options=sess_options,
             )
         return sess, sess.get_inputs()[0], None, None
 


### PR DESCRIPTION
In current live version `PaddleOCR` with `use_onnx` flag works only either with `CPUExecutionProvider` or with `CUDAExecutionProvider` is available and `use_gpu` flag is provided.

Onnx ecosystem have lots of different execution providers and I see no reason to limit it only to proprietary Nvidia tech stack. Here is a list of currently available execution providers: https://onnxruntime.ai/docs/execution-providers/

This PR adds a new `onnx_providers` array args that is being used in `create_predictor` function when it is passed to initiate onnx runtime `InferenceSession` with requested execution providers.