### PR TITLE
Create lock_closed_issues.yaml

### DIFF
--- a/.github/workflows/lock_closed_issues.yaml
+++ b/.github/workflows/lock_closed_issues.yaml
@@ -1,0 +1,29 @@
+name: Lock
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  inactivity-lock:
+    name: Lock issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: 🔒 Lock closed issues and PRs
+        uses: klaasnicolaas/action-inactivity-lock@v1
+        id: lock
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          rate-limit-buffer: 200
+          days-inactive-issues: 30
+          days-inactive-prs: -1
+          lock-reason-issues: "This issue was locked because it has been inactive for 30 days since being closed."
+          lock-reason-prs: "This PR was locked because it has been inactive for 30 days since being closed."
+      - name: 🔍 Display locked issues and PRs
+        run: |
+          echo "Locked issues: $(echo '${{ steps.lock.outputs.locked-issues }}' | jq)"
+          echo "Locked PRs: $(echo '${{ steps.lock.outputs.locked-prs }}' | jq)"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically lock closed issues and pull requests after a period of inactivity. The workflow is scheduled to run daily and can also be triggered manually.

New GitHub Actions workflow:

* [`.github/workflows/lock_closed_issues.yaml`](diffhunk://#diff-84f68607113887cba84e14191c3727c45c78461e035fa66f1f5d92cf3d758dc6R1-R29): Added a workflow named "Lock" that locks closed issues after 30 days of inactivity and closed pull requests immediately. It uses the `klaasnicolaas/action-inactivity-lock` action and includes steps to display the locked issues and PRs.