### PR TITLE
docs: update quick_start and recognition doc

### DIFF
--- a/docs/ppocr/model_train/recognition.md
+++ b/docs/ppocr/model_train/recognition.md
@@ -344,7 +344,7 @@ class MyBackbone(nn.Layer):
         return y
 ```
 
-3. 在 [ppocr/modeling/backbones/\_*init\_*.py](../../ppocr/modeling/backbones/__init__.py)文件内导入添加的`MyBackbone`模块，然后修改配置文件中Backbone进行配置即可使用，格式如下:
+3. 在 [ppocr/modeling/backbones/\_*init\_*.py](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/modeling/backbones/__init__.py)文件内导入添加的`MyBackbone`模块，然后修改配置文件中Backbone进行配置即可使用，格式如下:
 
 ```yaml linenums="1"
 Backbone:
@@ -356,7 +356,7 @@ args1: args1
 
 ### 2.4. 混合精度训练
 
-如果您想进一步加快训练速度，可以使用[自动混合精度训练](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/01_paddle2.0_introduction/basic_concept/amp_cn.html)， 以单机单卡为例，命令如下：
+如果您想进一步加快训练速度，可以使用[自动混合精度训练](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/performance_improving/amp_cn.html)， 以单机单卡为例，命令如下：
 
 ```bash linenums="1"
 python3 tools/train.py -c configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml \
@@ -534,6 +534,9 @@ inference 模型（`paddle.jit.save`保存的模型）
 识别模型转inference模型与检测的方式相同，如下：
 
 ```bash linenums="1"
+# 开启旧 IR 模式
+export FLAGS_enable_pir_api=0
+
 # -c 后面设置训练算法的yml配置文件
 # -o 配置可选参数
 # Global.pretrained_model 参数设置待转换的训练模型地址，不用添加文件后缀 .pdmodel，.pdopt或.pdparams。
@@ -551,6 +554,21 @@ inference/en_PP-OCRv3_rec/
     ├── inference.pdiparams         # 识别inference模型的参数文件
     ├── inference.pdiparams.info    # 识别inference模型的参数信息，可忽略
     └── inference.pdmodel           # 识别inference模型的program文件
+```
+
+**注意：** 如果需要以新 IR 模式（`FLAGS_enable_pir_api=1`）存储 `.json` 文件，请执行以下命令切换到新 IR 模式：
+
+```bash linenums="1"
+export FLAGS_enable_pir_api=1
+python3 tools/export_model.py -c configs/rec/PP-OCRv3/en_PP-OCRv3_rec.yml -o Global.pretrained_model=./pretrain_models/en_PP-OCRv3_rec_train/best_accuracy  Global.save_inference_dir=./inference/en_PP-OCRv3_rec/
+```
+
+转换成功后，在目录下有三个文件：
+
+```text linenums="1"
+inference/en_PP-OCRv3_rec/
+    ├── inference.pdiparams         # 识别inference模型的参数文件
+    └── inference.json              # 识别inference模型的program文件
 ```
 
 - 自定义模型推理

--- a/docs/ppstructure/quick_start.en.md
+++ b/docs/ppstructure/quick_start.en.md
@@ -10,28 +10,33 @@ comments: true
 
 > If you do not have a Python environment, please refer to [Environment Preparation](../ppocr/environment.en.md).
 
-- If you have CUDA 9 or CUDA 10 installed on your machine, please run the following command to install
+- PaddlePaddle with CUDA 11.8
 
   ```bash linenums="1"
-  python3 -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple
+  python3 -m pip install paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
   ```
 
-- If you have no available GPU on your machine, please run the following command to install the CPU version
+- PaddlePaddle with CUDA 12.3
 
   ```bash linenums="1"
-  python3 -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple
+  python3 -m pip install paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/stable/cu123/
   ```
 
-For more software version requirements, please refer to the instructions in [Installation Document](https://www.paddlepaddle.org.cn/install/quick) for operation.
+- If your machine does not have an available GPU, please run the following command to install the CPU version
+
+  ```bash linenums="1"
+  python3 -m pip install paddlepaddle -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
+  ```
+
+For more software version requirements, please refer to the instructions in the [Installation Document](https://www.paddlepaddle.org.cn/en/install/quick).
 
 ### 1.2 Install PaddleOCR Whl Package
 
 ```bash linenums="1"
-# Install paddleocr, version 2.6 is recommended
-pip3 install "paddleocr>=2.6.0.3"
+python3 -m pip install paddleocr
 
 # Install the image direction classification dependency package paddleclas (if you do not use the image direction classification, you can skip it)
-pip3 install paddleclas>=2.4.3
+python3 -m pip install paddleclas
 ```
 
 ## 2. Quick Use
@@ -41,6 +46,8 @@ pip3 install paddleclas>=2.4.3
 #### 2.1.1 image orientation + layout analysis + table recognition
 
 ```bash linenums="1"
