### PR TITLE
update infer/utility.py to support json format model

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -230,6 +230,8 @@ def create_predictor(args, mode, logger):
         )
 
     else:
+        from packaging.version import parse as parse_version
+
         file_names = ["model", "inference"]
         for file_name in file_names:
             params_file_path = f"{model_dir}/{file_name}.pdiparams"
@@ -247,10 +249,10 @@ def create_predictor(args, mode, logger):
                 f"neither {file_name}.json nor {file_name}.pdmodel was found in {model_dir}."
             )
 
-        if paddle.__version__ == "0.0.0" or paddle.__version__ >= "3.0.0":
-            model_path = model_dir
-            model_prefix = file_name
-            config = inference.Config(model_path, model_prefix)
+        if parse_version(paddle.__version__) == parse_version("0.0.0") or parse_version(
+            paddle.__version__
+        ) >= parse_version("3.0.0-beta1"):
+            config = inference.Config(model_dir, file_name)
         else:
             model_file_path = f"{model_dir}/{file_name}.pdmodel"
             config = inference.Config(model_file_path, params_file_path)

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -234,12 +234,19 @@ def create_predictor(args, mode, logger):
         for file_name in file_names:
             model_file_path = "{}/{}.pdmodel".format(model_dir, file_name)
             params_file_path = "{}/{}.pdiparams".format(model_dir, file_name)
-            if os.path.exists(model_file_path) and os.path.exists(params_file_path):
+            model_json_file_path = "{}/{}.json".format(model_dir, file_name)
+            if (
+                os.path.exists(model_file_path) or os.path.exists(model_json_file_path)
+            ) and os.path.exists(params_file_path):
                 break
-        if not os.path.exists(model_file_path):
+        if not os.path.exists(model_file_path) and not os.path.exists(
+            model_json_file_path
+        ):
             raise ValueError(
                 "not find model.pdmodel or inference.pdmodel in {}".format(model_dir)
             )
+        if not os.path.exists(model_file_path) and os.path.exists(model_json_file_path):
+            model_file_path = model_json_file_path
         if not os.path.exists(params_file_path):
             raise ValueError(
                 "not find model.pdiparams or inference.pdiparams in {}".format(

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -232,29 +232,28 @@ def create_predictor(args, mode, logger):
     else:
         file_names = ["model", "inference"]
         for file_name in file_names:
-            model_file_path = "{}/{}.pdmodel".format(model_dir, file_name)
-            params_file_path = "{}/{}.pdiparams".format(model_dir, file_name)
-            model_json_file_path = "{}/{}.json".format(model_dir, file_name)
-            if (
-                os.path.exists(model_file_path) or os.path.exists(model_json_file_path)
-            ) and os.path.exists(params_file_path):
+            params_file_path = f"{model_dir}/{file_name}.pdiparams"
+            if os.path.exists(params_file_path):
                 break
-        if not os.path.exists(model_file_path) and not os.path.exists(
-            model_json_file_path
+
+        if not os.path.exists(params_file_path):
+            raise ValueError(f"not find {file_name}.pdiparams in {model_dir}")
+
+        if not (
+            os.path.exists(f"{model_dir}/{file_name}.pdmodel")
+            or os.path.exists(f"{model_dir}/{file_name}.json")
         ):
             raise ValueError(
-                "not find model.pdmodel or inference.pdmodel in {}".format(model_dir)
-            )
-        if not os.path.exists(model_file_path) and os.path.exists(model_json_file_path):
-            model_file_path = model_json_file_path
-        if not os.path.exists(params_file_path):
-            raise ValueError(
-                "not find model.pdiparams or inference.pdiparams in {}".format(
-                    model_dir
-                )
+                f"neither {file_name}.json nor {file_name}.pdmodel was found in {model_dir}."
             )
 
-        config = inference.Config(model_file_path, params_file_path)
+        if paddle.__version__ == "0.0.0" or paddle.__version__ >= "3.0.0":
+            model_path = model_dir
+            model_prefix = file_name
+            config = inference.Config(model_path, model_prefix)
+        else:
+            model_file_path = f"{model_dir}/{file_name}.pdmodel"
+            config = inference.Config(model_file_path, params_file_path)
 
         if hasattr(args, "precision"):
             if args.precision == "fp16" and args.use_tensorrt:

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -247,9 +247,7 @@ def create_predictor(args, mode, logger):
                 f"neither {file_name}.json nor {file_name}.pdmodel was found in {model_dir}."
             )
 
-        if os.path.exists(
-            f"{model_dir}/{file_name}.json"
-        ):
+        if os.path.exists(f"{model_dir}/{file_name}.json"):
             model_file_path = f"{model_dir}/{file_name}.json"
         else:
             model_file_path = f"{model_dir}/{file_name}.pdmodel"

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -230,8 +230,6 @@ def create_predictor(args, mode, logger):
         )
 
     else:
-        from packaging.version import parse as parse_version
-
         file_names = ["model", "inference"]
         for file_name in file_names:
             params_file_path = f"{model_dir}/{file_name}.pdiparams"
@@ -249,13 +247,14 @@ def create_predictor(args, mode, logger):
                 f"neither {file_name}.json nor {file_name}.pdmodel was found in {model_dir}."
             )
 
-        if parse_version(paddle.__version__) == parse_version("0.0.0") or parse_version(
-            paddle.__version__
-        ) >= parse_version("3.0.0-beta1"):
-            config = inference.Config(model_dir, file_name)
+        if not os.path.exists(f"{model_dir}/{file_name}.pdmodel") and os.path.exists(
+            f"{model_dir}/{file_name}.json"
+        ):
+            model_file_path = f"{model_dir}/{file_name}.json"
         else:
             model_file_path = f"{model_dir}/{file_name}.pdmodel"
-            config = inference.Config(model_file_path, params_file_path)
+
+        config = inference.Config(model_file_path, params_file_path)
 
         if hasattr(args, "precision"):
             if args.precision == "fp16" and args.use_tensorrt:

--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -247,7 +247,7 @@ def create_predictor(args, mode, logger):
                 f"neither {file_name}.json nor {file_name}.pdmodel was found in {model_dir}."
             )
 
-        if not os.path.exists(f"{model_dir}/{file_name}.pdmodel") and os.path.exists(
+        if os.path.exists(
             f"{model_dir}/{file_name}.json"
         ):
             model_file_path = f"{model_dir}/{file_name}.json"


### PR DESCRIPTION
This pull request includes changes to the `create_predictor` function in `tools/infer/utility.py` to improve the logic for locating model files. The most important changes include simplifying the file existence checks and enhancing error messages for missing files.

Improvements to file existence checks:

* Simplified the logic by removing redundant checks for `model.pdmodel` and `inference.pdmodel` files and instead using formatted strings for file paths.
* Enhanced the error messages to provide clearer information when neither `.pdmodel` nor `.json` files are found.

Enhancements to error handling:

* Updated the error message to specify which `.pdiparams` file is missing when it is not found in the specified directory.
* Added a conditional to set the `model_file_path` based on the existence of `.json` or `.pdmodel` files, ensuring the correct file is used for configuration.