### PR TITLE
fix benchmark det_r50_vd_pse_v2_0 train error

### DIFF
--- a/ppocr/data/imaug/iaa_augment.py
+++ b/ppocr/data/imaug/iaa_augment.py
@@ -208,5 +208,5 @@ class IaaAugment:
                 new_poly = transformed_keypoints[idx : idx + length]
                 new_polys.append(np.array([kp[:2] for kp in new_poly]))
                 idx += length
-            data["polys"] = new_polys
+            data["polys"] = np.array(new_polys)
         return data

--- a/tests/test_iaa_augment.py
+++ b/tests/test_iaa_augment.py
@@ -50,7 +50,9 @@ def test_iaa_augment_default(sample_image, sample_polys):
     assert isinstance(
         transformed_data["image"], np.ndarray
     ), "Image should be a numpy array"
-    assert isinstance(transformed_data["polys"], list), "Polys should be a list"
+    assert isinstance(
+        transformed_data["polys"], np.ndarray
+    ), "Polys should be a numpy array"
     assert transformed_data["image"].ndim == 3, "Image should be 3-dimensional"
 
     # Verify that the polygons have been transformed


### PR DESCRIPTION
This pull request includes changes to the `ppocr` data augmentation and its corresponding tests to update the data type of `polys` from a list to a numpy array. This ensures consistency and compatibility with other numpy operations.

Changes to `ppocr` data augmentation:

* [`ppocr/data/imaug/iaa_augment.py`](diffhunk://#diff-cfb976e0fb8bb05e4bca0b6b32b49a42f55d1ff7266ec93d6bac9baabfa2716dL211-R211): Modified the `__call__` method to set `data["polys"]` as a numpy array instead of a list.

Updates to tests:

* [`tests/test_iaa_augment.py`](diffhunk://#diff-997848a3b11501077cb5fd1cdedab72dd24a33b98431fd14fb1e56e0b0902ab3L53-R55): Updated the test `test_iaa_augment_default` to check that `transformed_data["polys"]` is a numpy array instead of a list.

Fixes:

- https://github.com/PaddlePaddle/PaddleOCR/pull/13937#issuecomment-2477868176