### PR TITLE
paddle.shape return int64 tensor

### DIFF
--- a/ppocr/modeling/heads/rec_sar_head.py
+++ b/ppocr/modeling/heads/rec_sar_head.py
@@ -242,7 +242,7 @@ class ParallelSARDecoder(BaseDecoder):
         # bsz * (seq_len + 1) * h * w * attn_size
         attn_weight = self.conv1x1_2(attn_weight)
         # bsz * (seq_len + 1) * h * w * 1
-        bsz, T, h, w, c = paddle.shape(attn_weight)
+        bsz, T, h, w, c = paddle.shape(attn_weight).astype("int32")
         assert c == 1
 
         if valid_ratios is not None:


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/pull/69589 后 paddle.shape返回int64类型。属于Paddle的不兼容升级。需要在套件中适配。
