### PR TITLE
Update close_inactive_issues.yaml

### DIFF
--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -36,8 +36,8 @@ jobs:
           rate-limit-buffer: 200
           days-inactive-issues: 30
           days-inactive-prs: -1
-          lock-reason-issues: "This issue was locked because it has been inactive for 30 days since being closed."
-          lock-reason-prs: "This PR was locked because it has been inactive for 30 days since being closed."
+          lock-reason-issues: "resolved"
+          lock-reason-prs: "resolved"
       - name: 🔍 Display locked issues and PRs
         run: |
           echo "Locked issues: $(echo '${{ steps.lock.outputs.locked-issues }}' | jq)"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/close_inactive_issues.yaml` file. The change updates the lock reason for inactive issues and pull requests to "resolved".

* [`.github/workflows/close_inactive_issues.yaml`](diffhunk://#diff-f94b9326dae1a7451870d63d66bbfa08ad589ac729d0220e716d4d95e330c675L39-R40): Changed `lock-reason-issues` and `lock-reason-prs` from detailed messages to "resolved".