+# Temporarily disable the new IR feature
+export FLAGS_enable_pir_api=0
 paddleocr --image_dir=ppstructure/docs/table/1.png --type=structure --image_orientation=true
 ```
 
@@ -64,9 +71,9 @@ paddleocr --image_dir=ppstructure/docs/table/table.jpg --type=structure --layout
 
 #### 2.1.5 Key Information Extraction
 
-Key information extraction does not currently support use by the whl package. For detailed usage tutorials, please refer to: [inference document](./infer_deploy/python_infer.en.md).
+Key information extraction does not currently support use by the whl package. For detailed usage tutorials, please refer to: [Key Information Extraction](../ppocr/model_train/kie.en.md).
 
-#### 2.1.6 layout recovery(PDF to Word)
+#### 2.1.6 layout recovery
 
 Two layout recovery methods are provided, For detailed usage tutorials, please refer to: [Layout Recovery](./model_train/recovery_to_doc.en.md).
 

--- a/docs/ppstructure/quick_start.md
+++ b/docs/ppstructure/quick_start.md
@@ -10,16 +10,22 @@ comments: true
 >
 > 如果您没有基础的Python运行环境，请参考[运行环境准备](../ppocr/environment.md)。
 
-- 您的机器安装的是CUDA9或CUDA10，请运行以下命令安装
+- CUDA11.8 的 PaddlePaddle
 
   ```bash linenums="1"
-  python3 -m pip install paddlepaddle-gpu -i https://mirror.baidu.com/pypi/simple
+  python3 -m pip install paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
+  ```
+
+-  CUDA12.3 的 PaddlePaddle
+
+  ```bash linenums="1"
+  python3 -m pip install paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/stable/cu123/
   ```
 
 - 您的机器是CPU，请运行以下命令安装
 
   ```bash linenums="1"
-  python3 -m pip install paddlepaddle -i https://mirror.baidu.com/pypi/simple
+  python3 -m pip install paddlepaddle -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
   ```
 
 更多的版本需求，请参照[飞桨官网安装文档](https://www.paddlepaddle.org.cn/install/quick)中的说明进行操作。
@@ -27,11 +33,10 @@ comments: true
 ### 1.2 安装PaddleOCR whl包
 
 ```bash linenums="1"
-# 安装 paddleocr，推荐使用2.6版本
-pip3 install "paddleocr>=2.6.0.3"
+python3 -m pip install paddleocr
 
 # 安装 图像方向分类依赖包paddleclas（如不需要图像方向分类功能，可跳过）
-pip3 install paddleclas>=2.4.3
+python3 -m pip install paddleclas
 ```
 
 ## 2. 便捷使用
@@ -41,6 +46,8 @@ pip3 install paddleclas>=2.4.3
 #### 2.1.1 图像方向分类+版面分析+表格识别
 
 ```bash linenums="1"
+# 暂时关闭新 IR 功能
+export FLAGS_enable_pir_api=0
 paddleocr --image_dir=ppstructure/docs/table/1.png --type=structure --image_orientation=true
 ```
 


### PR DESCRIPTION
This pull request includes significant updates to the `docs/ppocr/model_train/recognition.en.md` and `docs/ppstructure/quick_start.en.md` files to improve the documentation for PaddleOCR. The changes provide clearer instructions for data preparation, training, evaluation, and model inference. Additionally, there are updates to the installation instructions for PaddlePaddle with different CUDA versions.

Documentation Improvements:

* [`docs/ppocr/model_train/recognition.en.md`](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115R8-R90): Added comprehensive instructions for data preparation, including dataset formats, symbolic links, and custom datasets.
* [`docs/ppocr/model_train/recognition.en.md`](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L98-R168): Updated sections on model training, including new examples and detailed steps for mixed precision training and distributed training. [[1]](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L98-R168) [[2]](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L281-R358)
* [`docs/ppocr/model_train/recognition.en.md`](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L459-R559): Enhanced the model export and prediction section with instructions for both old and new IR modes and custom model inference. ([docs/ppocr/model_train/recognition.en.mdL459-R559](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L459-R559), F4918fafL553R556)
* [`docs/ppocr/model_train/recognition.en.md`](diffhunk://#diff-8db1254a8a85f63a7819d54673b81a4e31416613afec443818f912cb4e34b115L59-R156): Improved the multilingual training and dictionary usage sections, providing better clarity and additional examples.
* [`docs/ppstructure/quick_start.en.md`](diffhunk://#diff-a2c6c6fd8fadde136f2354b3f373aa9d8b18df0419ab9b58f60174d12bfe02d9L13-R39): Updated installation instructions for PaddlePaddle with CUDA 11.8, CUDA 12.3, and CPU versions, along with the command to temporarily disable the new IR feature. [[1]](diffhunk://#diff-a2c6c6fd8fadde136f2354b3f373aa9d8b18df0419ab9b58f60174d12bfe02d9L13-R39) [[2]](diffhunk://#diff-a2c6c6fd8fadde136f2354b3f373aa9d8b18df0419ab9b58f60174d12bfe02d9R49-R50)