### PR TITLE
fix shape64

### DIFF
--- a/ppocr/modeling/heads/rec_sar_head.py
+++ b/ppocr/modeling/heads/rec_sar_head.py
@@ -242,14 +242,14 @@ class ParallelSARDecoder(BaseDecoder):
         # bsz * (seq_len + 1) * h * w * attn_size
         attn_weight = self.conv1x1_2(attn_weight)
         # bsz * (seq_len + 1) * h * w * 1
-        bsz, T, h, w, c = paddle.shape(attn_weight).astype("int32")
+        bsz, T, h, w, c = paddle.shape(attn_weight)
         assert c == 1
 
         if valid_ratios is not None:
             # cal mask of attention weight
             for i in range(valid_ratios.shape[0]):
                 valid_width = paddle.minimum(
-                    w, paddle.ceil(valid_ratios[i] * w).astype("int32")
+                    w, paddle.ceil(valid_ratios[i] * w).astype("int64")
                 )
                 if valid_width < w:
                     attn_weight[i, :, :, valid_width:, :] = float("-inf")


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleOCR/pull/14318
对shape64的改法是将paddle.shape的结果cast成int32。
更好的改法应该是，对使用paddle.shape的地方进行适配。
本PR进行修复。