### PR TITLE
Update close_inactive_issues.yaml

### DIFF
--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: 🔒 Lock closed issues and PRs
-        uses: klaasnicolaas/action-inactivity-lock@v1
+        uses: klaasnicolaas/action-inactivity-lock@v1.1.1
         id: lock
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration to use a newer version of the inactivity lock action.

* [`.github/workflows/close_inactive_issues.yaml`](diffhunk://#diff-f94b9326dae1a7451870d63d66bbfa08ad589ac729d0220e716d4d95e330c675L32-R32): Updated the `klaasnicolaas/action-inactivity-lock` action from version `v1` to `v1.1.1`.