### PR TITLE
fix: unable to export images without text to docx format

### DIFF
--- a/ppstructure/recovery/recovery_to_doc.py
+++ b/ppstructure/recovery/recovery_to_doc.py
@@ -37,7 +37,7 @@ def convert_info_docx(img, res, save_folder, img_name):
 
     flag = 1
     for i, region in enumerate(res):
-        if len(region["res"]) == 0:
+        if not region["res"] and region["type"].lower() != "figure":
             continue
         img_idx = region["img_idx"]
         if flag == 2 and region["layout"] == "single":

--- a/ppstructure/recovery/recovery_to_markdown.py
+++ b/ppstructure/recovery/recovery_to_markdown.py
@@ -147,7 +147,7 @@ def convert_info_markdown(res, save_folder, img_name):
     markdown_string = []
 
     for i, region in enumerate(res):
-        if len(region["res"]) == 0:
+        if not region["res"] and region["type"].lower() != "figure":
             continue
         img_idx = region["img_idx"]
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of empty regions in the `ppstructure` module. The changes ensure that regions of type "figure" are not skipped even if they have no content.

Improvements to handling empty regions:

* [`ppstructure/recovery/recovery_to_doc.py`](diffhunk://#diff-40d793b87ea5ce6dc31541b8a73dc004a5a2d9df3438bf717e9773c36b025cd3L40-R40): Modified the condition in `convert_info_docx` to continue only if the region is empty and its type is not "figure".
* [`ppstructure/recovery/recovery_to_markdown.py`](diffhunk://#diff-d4707d5b26d28fef1614cdc7e2d05fe7a096bd71c9acaeaff4510b8413290fceL150-R150): Modified the condition in `convert_info_markdown` to continue only if the region is empty and its type is not "figure".

close #14292 