### PR TITLE
remove max inplace grad

### DIFF
--- a/test_tipc/supplementary/train.py
+++ b/test_tipc/supplementary/train.py
@@ -66,7 +66,6 @@ def amp_scaler(config):
     if "AMP" in config and config["AMP"]["use_amp"] is True:
         AMP_RELATED_FLAGS_SETTING = {
             "FLAGS_cudnn_batchnorm_spatial_persistent": 1,
-            "FLAGS_max_inplace_grad_add": 8,
         }
         paddle.set_flags(AMP_RELATED_FLAGS_SETTING)
         scale_loss = config["AMP"].get("scale_loss", 1.0)

--- a/tools/eval.py
+++ b/tools/eval.py
@@ -131,7 +131,6 @@ def main():
     if use_amp:
         AMP_RELATED_FLAGS_SETTING = {
             "FLAGS_cudnn_batchnorm_spatial_persistent": 1,
-            "FLAGS_max_inplace_grad_add": 8,
         }
         paddle.set_flags(AMP_RELATED_FLAGS_SETTING)
         scale_loss = config["Global"].get("scale_loss", 1.0)

--- a/tools/train.py
+++ b/tools/train.py
@@ -181,8 +181,7 @@ def main(config, device, logger, vdl_writer, seed):
         except:
             pass
     if use_amp:
-        AMP_RELATED_FLAGS_SETTING = {
-        }
+        AMP_RELATED_FLAGS_SETTING = {}
         if paddle.is_compiled_with_cuda():
             AMP_RELATED_FLAGS_SETTING.update(
                 {

--- a/tools/train.py
+++ b/tools/train.py
@@ -182,7 +182,6 @@ def main(config, device, logger, vdl_writer, seed):
             pass
     if use_amp:
         AMP_RELATED_FLAGS_SETTING = {
-            "FLAGS_max_inplace_grad_add": 8,
         }
         if paddle.is_compiled_with_cuda():
             AMP_RELATED_FLAGS_SETTING.update(


### PR DESCRIPTION
移除FLAGS_max_inplace_grad_add的配置，这个max inplace grad add当前基于inplace的逻辑实现的，cinn不容易处理（开启编译器之后，部分任务性能会差距10%），暂时移除该配置，该配置仅影响动转静之后的性能