### PR TITLE
Create close_inactive_issues.yaml

### DIFF
--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -20,3 +20,25 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+  inactivity-lock:
+    name: Lock issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: 🔒 Lock closed issues and PRs
+        uses: klaasnicolaas/action-inactivity-lock@v1
+        id: lock
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          rate-limit-buffer: 200
+          days-inactive-issues: 30
+          days-inactive-prs: -1
+          lock-reason-issues: "This issue was locked because it has been inactive for 30 days since being closed."
+          lock-reason-prs: "This PR was locked because it has been inactive for 30 days since being closed."
+      - name: 🔍 Display locked issues and PRs
+        run: |
+          echo "Locked issues: $(echo '${{ steps.lock.outputs.locked-issues }}' | jq)"
+          echo "Locked PRs: $(echo '${{ steps.lock.outputs.locked-prs }}' | jq)"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage inactive issues and pull requests. The workflow includes two main jobs: one to close inactive issues and another to lock issues and PRs after a period of inactivity.

New GitHub Actions workflow:

* [`.github/workflows/close_inactive_issues.yaml`](diffhunk://#diff-f94b9326dae1a7451870d63d66bbfa08ad589ac729d0220e716d4d95e330c675R1-R44): Added a workflow that schedules a job to mark issues as stale after 90 days of inactivity and close them after an additional 14 days. Another job locks issues and PRs that have been inactive for 30 days after being closed.