### PR TITLE
fix: replace `rec_image_shape` when manually set

### DIFF
--- a/paddleocr.py
+++ b/paddleocr.py
@@ -664,6 +664,8 @@ class PaddleOCR(predict_system.TextSystem):
             params.rec_image_shape = "3, 48, 320"
         else:
             params.rec_image_shape = "3, 32, 320"
+        if kwargs.get("rec_image_shape") is not None:
+            params.rec_image_shape = kwargs.get("rec_image_shape")
         # download model if using paddle infer
         if not params.use_onnx:
             maybe_download(params.det_model_dir, det_url)


### PR DESCRIPTION
修复使用自定义模型的时候，无法自定义`rec_image_shape`的问题