### PR TITLE
CPP: Make functions mostly noexcept to improve runtime performance

### DIFF
--- a/deploy/cpp_infer/include/clipper.h
+++ b/deploy/cpp_infer/include/clipper.h
@@ -85,11 +85,11 @@ struct IntPoint {
   cInt Y;
 #ifdef use_xyz
   cInt Z;
-  IntPoint(cInt x = 0, cInt y = 0, cInt z = 0) : X(x), Y(y), Z(z){};
-  IntPoint(IntPoint const &ip) : X(ip.X), Y(ip.Y), Z(ip.Z) {}
+  IntPoint(cInt x = 0, cInt y = 0, cInt z = 0) noexcept : X(x), Y(y), Z(z) {}
+  IntPoint(IntPoint const &ip) noexcept : X(ip.X), Y(ip.Y), Z(ip.Z) {}
 #else
-  IntPoint(cInt x = 0, cInt y = 0) : X(x), Y(y){};
-  IntPoint(IntPoint const &ip) : X(ip.X), Y(ip.Y) {}
+  IntPoint(cInt x = 0, cInt y = 0) noexcept : X(x), Y(y) {}
+  IntPoint(IntPoint const &ip) noexcept : X(ip.X), Y(ip.Y) {}
 #endif
 
   inline void reset(cInt x = 0, cInt y = 0) noexcept {
@@ -97,10 +97,10 @@ struct IntPoint {
     Y = y;
   }
 
-  friend inline bool operator==(const IntPoint &a, const IntPoint &b) {
+  friend inline bool operator==(const IntPoint &a, const IntPoint &b) noexcept {
     return a.X == b.X && a.Y == b.Y;
   }
-  friend inline bool operator!=(const IntPoint &a, const IntPoint &b) {
+  friend inline bool operator!=(const IntPoint &a, const IntPoint &b) noexcept {
     return a.X != b.X || a.Y != b.Y;
   }
 };
@@ -109,18 +109,18 @@ struct IntPoint {
 typedef std::vector<IntPoint> Path;
 typedef std::vector<Path> Paths;
 
-inline Path &operator<<(Path &poly, IntPoint &&p) {
+inline Path &operator<<(Path &poly, IntPoint &&p) noexcept {
   poly.emplace_back(std::forward<IntPoint>(p));
   return poly;
 }
-inline Paths &operator<<(Paths &polys, Path &&p) {
+inline Paths &operator<<(Paths &polys, Path &&p) noexcept {
   polys.emplace_back(std::forward<Path>(p));
   return polys;
 }
 
-std::ostream &operator<<(std::ostream &s, const IntPoint &p);
-std::ostream &operator<<(std::ostream &s, const Path &p);
-std::ostream &operator<<(std::ostream &s, const Paths &p);
+std::ostream &operator<<(std::ostream &s, const IntPoint &p) noexcept;
+std::ostream &operator<<(std::ostream &s, const Path &p) noexcept;
+std::ostream &operator<<(std::ostream &s, const Paths &p) noexcept;
 
 struct DoublePoint {
   double X;
@@ -158,15 +158,15 @@ typedef std::vector<PolyNode *> PolyNodes;
 
 class PolyNode {
 public:
-  PolyNode();
-  virtual ~PolyNode(){};
+  PolyNode() noexcept;
+  virtual ~PolyNode() {}
   Path Contour;
   PolyNodes Childs;
   PolyNode *Parent;
-  PolyNode *GetNext() const;
-  bool IsHole() const;
-  bool IsOpen() const;
-  int ChildCount() const;
+  PolyNode *GetNext() const noexcept;
+  bool IsHole() const noexcept;
+  bool IsOpen() const noexcept;
+  int ChildCount() const noexcept;
 
 private:
   // PolyNode& operator =(PolyNode& other);
@@ -174,18 +174,18 @@ private:
   bool m_IsOpen;
   JoinType m_jointype;
   EndType m_endtype;
-  PolyNode *GetNextSiblingUp() const;
-  void AddChild(PolyNode &child);
+  PolyNode *GetNextSiblingUp() const noexcept;
+  void AddChild(PolyNode &child) noexcept;
   friend class Clipper; // to access Index
   friend class ClipperOffset;
 };
 
 class PolyTree : public PolyNode {
 public:
-  ~PolyTree() { Clear(); };
-  PolyNode *GetFirst() const;
-  void Clear();
-  int Total() const;
+  ~PolyTree() { Clear(); }
+  PolyNode *GetFirst() const noexcept;
+  void Clear() noexcept;
+  int Total() const noexcept;
 
 private:
   // PolyTree& operator =(PolyTree& other);
@@ -193,34 +193,40 @@ private:
   friend class Clipper; // to access AllNodes
 };
 
-bool Orientation(const Path &poly);
-double Area(const Path &poly);
-int PointInPolygon(const IntPoint &pt, const Path &path);
+bool Orientation(const Path &poly) noexcept;
+double Area(const Path &poly) noexcept;
+int PointInPolygon(const IntPoint &pt, const Path &path) noexcept;
 
+#if 0
 void SimplifyPolygon(const Path &in_poly, Paths &out_polys,
                      PolyFillType fillType = pftEvenOdd);
 void SimplifyPolygons(const Paths &in_polys, Paths &out_polys,
                       PolyFillType fillType = pftEvenOdd);
 void SimplifyPolygons(Paths &polys, PolyFillType fillType = pftEvenOdd);
+#endif
 
-void CleanPolygon(const Path &in_poly, Path &out_poly, double distance = 1.415);
-void CleanPolygon(Path &poly, double distance = 1.415);
+void CleanPolygon(const Path &in_poly, Path &out_poly,
+                  double distance = 1.415) noexcept;
+void CleanPolygon(Path &poly, double distance = 1.415) noexcept;
 void CleanPolygons(const Paths &in_polys, Paths &out_polys,
-                   double distance = 1.415);
-void CleanPolygons(Paths &polys, double distance = 1.415);
+                   double distance = 1.415) noexcept;
+void CleanPolygons(Paths &polys, double distance = 1.415) noexcept;
 
+#if 0
 void MinkowskiSum(const Path &pattern, const Path &path, Paths &solution,
                   bool pathIsClosed);
 void MinkowskiSum(const Path &pattern, const Paths &paths, Paths &solution,
                   bool pathIsClosed);
+
 void MinkowskiDiff(const Path &poly1, const Path &poly2, Paths &solution);
+#endif
 
-void PolyTreeToPaths(const PolyTree &polytree, Paths &paths);
-void ClosedPathsFromPolyTree(const PolyTree &polytree, Paths &paths);
-void OpenPathsFromPolyTree(PolyTree &polytree, Paths &paths);
+void PolyTreeToPaths(const PolyTree &polytree, Paths &paths) noexcept;
+void ClosedPathsFromPolyTree(const PolyTree &polytree, Paths &paths) noexcept;
+void OpenPathsFromPolyTree(PolyTree &polytree, Paths &paths) noexcept;
 
-void ReversePath(Path &p);
-void ReversePaths(Paths &p);
+void ReversePath(Path &p) noexcept;
+void ReversePaths(Paths &p) noexcept;
 
 struct IntRect {
   cInt left;
@@ -252,29 +258,29 @@ typedef std::vector<IntersectNode *> IntersectList;
 // polygon coordinates into edge objects that are stored in a LocalMinima list.
 class ClipperBase {
 public:
-  ClipperBase();
+  ClipperBase() noexcept;
   virtual ~ClipperBase();
   virtual bool AddPath(const Path &pg, PolyType PolyTyp, bool Closed);
   bool AddPaths(const Paths &ppg, PolyType PolyTyp, bool Closed);
-  virtual void Clear();
-  IntRect GetBounds();
-  bool PreserveCollinear() { return m_PreserveCollinear; };
-  void PreserveCollinear(bool value) { m_PreserveCollinear = value; };
+  virtual void Clear() noexcept;
+  IntRect GetBounds() noexcept;
+  bool PreserveCollinear() const noexcept { return m_PreserveCollinear; }
+  void PreserveCollinear(bool value) noexcept { m_PreserveCollinear = value; }
 
 protected:
-  void DisposeLocalMinimaList();
-  TEdge *AddBoundsToLML(TEdge *e, bool IsClosed);
-  virtual void Reset();
-  TEdge *ProcessBound(TEdge *E, bool IsClockwise);
-  void InsertScanbeam(const cInt Y);
-  bool PopScanbeam(cInt &Y);
-  bool LocalMinimaPending();
-  bool PopLocalMinima(cInt Y, const LocalMinimum *&locMin);
-  OutRec *CreateOutRec();
-  void DisposeAllOutRecs();
-  void DisposeOutRec(PolyOutList::size_type index);
-  void SwapPositionsInAEL(TEdge *edge1, TEdge *edge2);
-  void DeleteFromAEL(TEdge *e);
+  void DisposeLocalMinimaList() noexcept;
+  TEdge *AddBoundsToLML(TEdge *e, bool IsClosed) noexcept;
+  virtual void Reset() noexcept;
+  TEdge *ProcessBound(TEdge *E, bool IsClockwise) noexcept;
+  void InsertScanbeam(const cInt Y) noexcept;
+  bool PopScanbeam(cInt &Y) noexcept;
+  bool LocalMinimaPending() noexcept;
+  bool PopLocalMinima(cInt Y, const LocalMinimum *&locMin) noexcept;
+  OutRec *CreateOutRec() noexcept;
+  void DisposeAllOutRecs() noexcept;
+  void DisposeOutRec(PolyOutList::size_type index) noexcept;
+  void SwapPositionsInAEL(TEdge *edge1, TEdge *edge2) noexcept;
+  void DeleteFromAEL(TEdge *e) noexcept;
   void UpdateEdgeIntoAEL(TEdge *&e);
 
   typedef std::vector<LocalMinimum> MinimaList;
@@ -295,26 +301,26 @@ protected:
 
 class Clipper : public virtual ClipperBase {
 public:
-  Clipper(int initOptions = 0);
+  Clipper(int initOptions = 0) noexcept;
   bool Execute(ClipType clipType, Paths &solution,
                PolyFillType fillType = pftEvenOdd);
   bool Execute(ClipType clipType, Paths &solution, PolyFillType subjFillType,
                PolyFillType clipFillType);
   bool Execute(ClipType clipType, PolyTree &polytree,
-               PolyFillType fillType = pftEvenOdd);
+               PolyFillType fillType = pftEvenOdd) noexcept;
   bool Execute(ClipType clipType, PolyTree &polytree, PolyFillType subjFillType,
-               PolyFillType clipFillType);
-  bool ReverseSolution() { return m_ReverseOutput; };
-  void ReverseSolution(bool value) { m_ReverseOutput = value; };
-  bool StrictlySimple() { return m_StrictSimple; };
-  void StrictlySimple(bool value) { m_StrictSimple = value; };
+               PolyFillType clipFillType) noexcept;
+  bool ReverseSolution() const noexcept { return m_ReverseOutput; }
+  void ReverseSolution(bool value) noexcept { m_ReverseOutput = value; }
+  bool StrictlySimple() const noexcept { return m_StrictSimple; }
+  void StrictlySimple(bool value) noexcept { m_StrictSimple = value; }
 // set the callback function for z value filling on intersections (otherwise Z
 // is 0)
 #ifdef use_xyz
-  void ZFillFunction(ZFillCallback zFillFunc);
+  void ZFillFunction(ZFillCallback zFillFunc) noexcept;
 #endif
 protected:
-  virtual bool ExecuteInternal();
+  virtual bool ExecuteInternal() noexcept;
 
 private:
   JoinList m_Joins;
@@ -333,71 +339,73 @@ private:
 #ifdef use_xyz
   ZFillCallback m_ZFill; // custom callback
 #endif
-  void SetWindingCount(TEdge &edge);
-  bool IsEvenOddFillType(const TEdge &edge) const;
-  bool IsEvenOddAltFillType(const TEdge &edge) const;
-  void InsertLocalMinimaIntoAEL(const cInt botY);
-  void InsertEdgeIntoAEL(TEdge *edge, TEdge *startEdge);
-  void AddEdgeToSEL(TEdge *edge);
-  bool PopEdgeFromSEL(TEdge *&edge);
-  void CopyAELToSEL();
-  void DeleteFromSEL(TEdge *e);
-  void SwapPositionsInSEL(TEdge *edge1, TEdge *edge2);
-  bool IsContributing(const TEdge &edge) const;
-  bool IsTopHorz(const cInt XPos);
+  void SetWindingCount(TEdge &edge) noexcept;
+  bool IsEvenOddFillType(const TEdge &edge) const noexcept;
+  bool IsEvenOddAltFillType(const TEdge &edge) const noexcept;
+  void InsertLocalMinimaIntoAEL(const cInt botY) noexcept;
+  void InsertEdgeIntoAEL(TEdge *edge, TEdge *startEdge) noexcept;
+  void AddEdgeToSEL(TEdge *edge) noexcept;
+  bool PopEdgeFromSEL(TEdge *&edge) noexcept;
+  void CopyAELToSEL() noexcept;
+  void DeleteFromSEL(TEdge *e) noexcept;
+  void SwapPositionsInSEL(TEdge *edge1, TEdge *edge2) noexcept;
+  bool IsContributing(const TEdge &edge) const noexcept;
+  bool IsTopHorz(const cInt XPos) noexcept;
   void DoMaxima(TEdge *e);
-  void ProcessHorizontals();
-  void ProcessHorizontal(TEdge *horzEdge);
-  void AddLocalMaxPoly(TEdge *e1, TEdge *e2, const IntPoint &pt);
-  OutPt *AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &pt);
-  OutRec *GetOutRec(int idx);
-  void AppendPolygon(TEdge *e1, TEdge *e2);
-  void IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &pt);
-  OutPt *AddOutPt(TEdge *e, const IntPoint &pt);
-  OutPt *GetLastOutPt(TEdge *e);
+  void ProcessHorizontals() noexcept;
+  void ProcessHorizontal(TEdge *horzEdge) noexcept;
+  void AddLocalMaxPoly(TEdge *e1, TEdge *e2, const IntPoint &pt) noexcept;
+  OutPt *AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &pt) noexcept;
+  OutRec *GetOutRec(int idx) noexcept;
+  void AppendPolygon(TEdge *e1, TEdge *e2) noexcept;
+  void IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &pt) noexcept;
+  OutPt *AddOutPt(TEdge *e, const IntPoint &pt) noexcept;
+  OutPt *GetLastOutPt(TEdge *e) noexcept;
   bool ProcessIntersections(const cInt topY);
-  void BuildIntersectList(const cInt topY);
-  void ProcessIntersectList();
+  void BuildIntersectList(const cInt topY) noexcept;
+  void ProcessIntersectList() noexcept;
   void ProcessEdgesAtTopOfScanbeam(const cInt topY);
-  void BuildResult(Paths &polys);
-  void BuildResult2(PolyTree &polytree);
-  void SetHoleState(TEdge *e, OutRec *outrec);
-  void DisposeIntersectNodes();
-  bool FixupIntersectionOrder();
-  void FixupOutPolygon(OutRec &outrec);
-  void FixupOutPolyline(OutRec &outrec);
-  bool IsHole(TEdge *e);
-  bool FindOwnerFromSplitRecs(OutRec &outRec, OutRec *&currOrfl);
-  void FixHoleLinkage(OutRec &outrec);
-  void AddJoin(OutPt *op1, OutPt *op2, const IntPoint offPt);
-  void ClearJoins();
-  void ClearGhostJoins();
-  void AddGhostJoin(OutPt *op, const IntPoint offPt);
-  bool JoinPoints(Join *j, OutRec *outRec1, OutRec *outRec2);
-  void JoinCommonEdges();
-  void DoSimplePolygons();
-  void FixupFirstLefts1(OutRec *OldOutRec, OutRec *NewOutRec);
-  void FixupFirstLefts2(OutRec *InnerOutRec, OutRec *OuterOutRec);
-  void FixupFirstLefts3(OutRec *OldOutRec, OutRec *NewOutRec);
+  void BuildResult(Paths &polys) noexcept;
+  void BuildResult2(PolyTree &polytree) noexcept;
+  void SetHoleState(TEdge *e, OutRec *outrec) noexcept;
+  void DisposeIntersectNodes() noexcept;
+  bool FixupIntersectionOrder() noexcept;
+  void FixupOutPolygon(OutRec &outrec) noexcept;
+  void FixupOutPolyline(OutRec &outrec) noexcept;
+  bool IsHole(TEdge *e) noexcept;
+  bool FindOwnerFromSplitRecs(OutRec &outRec, OutRec *&currOrfl) noexcept;
+  void FixHoleLinkage(OutRec &outrec) noexcept;
+  void AddJoin(OutPt *op1, OutPt *op2, const IntPoint offPt) noexcept;
+  void ClearJoins() noexcept;
+  void ClearGhostJoins() noexcept;
+  void AddGhostJoin(OutPt *op, const IntPoint offPt) noexcept;
+  bool JoinPoints(Join *j, OutRec *outRec1, OutRec *outRec2) noexcept;
+  void JoinCommonEdges() noexcept;
+  void DoSimplePolygons() noexcept;
+  void FixupFirstLefts1(OutRec *OldOutRec, OutRec *NewOutRec) noexcept;
+  void FixupFirstLefts2(OutRec *InnerOutRec, OutRec *OuterOutRec) noexcept;
+  void FixupFirstLefts3(OutRec *OldOutRec, OutRec *NewOutRec) noexcept;
 #ifdef use_xyz
-  void SetZ(IntPoint &pt, TEdge &e1, TEdge &e2);
+  void SetZ(IntPoint &pt, TEdge &e1, TEdge &e2) noexcept;
 #endif
 };
 //------------------------------------------------------------------------------
 
 class ClipperOffset {
 public:
-  ClipperOffset(double miterLimit = 2.0, double roundPrecision = 0.25);
+  ClipperOffset(double miterLimit = 2.0, double roundPrecision = 0.25) noexcept;
   ~ClipperOffset();
-  void AddPath(const Path &path, JoinType joinType, EndType endType);
-  void AddPaths(const Paths &paths, JoinType joinType, EndType endType);
-  void Execute(Paths &solution, double delta);
-  void Execute(PolyTree &solution, double delta);
-  void Clear();
+  void AddPath(const Path &path, JoinType joinType, EndType endType) noexcept;
+  void AddPaths(const Paths &paths, JoinType joinType,
+                EndType endType) noexcept;
+  bool Execute(Paths &solution, double delta) noexcept;
+  bool Execute(PolyTree &solution, double delta) noexcept;
+  void Clear() noexcept;
+
+private:
   double MiterLimit;
   double ArcTolerance;
 
-private:
   Paths m_destPolys;
   Path m_srcPoly;
   Path m_destPoly;
@@ -407,20 +415,20 @@ private:
   IntPoint m_lowest;
   PolyNode m_polyNodes;
 
-  void FixOrientations();
-  void DoOffset(double delta);
-  void OffsetPoint(int j, int &k, JoinType jointype);
-  void DoSquare(int j, int k);
-  void DoMiter(int j, int k, double r);
-  void DoRound(int j, int k);
+  void FixOrientations() noexcept;
+  void DoOffset(double delta) noexcept;
+  void OffsetPoint(int j, int &k, JoinType jointype) noexcept;
+  void DoSquare(int j, int k) noexcept;
+  void DoMiter(int j, int k, double r) noexcept;
+  void DoRound(int j, int k) noexcept;
 };
 //------------------------------------------------------------------------------
 
 class clipperException : public std::exception {
 public:
-  clipperException(const char *description) : m_descr(description) {}
-  virtual ~clipperException() throw() {}
-  virtual const char *what() const throw() { return m_descr.c_str(); }
+  clipperException(const char *description) noexcept : m_descr(description) {}
+  ~clipperException() {}
+  virtual const char *what() const noexcept { return m_descr.c_str(); }
 
 private:
   std::string m_descr;

--- a/deploy/cpp_infer/include/ocr_cls.h
+++ b/deploy/cpp_infer/include/ocr_cls.h
@@ -29,7 +29,7 @@ public:
                       const int &cpu_math_library_num_threads,
                       const bool &use_mkldnn, const double &cls_thresh,
                       const bool &use_tensorrt, const std::string &precision,
-                      const int &cls_batch_num) {
+                      const int &cls_batch_num) noexcept {
     this->use_gpu_ = use_gpu;
     this->gpu_id_ = gpu_id;
     this->gpu_mem_ = gpu_mem;
@@ -46,10 +46,10 @@ public:
   double cls_thresh = 0.9;
 
   // Load Paddle inference model
-  void LoadModel(const std::string &model_dir);
+  void LoadModel(const std::string &model_dir) noexcept;
 
   void Run(const std::vector<cv::Mat> &img_list, std::vector<int> &cls_labels,
-           std::vector<float> &cls_scores, std::vector<double> &times);
+           std::vector<float> &cls_scores, std::vector<double> &times) noexcept;
 
 private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp_infer/include/ocr_det.h
+++ b/deploy/cpp_infer/include/ocr_det.h
@@ -33,7 +33,7 @@ public:
                       const double &det_db_unclip_ratio,
                       const std::string &det_db_score_mode,
                       const bool &use_dilation, const bool &use_tensorrt,
-                      const std::string &precision) {
+                      const std::string &precision) noexcept {
     this->use_gpu_ = use_gpu;
     this->gpu_id_ = gpu_id;
     this->gpu_mem_ = gpu_mem;
@@ -56,12 +56,12 @@ public:
   }
 
   // Load Paddle inference model
-  void LoadModel(const std::string &model_dir);
+  void LoadModel(const std::string &model_dir) noexcept;
 
   // Run predictor
   void Run(const cv::Mat &img,
            std::vector<std::vector<std::vector<int>>> &boxes,
-           std::vector<double> &times);
+           std::vector<double> &times) noexcept;
 
 private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp_infer/include/ocr_rec.h
+++ b/deploy/cpp_infer/include/ocr_rec.h
@@ -31,7 +31,7 @@ public:
                           const bool &use_tensorrt,
                           const std::string &precision,
                           const int &rec_batch_num, const int &rec_img_h,
-                          const int &rec_img_w) {
+                          const int &rec_img_w) noexcept {
     this->use_gpu_ = use_gpu;
     this->gpu_id_ = gpu_id;
     this->gpu_mem_ = gpu_mem;
@@ -54,11 +54,12 @@ public:
   }
 
   // Load Paddle inference model
-  void LoadModel(const std::string &model_dir);
+  void LoadModel(const std::string &model_dir) noexcept;
 
   void Run(const std::vector<cv::Mat> &img_list,
            std::vector<std::string> &rec_texts,
-           std::vector<float> &rec_text_scores, std::vector<double> &times);
+           std::vector<float> &rec_text_scores,
+           std::vector<double> &times) noexcept;
 
 private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp_infer/include/paddleocr.h
+++ b/deploy/cpp_infer/include/paddleocr.h
@@ -22,28 +22,29 @@ namespace PaddleOCR {
 
 class PPOCR {
 public:
-  explicit PPOCR();
-  virtual ~PPOCR(){};
+  explicit PPOCR() noexcept;
+  virtual ~PPOCR() {}
 
   std::vector<std::vector<OCRPredictResult>>
   ocr(const std::vector<cv::Mat> &img_list, bool det = true, bool rec = true,
-      bool cls = true);
+      bool cls = true) noexcept;
   std::vector<OCRPredictResult> ocr(const cv::Mat &img, bool det = true,
-                                    bool rec = true, bool cls = true);
+                                    bool rec = true, bool cls = true) noexcept;
 
-  void reset_timer();
-  void benchmark_log(int img_num);
+  void reset_timer() noexcept;
+  void benchmark_log(int img_num) noexcept;
 
 protected:
   std::vector<double> time_info_det = {0, 0, 0};
   std::vector<double> time_info_rec = {0, 0, 0};
   std::vector<double> time_info_cls = {0, 0, 0};
 
-  void det(const cv::Mat &img, std::vector<OCRPredictResult> &ocr_results);
+  void det(const cv::Mat &img,
+           std::vector<OCRPredictResult> &ocr_results) noexcept;
   void rec(const std::vector<cv::Mat> &img_list,
-           std::vector<OCRPredictResult> &ocr_results);
+           std::vector<OCRPredictResult> &ocr_results) noexcept;
   void cls(const std::vector<cv::Mat> &img_list,
-           std::vector<OCRPredictResult> &ocr_results);
+           std::vector<OCRPredictResult> &ocr_results) noexcept;
 
 private:
   std::unique_ptr<DBDetector> detector_;

--- a/deploy/cpp_infer/include/paddlestructure.h
+++ b/deploy/cpp_infer/include/paddlestructure.h
@@ -22,16 +22,16 @@ namespace PaddleOCR {
 
 class PaddleStructure : public PPOCR {
 public:
-  explicit PaddleStructure();
+  explicit PaddleStructure() noexcept;
   ~PaddleStructure() = default;
 
   std::vector<StructurePredictResult> structure(const cv::Mat &img,
                                                 bool layout = false,
                                                 bool table = true,
-                                                bool ocr = false);
+                                                bool ocr = false) noexcept;
 
-  void reset_timer();
-  void benchmark_log(int img_num);
+  void reset_timer() noexcept;
+  void benchmark_log(int img_num) noexcept;
 
 private:
   std::vector<double> time_info_table = {0, 0, 0};
@@ -41,18 +41,20 @@ private:
   std::unique_ptr<StructureLayoutRecognizer> layout_model_;
 
   void layout(const cv::Mat &img,
-              std::vector<StructurePredictResult> &structure_result);
+              std::vector<StructurePredictResult> &structure_result) noexcept;
 
-  void table(const cv::Mat &img, StructurePredictResult &structure_result);
+  void table(const cv::Mat &img,
+             StructurePredictResult &structure_result) noexcept;
 
   std::string rebuild_table(const std::vector<std::string> &rec_html_tags,
                             const std::vector<std::vector<int>> &rec_boxes,
-                            std::vector<OCRPredictResult> &ocr_result);
+                            std::vector<OCRPredictResult> &ocr_result) noexcept;
 
-  float dis(const std::vector<int> &box1, const std::vector<int> &box2);
+  float dis(const std::vector<int> &box1,
+            const std::vector<int> &box2) noexcept;
 
   static bool comparison_dis(const std::vector<float> &dis1,
-                             const std::vector<float> &dis2) {
+                             const std::vector<float> &dis2) noexcept {
     if (dis1[1] < dis2[1]) {
       return true;
     } else if (dis1[1] == dis2[1]) {

--- a/deploy/cpp_infer/include/postprocess_op.h
+++ b/deploy/cpp_infer/include/postprocess_op.h
@@ -22,39 +22,41 @@ namespace PaddleOCR {
 class DBPostProcessor {
 public:
   void GetContourArea(const std::vector<std::vector<float>> &box,
-                      float unclip_ratio, float &distance);
+                      float unclip_ratio, float &distance) noexcept;
 
   cv::RotatedRect UnClip(const std::vector<std::vector<float>> &box,
-                         const float &unclip_ratio);
+                         const float &unclip_ratio) noexcept;
 
-  float **Mat2Vec(const cv::Mat &mat);
+  float **Mat2Vec(const cv::Mat &mat) noexcept;
 
   std::vector<std::vector<int>>
-  OrderPointsClockwise(const std::vector<std::vector<int>> &pts);
+  OrderPointsClockwise(const std::vector<std::vector<int>> &pts) noexcept;
 
   std::vector<std::vector<float>> GetMiniBoxes(const cv::RotatedRect &box,
-                                               float &ssid);
+                                               float &ssid) noexcept;
 
   float BoxScoreFast(const std::vector<std::vector<float>> &box_array,
-                     const cv::Mat &pred);
+                     const cv::Mat &pred) noexcept;
   float PolygonScoreAcc(const std::vector<cv::Point> &contour,
-                        const cv::Mat &pred);
+                        const cv::Mat &pred) noexcept;
 
   std::vector<std::vector<std::vector<int>>>
   BoxesFromBitmap(const cv::Mat &pred, const cv::Mat &bitmap,
                   const float &box_thresh, const float &det_db_unclip_ratio,
-                  const std::string &det_db_score_mode);
+                  const std::string &det_db_score_mode) noexcept;
 
   void FilterTagDetRes(std::vector<std::vector<std::vector<int>>> &boxes,
-                       float ratio_h, float ratio_w, const cv::Mat &srcimg);
+                       float ratio_h, float ratio_w,
+                       const cv::Mat &srcimg) noexcept;
 
 private:
-  static bool XsortInt(const std::vector<int> &a, const std::vector<int> &b);
+  static bool XsortInt(const std::vector<int> &a,
+                       const std::vector<int> &b) noexcept;
 
   static bool XsortFp32(const std::vector<float> &a,
-                        const std::vector<float> &b);
+                        const std::vector<float> &b) noexcept;
 
-  std::vector<std::vector<float>> Mat2Vector(const cv::Mat &mat);
+  std::vector<std::vector<float>> Mat2Vector(const cv::Mat &mat) noexcept;
 
   inline int _max(int a, int b) const noexcept { return a >= b ? a : b; }
 
@@ -79,7 +81,8 @@ private:
 
 class TablePostProcessor {
 public:
-  void init(const std::string &label_path, bool merge_no_span_structure = true);
+  void init(const std::string &label_path,
+            bool merge_no_span_structure = true) noexcept;
   void Run(const std::vector<float> &loc_preds,
            const std::vector<float> &structure_probs,
            std::vector<float> &rec_scores,
@@ -88,7 +91,7 @@ public:
            std::vector<std::vector<std::string>> &rec_html_tag_batch,
            std::vector<std::vector<std::vector<int>>> &rec_boxes_batch,
            const std::vector<int> &width_list,
-           const std::vector<int> &height_list);
+           const std::vector<int> &height_list) noexcept;
 
 private:
   std::vector<std::string> label_list_;
@@ -100,21 +103,21 @@ class PicodetPostProcessor {
 public:
   void init(const std::string &label_path, const double score_threshold = 0.4,
             const double nms_threshold = 0.5,
-            const std::vector<int> &fpn_stride = {8, 16, 32, 64});
+            const std::vector<int> &fpn_stride = {8, 16, 32, 64}) noexcept;
   void Run(std::vector<StructurePredictResult> &results,
            const std::vector<std::vector<float>> &outs,
            const std::vector<int> &ori_shape,
-           const std::vector<int> &resize_shape, int eg_max);
-  inline size_t fpn_stride_size() const { return fpn_stride_.size(); }
+           const std::vector<int> &resize_shape, int eg_max) noexcept;
+  inline size_t fpn_stride_size() const noexcept { return fpn_stride_.size(); }
 
 private:
   StructurePredictResult disPred2Bbox(const std::vector<float> &bbox_pred,
                                       int label, float score, int x, int y,
                                       int stride,
                                       const std::vector<int> &im_shape,
-                                      int reg_max);
+                                      int reg_max) noexcept;
   void nms(std::vector<StructurePredictResult> &input_boxes,
-           float nms_threshold);
+           float nms_threshold) noexcept;
 
   std::vector<int> fpn_stride_ = {8, 16, 32, 64};
 

--- a/deploy/cpp_infer/include/preprocess_op.h
+++ b/deploy/cpp_infer/include/preprocess_op.h
@@ -26,57 +26,59 @@ namespace PaddleOCR {
 class Normalize {
 public:
   virtual void Run(cv::Mat &im, const std::vector<float> &mean,
-                   const std::vector<float> &scale, const bool is_scale = true);
+                   const std::vector<float> &scale,
+                   const bool is_scale = true) noexcept;
 };
 
 // RGB -> CHW
 class Permute {
 public:
-  virtual void Run(const cv::Mat &im, float *data);
+  virtual void Run(const cv::Mat &im, float *data) noexcept;
 };
 
 class PermuteBatch {
 public:
-  virtual void Run(const std::vector<cv::Mat> &imgs, float *data);
+  virtual void Run(const std::vector<cv::Mat> &imgs, float *data) noexcept;
 };
 
 class ResizeImgType0 {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img,
                    const std::string &limit_type, int limit_side_len,
-                   float &ratio_h, float &ratio_w, bool use_tensorrt);
+                   float &ratio_h, float &ratio_w, bool use_tensorrt) noexcept;
 };
 
 class CrnnResizeImg {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
                    bool use_tensorrt = false,
-                   const std::vector<int> &rec_image_shape = {3, 32, 320});
+                   const std::vector<int> &rec_image_shape = {3, 32,
+                                                              320}) noexcept;
 };
 
 class ClsResizeImg {
 public:
-  virtual void Run(const cv::Mat &img, cv::Mat &resize_img,
-                   bool use_tensorrt = false,
-                   const std::vector<int> &rec_image_shape = {3, 48, 192});
+  virtual void
+  Run(const cv::Mat &img, cv::Mat &resize_img, bool use_tensorrt = false,
+      const std::vector<int> &rec_image_shape = {3, 48, 192}) noexcept;
 };
 
 class TableResizeImg {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img,
-                   const int max_len = 488);
+                   const int max_len = 488) noexcept;
 };
 
 class TablePadImg {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img,
-                   const int max_len = 488);
+                   const int max_len = 488) noexcept;
 };
 
 class Resize {
 public:
   virtual void Run(const cv::Mat &img, cv::Mat &resize_img, const int h,
-                   const int w);
+                   const int w) noexcept;
 };
 
 } // namespace PaddleOCR

--- a/deploy/cpp_infer/include/structure_layout.h
+++ b/deploy/cpp_infer/include/structure_layout.h
@@ -30,7 +30,7 @@ public:
       const bool &use_mkldnn, const std::string &label_path,
       const bool &use_tensorrt, const std::string &precision,
       const double &layout_score_threshold,
-      const double &layout_nms_threshold) {
+      const double &layout_nms_threshold) noexcept {
     this->use_gpu_ = use_gpu;
     this->gpu_id_ = gpu_id;
     this->gpu_mem_ = gpu_mem;
@@ -45,10 +45,10 @@ public:
   }
 
   // Load Paddle inference model
-  void LoadModel(const std::string &model_dir);
+  void LoadModel(const std::string &model_dir) noexcept;
 
   void Run(const cv::Mat &img, std::vector<StructurePredictResult> &result,
-           std::vector<double> &times);
+           std::vector<double> &times) noexcept;
 
 private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp_infer/include/structure_table.h
+++ b/deploy/cpp_infer/include/structure_table.h
@@ -30,7 +30,7 @@ public:
       const bool &use_mkldnn, const std::string &label_path,
       const bool &use_tensorrt, const std::string &precision,
       const int &table_batch_num, const int &table_max_len,
-      const bool &merge_no_span_structure) {
+      const bool &merge_no_span_structure) noexcept {
     this->use_gpu_ = use_gpu;
     this->gpu_id_ = gpu_id;
     this->gpu_mem_ = gpu_mem;
@@ -46,13 +46,13 @@ public:
   }
 
   // Load Paddle inference model
-  void LoadModel(const std::string &model_dir);
+  void LoadModel(const std::string &model_dir) noexcept;
 
   void Run(const std::vector<cv::Mat> &img_list,
            std::vector<std::vector<std::string>> &rec_html_tags,
            std::vector<float> &rec_scores,
            std::vector<std::vector<std::vector<int>>> &rec_boxes,
-           std::vector<double> &times);
+           std::vector<double> &times) noexcept;
 
 private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp_infer/include/utility.h
+++ b/deploy/cpp_infer/include/utility.h
@@ -52,55 +52,60 @@ struct StructurePredictResult {
 
 class Utility {
 public:
-  static std::vector<std::string> ReadDict(const std::string &path);
+  static std::vector<std::string> ReadDict(const std::string &path) noexcept;
 
   static void VisualizeBboxes(const cv::Mat &srcimg,
                               const std::vector<OCRPredictResult> &ocr_result,
-                              const std::string &save_path);
+                              const std::string &save_path) noexcept;
 
   static void VisualizeBboxes(const cv::Mat &srcimg,
                               const StructurePredictResult &structure_result,
-                              const std::string &save_path);
+                              const std::string &save_path) noexcept;
 
   template <class ForwardIterator>
-  inline static size_t argmax(ForwardIterator first, ForwardIterator last) {
+  inline static size_t argmax(ForwardIterator first,
+                              ForwardIterator last) noexcept {
     return std::distance(first, std::max_element(first, last));
   }
 
   static void GetAllFiles(const char *dir_name,
-                          std::vector<std::string> &all_inputs);
+                          std::vector<std::string> &all_inputs) noexcept;
 
-  static cv::Mat GetRotateCropImage(const cv::Mat &srcimage,
-                                    const std::vector<std::vector<int>> &box);
+  static cv::Mat
+  GetRotateCropImage(const cv::Mat &srcimage,
+                     const std::vector<std::vector<int>> &box) noexcept;
 
-  static std::vector<int> argsort(const std::vector<float> &array);
+  static std::vector<int> argsort(const std::vector<float> &array) noexcept;
 
-  static std::string basename(const std::string &filename);
+  static std::string basename(const std::string &filename) noexcept;
 
-  static bool PathExists(const std::string &path);
+  static bool PathExists(const std::string &path) noexcept;
 
-  static void CreateDir(const std::string &path);
+  static void CreateDir(const std::string &path) noexcept;
 
-  static void print_result(const std::vector<OCRPredictResult> &ocr_result);
+  static void
+  print_result(const std::vector<OCRPredictResult> &ocr_result) noexcept;
 
-  static cv::Mat crop_image(cv::Mat &img, const std::vector<int> &area);
-  static cv::Mat crop_image(cv::Mat &img, const std::vector<float> &area);
+  static cv::Mat crop_image(cv::Mat &img,
+                            const std::vector<int> &area) noexcept;
+  static cv::Mat crop_image(cv::Mat &img,
+                            const std::vector<float> &area) noexcept;
 
-  static void sorted_boxes(std::vector<OCRPredictResult> &ocr_result);
+  static void sorted_boxes(std::vector<OCRPredictResult> &ocr_result) noexcept;
 
   static std::vector<int>
-  xyxyxyxy2xyxy(const std::vector<std::vector<int>> &box);
-  static std::vector<int> xyxyxyxy2xyxy(const std::vector<int> &box);
+  xyxyxyxy2xyxy(const std::vector<std::vector<int>> &box) noexcept;
+  static std::vector<int> xyxyxyxy2xyxy(const std::vector<int> &box) noexcept;
 
-  static float fast_exp(float x);
+  static float fast_exp(float x) noexcept;
   static std::vector<float>
-  activation_function_softmax(std::vector<float> &src);
-  static float iou(std::vector<int> &box1, std::vector<int> &box2);
-  static float iou(std::vector<float> &box1, std::vector<float> &box2);
+  activation_function_softmax(std::vector<float> &src) noexcept;
+  static float iou(std::vector<int> &box1, std::vector<int> &box2) noexcept;
+  static float iou(std::vector<float> &box1, std::vector<float> &box2) noexcept;
 
 private:
   static bool comparison_box(const OCRPredictResult &result1,
-                             const OCRPredictResult &result2) {
+                             const OCRPredictResult &result2) noexcept {
     if (result1.box[0][1] < result2.box[0][1]) {
       return true;
     } else if (result1.box[0][1] == result2.box[0][1]) {

--- a/deploy/cpp_infer/src/clipper.cpp
+++ b/deploy/cpp_infer/src/clipper.cpp
@@ -120,7 +120,7 @@ struct Join {
 
 struct LocMinSorter {
   inline bool operator()(const LocalMinimum &locMin1,
-                         const LocalMinimum &locMin2) {
+                         const LocalMinimum &locMin2) noexcept {
     return locMin2.Y < locMin1.Y;
   }
 };
@@ -128,7 +128,7 @@ struct LocMinSorter {
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 
-inline cInt Round(double val) {
+inline cInt Round(double val) noexcept {
   if ((val < 0))
     return static_cast<cInt>(val - 0.5);
   else
@@ -136,13 +136,13 @@ inline cInt Round(double val) {
 }
 //------------------------------------------------------------------------------
 
-inline cInt Abs(cInt val) { return val < 0 ? -val : val; }
+inline cInt Abs(cInt val) noexcept { return val < 0 ? -val : val; }
 
 //------------------------------------------------------------------------------
 // PolyTree methods ...
 //------------------------------------------------------------------------------
 
-void PolyTree::Clear() {
+void PolyTree::Clear() noexcept {
   for (PolyNodes::size_type i = 0; i < AllNodes.size(); ++i)
     delete AllNodes[i];
   AllNodes.resize(0);
@@ -150,7 +150,7 @@ void PolyTree::Clear() {
 }
 //------------------------------------------------------------------------------
 
-PolyNode *PolyTree::GetFirst() const {
+PolyNode *PolyTree::GetFirst() const noexcept {
   if (!Childs.empty())
     return Childs[0];
   else
@@ -158,7 +158,7 @@ PolyNode *PolyTree::GetFirst() const {
 }
 //------------------------------------------------------------------------------
 
-int PolyTree::Total() const {
+int PolyTree::Total() const noexcept {
   int result = (int)AllNodes.size();
   // with negative offsets, ignore the hidden outer polygon ...
   if (result > 0 && Childs[0] != AllNodes[0])
@@ -170,13 +170,13 @@ int PolyTree::Total() const {
 // PolyNode methods ...
 //------------------------------------------------------------------------------
 
-PolyNode::PolyNode() : Parent(0), Index(0), m_IsOpen(false) {}
+PolyNode::PolyNode() noexcept : Parent(0), Index(0), m_IsOpen(false) {}
 //------------------------------------------------------------------------------
 
-int PolyNode::ChildCount() const { return (int)Childs.size(); }
+int PolyNode::ChildCount() const noexcept { return (int)Childs.size(); }
 //------------------------------------------------------------------------------
 
-void PolyNode::AddChild(PolyNode &child) {
+void PolyNode::AddChild(PolyNode &child) noexcept {
   unsigned cnt = (unsigned)Childs.size();
   Childs.emplace_back(&child);
   child.Parent = this;
@@ -184,7 +184,7 @@ void PolyNode::AddChild(PolyNode &child) {
 }
 //------------------------------------------------------------------------------
 
-PolyNode *PolyNode::GetNext() const {
+PolyNode *PolyNode::GetNext() const noexcept {
   if (!Childs.empty())
     return Childs[0];
   else
@@ -192,7 +192,7 @@ PolyNode *PolyNode::GetNext() const {
 }
 //------------------------------------------------------------------------------
 
-PolyNode *PolyNode::GetNextSiblingUp() const {
+PolyNode *PolyNode::GetNextSiblingUp() const noexcept {
   if (!Parent) // protects against PolyTree.GetNextSiblingUp()
     return 0;
   else if (Index == Parent->Childs.size() - 1)
@@ -202,7 +202,7 @@ PolyNode *PolyNode::GetNextSiblingUp() const {
 }
 //------------------------------------------------------------------------------
 
-bool PolyNode::IsHole() const {
+bool PolyNode::IsHole() const noexcept {
   bool result = true;
   PolyNode *node = Parent;
   while (node) {
@@ -213,7 +213,7 @@ bool PolyNode::IsHole() const {
 }
 //------------------------------------------------------------------------------
 
-bool PolyNode::IsOpen() const { return m_IsOpen; }
+bool PolyNode::IsOpen() const noexcept { return m_IsOpen; }
 //------------------------------------------------------------------------------
 
 #ifndef use_int32
@@ -231,7 +231,7 @@ public:
   ulong64 lo;
   long64 hi;
 
-  Int128(long64 _lo = 0) {
+  Int128(long64 _lo = 0) noexcept {
     lo = (ulong64)_lo;
     if (_lo < 0)
       hi = -1;
@@ -239,11 +239,11 @@ public:
       hi = 0;
   }
 
-  Int128(const Int128 &val) : lo(val.lo), hi(val.hi) {}
+  Int128(const Int128 &val) noexcept : lo(val.lo), hi(val.hi) {}
 
-  Int128(const long64 &_hi, const ulong64 &_lo) : lo(_lo), hi(_hi) {}
+  Int128(const long64 &_hi, const ulong64 &_lo) noexcept : lo(_lo), hi(_hi) {}
 
-  Int128 &operator=(const long64 &val) {
+  Int128 &operator=(const long64 &val) noexcept {
     lo = (ulong64)val;
     if (val < 0)
       hi = -1;
@@ -252,31 +252,31 @@ public:
     return *this;
   }
 
-  bool operator==(const Int128 &val) const {
+  bool operator==(const Int128 &val) const noexcept {
     return (hi == val.hi && lo == val.lo);
   }
 
-  bool operator!=(const Int128 &val) const { return !(*this == val); }
+  bool operator!=(const Int128 &val) const noexcept { return !(*this == val); }
 
-  bool operator>(const Int128 &val) const {
+  bool operator>(const Int128 &val) const noexcept {
     if (hi != val.hi)
       return hi > val.hi;
     else
       return lo > val.lo;
   }
 
-  bool operator<(const Int128 &val) const {
+  bool operator<(const Int128 &val) const noexcept {
     if (hi != val.hi)
       return hi < val.hi;
     else
       return lo < val.lo;
   }
 
-  bool operator>=(const Int128 &val) const { return !(*this < val); }
+  bool operator>=(const Int128 &val) const noexcept { return !(*this < val); }
 
-  bool operator<=(const Int128 &val) const { return !(*this > val); }
+  bool operator<=(const Int128 &val) const noexcept { return !(*this > val); }
 
-  Int128 &operator+=(const Int128 &rhs) {
+  Int128 &operator+=(const Int128 &rhs) noexcept {
     hi += rhs.hi;
     lo += rhs.lo;
     if (lo < rhs.lo)
@@ -284,24 +284,24 @@ public:
     return *this;
   }
 
-  Int128 operator+(const Int128 &rhs) const {
+  Int128 operator+(const Int128 &rhs) const noexcept {
     Int128 result(*this);
     result += rhs;
     return result;
   }
 
-  Int128 &operator-=(const Int128 &rhs) {
+  Int128 &operator-=(const Int128 &rhs) noexcept {
     *this += -rhs;
     return *this;
   }
 
-  Int128 operator-(const Int128 &rhs) const {
+  Int128 operator-(const Int128 &rhs) const noexcept {
     Int128 result(*this);
     result -= rhs;
     return result;
   }
 
-  Int128 operator-() const // unary negation
+  Int128 operator-() const noexcept // unary negation
   {
     if (lo == 0)
       return Int128(-hi, 0);
@@ -309,7 +309,7 @@ public:
       return Int128(~hi, ~lo + 1);
   }
 
-  operator double() const {
+  operator double() const noexcept {
     const double shift64 = 18446744073709551616.0; // 2^64
     if (hi < 0) {
       if (lo == 0)
@@ -322,7 +322,7 @@ public:
 };
 //------------------------------------------------------------------------------
 
-Int128 Int128Mul(long64 lhs, long64 rhs) {
+Int128 Int128Mul(long64 lhs, long64 rhs) noexcept {
   bool negate = (lhs < 0) != (rhs < 0);
 
   if (lhs < 0)
@@ -356,10 +356,10 @@ Int128 Int128Mul(long64 lhs, long64 rhs) {
 // Miscellaneous global functions
 //------------------------------------------------------------------------------
 
-bool Orientation(const Path &poly) { return Area(poly) >= 0; }
+bool Orientation(const Path &poly) noexcept { return Area(poly) >= 0; }
 //------------------------------------------------------------------------------
 
-double Area(const Path &poly) {
+double Area(const Path &poly) noexcept {
   int size = (int)poly.size();
   if (size < 3)
     return 0;
@@ -373,7 +373,7 @@ double Area(const Path &poly) {
 }
 //------------------------------------------------------------------------------
 
-double Area(const OutPt *op) {
+double Area(const OutPt *op) noexcept {
   const OutPt *startOp = op;
   if (!op)
     return 0;
@@ -387,10 +387,10 @@ double Area(const OutPt *op) {
 }
 //------------------------------------------------------------------------------
 
-double Area(const OutRec &outRec) { return Area(outRec.Pts); }
+double Area(const OutRec &outRec) noexcept { return Area(outRec.Pts); }
 //------------------------------------------------------------------------------
 
-bool PointIsVertex(const IntPoint &Pt, OutPt *pp) {
+bool PointIsVertex(const IntPoint &Pt, OutPt *pp) noexcept {
   OutPt *pp2 = pp;
   do {
     if (pp2->Pt == Pt)
@@ -404,7 +404,7 @@ bool PointIsVertex(const IntPoint &Pt, OutPt *pp) {
 // See "The Point in Polygon Problem for Arbitrary Polygons" by Hormann &
 // Agathos
 // http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.88.5498&rep=rep1&type=pdf
-int PointInPolygon(const IntPoint &pt, const Path &path) {
+int PointInPolygon(const IntPoint &pt, const Path &path) noexcept {
   // returns 0 if false, +1 if true, -1 if pt ON polygon boundary
   int result = 0;
   size_t cnt = path.size();
@@ -447,7 +447,7 @@ int PointInPolygon(const IntPoint &pt, const Path &path) {
 }
 //------------------------------------------------------------------------------
 
-int PointInPolygon(const IntPoint &pt, OutPt *op) {
+int PointInPolygon(const IntPoint &pt, OutPt *op) noexcept {
   // returns 0 if false, +1 if true, -1 if pt ON polygon boundary
   int result = 0;
   OutPt *startOp = op;
@@ -488,7 +488,7 @@ int PointInPolygon(const IntPoint &pt, OutPt *op) {
 }
 //------------------------------------------------------------------------------
 
-bool Poly2ContainsPoly1(OutPt *OutPt1, OutPt *OutPt2) {
+bool Poly2ContainsPoly1(OutPt *OutPt1, OutPt *OutPt2) noexcept {
   OutPt *op = OutPt1;
   do {
     // nb: PointInPolygon returns 0 if false, +1 if true, -1 if pt on polygon
@@ -501,7 +501,8 @@ bool Poly2ContainsPoly1(OutPt *OutPt1, OutPt *OutPt2) {
 }
 //----------------------------------------------------------------------
 
-bool SlopesEqual(const TEdge &e1, const TEdge &e2, bool UseFullInt64Range) {
+bool SlopesEqual(const TEdge &e1, const TEdge &e2,
+                 bool UseFullInt64Range) noexcept {
 #ifndef use_int32
   if (UseFullInt64Range)
     return Int128Mul(e1.Top.Y - e1.Bot.Y, e2.Top.X - e2.Bot.X) ==
@@ -514,7 +515,7 @@ bool SlopesEqual(const TEdge &e1, const TEdge &e2, bool UseFullInt64Range) {
 //------------------------------------------------------------------------------
 
 bool SlopesEqual(const IntPoint &pt1, const IntPoint &pt2, const IntPoint &pt3,
-                 bool UseFullInt64Range) {
+                 bool UseFullInt64Range) noexcept {
 #ifndef use_int32
   if (UseFullInt64Range)
     return Int128Mul(pt1.Y - pt2.Y, pt2.X - pt3.X) ==
@@ -527,7 +528,7 @@ bool SlopesEqual(const IntPoint &pt1, const IntPoint &pt2, const IntPoint &pt3,
 //------------------------------------------------------------------------------
 
 bool SlopesEqual(const IntPoint &pt1, const IntPoint &pt2, const IntPoint &pt3,
-                 const IntPoint &pt4, bool UseFullInt64Range) {
+                 const IntPoint &pt4, bool UseFullInt64Range) noexcept {
 #ifndef use_int32
   if (UseFullInt64Range)
     return Int128Mul(pt1.Y - pt2.Y, pt3.X - pt4.X) ==
@@ -539,16 +540,16 @@ bool SlopesEqual(const IntPoint &pt1, const IntPoint &pt2, const IntPoint &pt3,
 }
 //------------------------------------------------------------------------------
 
-inline bool IsHorizontal(TEdge &e) { return e.Dx == HORIZONTAL; }
+inline bool IsHorizontal(TEdge &e) noexcept { return e.Dx == HORIZONTAL; }
 //------------------------------------------------------------------------------
 
-inline double GetDx(const IntPoint &pt1, const IntPoint &pt2) {
+inline double GetDx(const IntPoint &pt1, const IntPoint &pt2) noexcept {
   return (pt1.Y == pt2.Y) ? HORIZONTAL
                           : (double)(pt2.X - pt1.X) / (pt2.Y - pt1.Y);
 }
 //---------------------------------------------------------------------------
 
-inline void SetDx(TEdge &e) {
+inline void SetDx(TEdge &e) noexcept {
   cInt dy = (e.Top.Y - e.Bot.Y);
   if (dy == 0)
     e.Dx = HORIZONTAL;
@@ -557,28 +558,28 @@ inline void SetDx(TEdge &e) {
 }
 //---------------------------------------------------------------------------
 
-inline void SwapSides(TEdge &Edge1, TEdge &Edge2) {
+inline void SwapSides(TEdge &Edge1, TEdge &Edge2) noexcept {
   EdgeSide Side = Edge1.Side;
   Edge1.Side = Edge2.Side;
   Edge2.Side = Side;
 }
 //------------------------------------------------------------------------------
 
-inline void SwapPolyIndexes(TEdge &Edge1, TEdge &Edge2) {
+inline void SwapPolyIndexes(TEdge &Edge1, TEdge &Edge2) noexcept {
   int OutIdx = Edge1.OutIdx;
   Edge1.OutIdx = Edge2.OutIdx;
   Edge2.OutIdx = OutIdx;
 }
 //------------------------------------------------------------------------------
 
-inline cInt TopX(TEdge &edge, const cInt currentY) {
+inline cInt TopX(TEdge &edge, const cInt currentY) noexcept {
   return (currentY == edge.Top.Y)
              ? edge.Top.X
              : edge.Bot.X + Round(edge.Dx * (currentY - edge.Bot.Y));
 }
 //------------------------------------------------------------------------------
 
-void IntersectPoint(TEdge &Edge1, TEdge &Edge2, IntPoint &ip) {
+void IntersectPoint(TEdge &Edge1, TEdge &Edge2, IntPoint &ip) noexcept {
 #ifdef use_xyz
   ip.Z = 0;
 #endif
@@ -637,7 +638,7 @@ void IntersectPoint(TEdge &Edge1, TEdge &Edge2, IntPoint &ip) {
 }
 //------------------------------------------------------------------------------
 
-void ReversePolyPtLinks(OutPt *pp) {
+void ReversePolyPtLinks(OutPt *pp) noexcept {
   if (!pp)
     return;
   OutPt *pp1, *pp2;
@@ -651,7 +652,7 @@ void ReversePolyPtLinks(OutPt *pp) {
 }
 //------------------------------------------------------------------------------
 
-void DisposeOutPts(OutPt *&pp) {
+void DisposeOutPts(OutPt *&pp) noexcept {
   if (pp == 0)
     return;
   pp->Prev->Next = 0;
@@ -663,7 +664,8 @@ void DisposeOutPts(OutPt *&pp) {
 }
 //------------------------------------------------------------------------------
 
-inline void InitEdge(TEdge *e, TEdge *eNext, TEdge *ePrev, const IntPoint &Pt) {
+inline void InitEdge(TEdge *e, TEdge *eNext, TEdge *ePrev,
+                     const IntPoint &Pt) noexcept {
   std::memset(e, int(0), sizeof(TEdge));
   e->Next = eNext;
   e->Prev = ePrev;
@@ -672,7 +674,7 @@ inline void InitEdge(TEdge *e, TEdge *eNext, TEdge *ePrev, const IntPoint &Pt) {
 }
 //------------------------------------------------------------------------------
 
-void InitEdge2(TEdge &e, PolyType Pt) {
+void InitEdge2(TEdge &e, PolyType Pt) noexcept {
   if (e.Curr.Y >= e.Next->Curr.Y) {
     e.Bot = e.Curr;
     e.Top = e.Next->Curr;
@@ -685,7 +687,7 @@ void InitEdge2(TEdge &e, PolyType Pt) {
 }
 //------------------------------------------------------------------------------
 
-TEdge *RemoveEdge(TEdge *e) {
+TEdge *RemoveEdge(TEdge *e) noexcept {
   // removes e from double_linked_list (but without removing from memory)
   e->Prev->Next = e->Next;
   e->Next->Prev = e->Prev;
@@ -695,7 +697,7 @@ TEdge *RemoveEdge(TEdge *e) {
 }
 //------------------------------------------------------------------------------
 
-inline void ReverseHorizontal(TEdge &e) {
+inline void ReverseHorizontal(TEdge &e) noexcept {
   // swap horizontal edges' Top and Bottom x's so they follow the natural
   // progression of the bounds - ie so their xbots will align with the
   // adjoining lower edge. [Helpful in the ProcessHorizontal() method.]
@@ -706,7 +708,7 @@ inline void ReverseHorizontal(TEdge &e) {
 }
 //------------------------------------------------------------------------------
 
-void SwapPoints(IntPoint &pt1, IntPoint &pt2) {
+void SwapPoints(IntPoint &pt1, IntPoint &pt2) noexcept {
   IntPoint tmp = pt1;
   pt1 = pt2;
   pt2 = tmp;
@@ -714,7 +716,7 @@ void SwapPoints(IntPoint &pt1, IntPoint &pt2) {
 //------------------------------------------------------------------------------
 
 bool GetOverlapSegment(IntPoint pt1a, IntPoint pt1b, IntPoint pt2a,
-                       IntPoint pt2b, IntPoint &pt1, IntPoint &pt2) {
+                       IntPoint pt2b, IntPoint &pt1, IntPoint &pt2) noexcept {
   // precondition: segments are Collinear.
   if (Abs(pt1a.X - pt1b.X) > Abs(pt1a.Y - pt1b.Y)) {
     if (pt1a.X > pt1b.X)
@@ -748,7 +750,7 @@ bool GetOverlapSegment(IntPoint pt1a, IntPoint pt1b, IntPoint pt2a,
 }
 //------------------------------------------------------------------------------
 
-bool FirstIsBottomPt(const OutPt *btmPt1, const OutPt *btmPt2) {
+bool FirstIsBottomPt(const OutPt *btmPt1, const OutPt *btmPt2) noexcept {
   OutPt *p = btmPt1->Prev;
   while ((p->Pt == btmPt1->Pt) && (p != btmPt1))
     p = p->Prev;
@@ -775,7 +777,7 @@ bool FirstIsBottomPt(const OutPt *btmPt1, const OutPt *btmPt2) {
 }
 //------------------------------------------------------------------------------
 
-OutPt *GetBottomPt(OutPt *pp) {
+OutPt *GetBottomPt(OutPt *pp) noexcept {
   OutPt *dups = 0;
   OutPt *p = pp->Next;
   while (p != pp) {
@@ -808,7 +810,7 @@ OutPt *GetBottomPt(OutPt *pp) {
 //------------------------------------------------------------------------------
 
 bool Pt2IsBetweenPt1AndPt3(const IntPoint pt1, const IntPoint pt2,
-                           const IntPoint pt3) {
+                           const IntPoint pt3) noexcept {
   if ((pt1 == pt3) || (pt1 == pt2) || (pt3 == pt2))
     return false;
   else if (pt1.X != pt3.X)
@@ -818,7 +820,8 @@ bool Pt2IsBetweenPt1AndPt3(const IntPoint pt1, const IntPoint pt2,
 }
 //------------------------------------------------------------------------------
 
-bool HorzSegmentsOverlap(cInt seg1a, cInt seg1b, cInt seg2a, cInt seg2b) {
+bool HorzSegmentsOverlap(cInt seg1a, cInt seg1b, cInt seg2a,
+                         cInt seg2b) noexcept {
   if (seg1a > seg1b)
     std::swap(seg1a, seg1b);
   if (seg2a > seg2b)
@@ -830,7 +833,7 @@ bool HorzSegmentsOverlap(cInt seg1a, cInt seg1b, cInt seg2a, cInt seg2b) {
 // ClipperBase class methods ...
 //------------------------------------------------------------------------------
 
-ClipperBase::ClipperBase() // constructor
+ClipperBase::ClipperBase() noexcept // constructor
 {
   m_CurrentLM = m_MinimaList.begin(); // begin() == end() here
   m_UseFullRange = false;
@@ -855,7 +858,7 @@ void RangeTest(const IntPoint &Pt, bool &useFullRange) {
 }
 //------------------------------------------------------------------------------
 
-TEdge *FindNextLocMin(TEdge *E) {
+TEdge *FindNextLocMin(TEdge *E) noexcept {
   for (;;) {
     while (E->Bot != E->Prev->Bot || E->Curr == E->Top)
       E = E->Next;
@@ -876,7 +879,7 @@ TEdge *FindNextLocMin(TEdge *E) {
 }
 //------------------------------------------------------------------------------
 
-TEdge *ClipperBase::ProcessBound(TEdge *E, bool NextIsForward) {
+TEdge *ClipperBase::ProcessBound(TEdge *E, bool NextIsForward) noexcept {
   TEdge *Result = E;
   TEdge *Horz = 0;
 
@@ -1177,7 +1180,7 @@ bool ClipperBase::AddPaths(const Paths &ppg, PolyType PolyTyp, bool Closed) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::Clear() {
+void ClipperBase::Clear() noexcept {
   DisposeLocalMinimaList();
   for (EdgeList::size_type i = 0; i < m_edges.size(); ++i) {
     TEdge *edges = m_edges[i];
@@ -1189,7 +1192,7 @@ void ClipperBase::Clear() {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::Reset() {
+void ClipperBase::Reset() noexcept {
   m_CurrentLM = m_MinimaList.begin();
   if (m_CurrentLM == m_MinimaList.end())
     return; // ie nothing to process
@@ -1219,13 +1222,13 @@ void ClipperBase::Reset() {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::DisposeLocalMinimaList() {
+void ClipperBase::DisposeLocalMinimaList() noexcept {
   m_MinimaList.clear();
   m_CurrentLM = m_MinimaList.begin();
 }
 //------------------------------------------------------------------------------
 
-bool ClipperBase::PopLocalMinima(cInt Y, const LocalMinimum *&locMin) {
+bool ClipperBase::PopLocalMinima(cInt Y, const LocalMinimum *&locMin) noexcept {
   if (m_CurrentLM == m_MinimaList.end() || (*m_CurrentLM).Y != Y)
     return false;
   locMin = &(*m_CurrentLM);
@@ -1234,7 +1237,7 @@ bool ClipperBase::PopLocalMinima(cInt Y, const LocalMinimum *&locMin) {
 }
 //------------------------------------------------------------------------------
 
-IntRect ClipperBase::GetBounds() {
+IntRect ClipperBase::GetBounds() noexcept {
   IntRect result;
   MinimaList::iterator lm = m_MinimaList.begin();
   if (lm == m_MinimaList.end()) {
@@ -1274,10 +1277,10 @@ IntRect ClipperBase::GetBounds() {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::InsertScanbeam(const cInt Y) { m_Scanbeam.push(Y); }
+void ClipperBase::InsertScanbeam(const cInt Y) noexcept { m_Scanbeam.push(Y); }
 //------------------------------------------------------------------------------
 
-bool ClipperBase::PopScanbeam(cInt &Y) {
+bool ClipperBase::PopScanbeam(cInt &Y) noexcept {
   if (m_Scanbeam.empty())
     return false;
   Y = m_Scanbeam.top();
@@ -1289,14 +1292,14 @@ bool ClipperBase::PopScanbeam(cInt &Y) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::DisposeAllOutRecs() {
+void ClipperBase::DisposeAllOutRecs() noexcept {
   for (PolyOutList::size_type i = 0; i < m_PolyOuts.size(); ++i)
     DisposeOutRec(i);
   m_PolyOuts.clear();
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::DisposeOutRec(PolyOutList::size_type index) {
+void ClipperBase::DisposeOutRec(PolyOutList::size_type index) noexcept {
   OutRec *outRec = m_PolyOuts[index];
   if (outRec->Pts)
     DisposeOutPts(outRec->Pts);
@@ -1305,7 +1308,7 @@ void ClipperBase::DisposeOutRec(PolyOutList::size_type index) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::DeleteFromAEL(TEdge *e) {
+void ClipperBase::DeleteFromAEL(TEdge *e) noexcept {
   TEdge *AelPrev = e->PrevInAEL;
   TEdge *AelNext = e->NextInAEL;
   if (!AelPrev && !AelNext && (e != m_ActiveEdges))
@@ -1321,7 +1324,7 @@ void ClipperBase::DeleteFromAEL(TEdge *e) {
 }
 //------------------------------------------------------------------------------
 
-OutRec *ClipperBase::CreateOutRec() {
+OutRec *ClipperBase::CreateOutRec() noexcept {
   OutRec *result = new OutRec;
   result->IsHole = false;
   result->IsOpen = false;
@@ -1335,7 +1338,7 @@ OutRec *ClipperBase::CreateOutRec() {
 }
 //------------------------------------------------------------------------------
 
-void ClipperBase::SwapPositionsInAEL(TEdge *Edge1, TEdge *Edge2) {
+void ClipperBase::SwapPositionsInAEL(TEdge *Edge1, TEdge *Edge2) noexcept {
   // check that one or other edge hasn't already been removed from AEL ...
   if (Edge1->NextInAEL == Edge1->PrevInAEL ||
       Edge2->NextInAEL == Edge2->PrevInAEL)
@@ -1413,7 +1416,7 @@ void ClipperBase::UpdateEdgeIntoAEL(TEdge *&e) {
 }
 //------------------------------------------------------------------------------
 
-bool ClipperBase::LocalMinimaPending() {
+bool ClipperBase::LocalMinimaPending() noexcept {
   return (m_CurrentLM != m_MinimaList.end());
 }
 
@@ -1421,7 +1424,7 @@ bool ClipperBase::LocalMinimaPending() {
 // TClipper methods ...
 //------------------------------------------------------------------------------
 
-Clipper::Clipper(int initOptions)
+Clipper::Clipper(int initOptions) noexcept
     : ClipperBase() // constructor
 {
   m_ExecuteLocked = false;
@@ -1437,7 +1440,9 @@ Clipper::Clipper(int initOptions)
 //------------------------------------------------------------------------------
 
 #ifdef use_xyz
-void Clipper::ZFillFunction(ZFillCallback zFillFunc) { m_ZFill = zFillFunc; }
+void Clipper::ZFillFunction(ZFillCallback zFillFunc) noexcept {
+  m_ZFill = zFillFunc;
+}
 //------------------------------------------------------------------------------
 #endif
 
@@ -1448,7 +1453,7 @@ bool Clipper::Execute(ClipType clipType, Paths &solution,
 //------------------------------------------------------------------------------
 
 bool Clipper::Execute(ClipType clipType, PolyTree &polytree,
-                      PolyFillType fillType) {
+                      PolyFillType fillType) noexcept {
   return Execute(clipType, polytree, fillType, fillType);
 }
 //------------------------------------------------------------------------------
@@ -1476,7 +1481,8 @@ bool Clipper::Execute(ClipType clipType, Paths &solution,
 //------------------------------------------------------------------------------
 
 bool Clipper::Execute(ClipType clipType, PolyTree &polytree,
-                      PolyFillType subjFillType, PolyFillType clipFillType) {
+                      PolyFillType subjFillType,
+                      PolyFillType clipFillType) noexcept {
   if (m_ExecuteLocked)
     return false;
   m_ExecuteLocked = true;
@@ -1493,7 +1499,7 @@ bool Clipper::Execute(ClipType clipType, PolyTree &polytree,
 }
 //------------------------------------------------------------------------------
 
-void Clipper::FixHoleLinkage(OutRec &outrec) {
+void Clipper::FixHoleLinkage(OutRec &outrec) noexcept {
   // skip OutRecs that (a) contain outermost polygons or
   //(b) already have the correct owner/child linkage ...
   if (!outrec.FirstLeft ||
@@ -1507,7 +1513,7 @@ void Clipper::FixHoleLinkage(OutRec &outrec) {
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::ExecuteInternal() {
+bool Clipper::ExecuteInternal() noexcept {
   bool succeeded = true;
   try {
     Reset();
@@ -1568,7 +1574,7 @@ bool Clipper::ExecuteInternal() {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::SetWindingCount(TEdge &edge) {
+void Clipper::SetWindingCount(TEdge &edge) noexcept {
   TEdge *e = edge.PrevInAEL;
   // find the edge of the same polytype that immediately preceeds 'edge' in AEL
   while (e && ((e->PolyTyp != edge.PolyTyp) || (e->WindDelta == 0)))
@@ -1653,7 +1659,7 @@ void Clipper::SetWindingCount(TEdge &edge) {
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::IsEvenOddFillType(const TEdge &edge) const {
+bool Clipper::IsEvenOddFillType(const TEdge &edge) const noexcept {
   if (edge.PolyTyp == ptSubject)
     return m_SubjFillType == pftEvenOdd;
   else
@@ -1661,7 +1667,7 @@ bool Clipper::IsEvenOddFillType(const TEdge &edge) const {
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::IsEvenOddAltFillType(const TEdge &edge) const {
+bool Clipper::IsEvenOddAltFillType(const TEdge &edge) const noexcept {
   if (edge.PolyTyp == ptSubject)
     return m_ClipFillType == pftEvenOdd;
   else
@@ -1669,7 +1675,7 @@ bool Clipper::IsEvenOddAltFillType(const TEdge &edge) const {
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::IsContributing(const TEdge &edge) const {
+bool Clipper::IsContributing(const TEdge &edge) const noexcept {
   PolyFillType pft, pft2;
   if (edge.PolyTyp == ptSubject) {
     pft = m_SubjFillType;
@@ -1763,7 +1769,8 @@ bool Clipper::IsContributing(const TEdge &edge) const {
 }
 //------------------------------------------------------------------------------
 
-OutPt *Clipper::AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &Pt) {
+OutPt *Clipper::AddLocalMinPoly(TEdge *e1, TEdge *e2,
+                                const IntPoint &Pt) noexcept {
   OutPt *result;
   TEdge *e, *prevE;
   if (IsHorizontal(*e2) || (e1->Dx > e2->Dx)) {
@@ -1802,7 +1809,8 @@ OutPt *Clipper::AddLocalMinPoly(TEdge *e1, TEdge *e2, const IntPoint &Pt) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::AddLocalMaxPoly(TEdge *e1, TEdge *e2, const IntPoint &Pt) {
+void Clipper::AddLocalMaxPoly(TEdge *e1, TEdge *e2,
+                              const IntPoint &Pt) noexcept {
   AddOutPt(e1, Pt);
   if (e2->WindDelta == 0)
     AddOutPt(e2, Pt);
@@ -1816,7 +1824,7 @@ void Clipper::AddLocalMaxPoly(TEdge *e1, TEdge *e2, const IntPoint &Pt) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::AddEdgeToSEL(TEdge *edge) {
+void Clipper::AddEdgeToSEL(TEdge *edge) noexcept {
   // SEL pointers in PEdge are reused to build a list of horizontal edges.
   // However, we don't need to worry about order with horizontal edge
   // processing.
@@ -1833,7 +1841,7 @@ void Clipper::AddEdgeToSEL(TEdge *edge) {
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::PopEdgeFromSEL(TEdge *&edge) {
+bool Clipper::PopEdgeFromSEL(TEdge *&edge) noexcept {
   if (!m_SortedEdges)
     return false;
   edge = m_SortedEdges;
@@ -1842,7 +1850,7 @@ bool Clipper::PopEdgeFromSEL(TEdge *&edge) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::CopyAELToSEL() {
+void Clipper::CopyAELToSEL() noexcept {
   TEdge *e = m_ActiveEdges;
   m_SortedEdges = e;
   while (e) {
@@ -1853,7 +1861,7 @@ void Clipper::CopyAELToSEL() {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::AddJoin(OutPt *op1, OutPt *op2, const IntPoint OffPt) {
+void Clipper::AddJoin(OutPt *op1, OutPt *op2, const IntPoint OffPt) noexcept {
   Join *j = new Join;
   j->OutPt1 = op1;
   j->OutPt2 = op2;
@@ -1862,21 +1870,21 @@ void Clipper::AddJoin(OutPt *op1, OutPt *op2, const IntPoint OffPt) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::ClearJoins() {
+void Clipper::ClearJoins() noexcept {
   for (JoinList::size_type i = 0; i < m_Joins.size(); ++i)
     delete m_Joins[i];
   m_Joins.resize(0);
 }
 //------------------------------------------------------------------------------
 
-void Clipper::ClearGhostJoins() {
+void Clipper::ClearGhostJoins() noexcept {
   for (JoinList::size_type i = 0; i < m_GhostJoins.size(); ++i)
     delete m_GhostJoins[i];
   m_GhostJoins.resize(0);
 }
 //------------------------------------------------------------------------------
 
-void Clipper::AddGhostJoin(OutPt *op, const IntPoint OffPt) {
+void Clipper::AddGhostJoin(OutPt *op, const IntPoint OffPt) noexcept {
   Join *j = new Join;
   j->OutPt1 = op;
   j->OutPt2 = 0;
@@ -1885,7 +1893,7 @@ void Clipper::AddGhostJoin(OutPt *op, const IntPoint OffPt) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::InsertLocalMinimaIntoAEL(const cInt botY) {
+void Clipper::InsertLocalMinimaIntoAEL(const cInt botY) noexcept {
   const LocalMinimum *lm;
   while (PopLocalMinima(botY, lm)) {
     TEdge *lb = lm->LeftBound;
@@ -1974,7 +1982,7 @@ void Clipper::InsertLocalMinimaIntoAEL(const cInt botY) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::DeleteFromSEL(TEdge *e) {
+void Clipper::DeleteFromSEL(TEdge *e) noexcept {
   TEdge *SelPrev = e->PrevInSEL;
   TEdge *SelNext = e->NextInSEL;
   if (!SelPrev && !SelNext && (e != m_SortedEdges))
@@ -1991,7 +1999,7 @@ void Clipper::DeleteFromSEL(TEdge *e) {
 //------------------------------------------------------------------------------
 
 #ifdef use_xyz
-void Clipper::SetZ(IntPoint &pt, TEdge &e1, TEdge &e2) {
+void Clipper::SetZ(IntPoint &pt, TEdge &e1, TEdge &e2) noexcept {
   if (pt.Z != 0 || !m_ZFill)
     return;
   else if (pt == e1.Bot)
@@ -2008,7 +2016,7 @@ void Clipper::SetZ(IntPoint &pt, TEdge &e1, TEdge &e2) {
 //------------------------------------------------------------------------------
 #endif
 
-void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt) {
+void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt) noexcept {
   bool e1Contributing = (e1->OutIdx >= 0);
   bool e2Contributing = (e2->OutIdx >= 0);
 
@@ -2197,7 +2205,7 @@ void Clipper::IntersectEdges(TEdge *e1, TEdge *e2, IntPoint &Pt) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::SetHoleState(TEdge *e, OutRec *outrec) {
+void Clipper::SetHoleState(TEdge *e, OutRec *outrec) noexcept {
   TEdge *e2 = e->PrevInAEL;
   TEdge *eTmp = 0;
   while (e2) {
@@ -2219,7 +2227,7 @@ void Clipper::SetHoleState(TEdge *e, OutRec *outrec) {
 }
 //------------------------------------------------------------------------------
 
-OutRec *GetLowermostRec(OutRec *outRec1, OutRec *outRec2) {
+OutRec *GetLowermostRec(OutRec *outRec1, OutRec *outRec2) noexcept {
   // work out which polygon fragment has the correct hole state ...
   if (!outRec1->BottomPt)
     outRec1->BottomPt = GetBottomPt(outRec1->Pts);
@@ -2246,7 +2254,7 @@ OutRec *GetLowermostRec(OutRec *outRec1, OutRec *outRec2) {
 }
 //------------------------------------------------------------------------------
 
-bool OutRec1RightOfOutRec2(OutRec *outRec1, OutRec *outRec2) {
+bool OutRec1RightOfOutRec2(OutRec *outRec1, OutRec *outRec2) noexcept {
   do {
     outRec1 = outRec1->FirstLeft;
     if (outRec1 == outRec2)
@@ -2256,7 +2264,7 @@ bool OutRec1RightOfOutRec2(OutRec *outRec1, OutRec *outRec2) {
 }
 //------------------------------------------------------------------------------
 
-OutRec *Clipper::GetOutRec(int Idx) {
+OutRec *Clipper::GetOutRec(int Idx) noexcept {
   OutRec *outrec = m_PolyOuts[Idx];
   while (outrec != m_PolyOuts[outrec->Idx])
     outrec = m_PolyOuts[outrec->Idx];
@@ -2264,7 +2272,7 @@ OutRec *Clipper::GetOutRec(int Idx) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::AppendPolygon(TEdge *e1, TEdge *e2) {
+void Clipper::AppendPolygon(TEdge *e1, TEdge *e2) noexcept {
   // get the start and ends of both output polygons ...
   OutRec *outRec1 = m_PolyOuts[e1->OutIdx];
   OutRec *outRec2 = m_PolyOuts[e2->OutIdx];
@@ -2351,7 +2359,7 @@ void Clipper::AppendPolygon(TEdge *e1, TEdge *e2) {
 }
 //------------------------------------------------------------------------------
 
-OutPt *Clipper::AddOutPt(TEdge *e, const IntPoint &pt) {
+OutPt *Clipper::AddOutPt(TEdge *e, const IntPoint &pt) noexcept {
   if (e->OutIdx < 0) {
     OutRec *outRec = CreateOutRec();
     outRec->IsOpen = (e->WindDelta == 0);
@@ -2390,7 +2398,7 @@ OutPt *Clipper::AddOutPt(TEdge *e, const IntPoint &pt) {
 }
 //------------------------------------------------------------------------------
 
-OutPt *Clipper::GetLastOutPt(TEdge *e) {
+OutPt *Clipper::GetLastOutPt(TEdge *e) noexcept {
   OutRec *outRec = m_PolyOuts[e->OutIdx];
   if (e->Side == esLeft)
     return outRec->Pts;
@@ -2399,29 +2407,29 @@ OutPt *Clipper::GetLastOutPt(TEdge *e) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::ProcessHorizontals() {
+void Clipper::ProcessHorizontals() noexcept {
   TEdge *horzEdge;
   while (PopEdgeFromSEL(horzEdge))
     ProcessHorizontal(horzEdge);
 }
 //------------------------------------------------------------------------------
 
-inline bool IsMinima(TEdge *e) {
+inline bool IsMinima(TEdge *e) noexcept {
   return e && (e->Prev->NextInLML != e) && (e->Next->NextInLML != e);
 }
 //------------------------------------------------------------------------------
 
-inline bool IsMaxima(TEdge *e, const cInt Y) {
+inline bool IsMaxima(TEdge *e, const cInt Y) noexcept {
   return e && e->Top.Y == Y && !e->NextInLML;
 }
 //------------------------------------------------------------------------------
 
-inline bool IsIntermediate(TEdge *e, const cInt Y) {
+inline bool IsIntermediate(TEdge *e, const cInt Y) noexcept {
   return e->Top.Y == Y && e->NextInLML;
 }
 //------------------------------------------------------------------------------
 
-TEdge *GetMaximaPair(TEdge *e) {
+TEdge *GetMaximaPair(TEdge *e) noexcept {
   if ((e->Next->Top == e->Top) && !e->Next->NextInLML)
     return e->Next;
   else if ((e->Prev->Top == e->Top) && !e->Prev->NextInLML)
@@ -2431,7 +2439,7 @@ TEdge *GetMaximaPair(TEdge *e) {
 }
 //------------------------------------------------------------------------------
 
-TEdge *GetMaximaPairEx(TEdge *e) {
+TEdge *GetMaximaPairEx(TEdge *e) noexcept {
   // as GetMaximaPair() but returns 0 if MaxPair isn't in AEL (unless it's
   // horizontal)
   TEdge *result = GetMaximaPair(e);
@@ -2443,7 +2451,7 @@ TEdge *GetMaximaPairEx(TEdge *e) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2) {
+void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2) noexcept {
   if (!(Edge1->NextInSEL) && !(Edge1->PrevInSEL))
     return;
   if (!(Edge2->NextInSEL) && !(Edge2->PrevInSEL))
@@ -2495,13 +2503,13 @@ void Clipper::SwapPositionsInSEL(TEdge *Edge1, TEdge *Edge2) {
 }
 //------------------------------------------------------------------------------
 
-TEdge *GetNextInAEL(TEdge *e, Direction dir) {
+TEdge *GetNextInAEL(TEdge *e, Direction dir) noexcept {
   return dir == dLeftToRight ? e->NextInAEL : e->PrevInAEL;
 }
 //------------------------------------------------------------------------------
 
 void GetHorzDirection(TEdge &HorzEdge, Direction &Dir, cInt &Left,
-                      cInt &Right) {
+                      cInt &Right) noexcept {
   if (HorzEdge.Bot.X < HorzEdge.Top.X) {
     Left = HorzEdge.Bot.X;
     Right = HorzEdge.Top.X;
@@ -2524,7 +2532,7 @@ void GetHorzDirection(TEdge &HorzEdge, Direction &Dir, cInt &Left,
  * the AEL. These 'promoted' edges may in turn intersect [%] with other HEs. *
  *******************************************************************************/
 
-void Clipper::ProcessHorizontal(TEdge *horzEdge) {
+void Clipper::ProcessHorizontal(TEdge *horzEdge) noexcept {
   Direction dir;
   cInt horzLeft, horzRight;
   bool IsOpen = (horzEdge->WindDelta == 0);
@@ -2719,14 +2727,14 @@ bool Clipper::ProcessIntersections(const cInt topY) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::DisposeIntersectNodes() {
+void Clipper::DisposeIntersectNodes() noexcept {
   for (size_t i = 0; i < m_IntersectList.size(); ++i)
     delete m_IntersectList[i];
   m_IntersectList.clear();
 }
 //------------------------------------------------------------------------------
 
-void Clipper::BuildIntersectList(const cInt topY) {
+void Clipper::BuildIntersectList(const cInt topY) noexcept {
   if (!m_ActiveEdges)
     return;
 
@@ -2772,7 +2780,7 @@ void Clipper::BuildIntersectList(const cInt topY) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::ProcessIntersectList() {
+void Clipper::ProcessIntersectList() noexcept {
   for (size_t i = 0; i < m_IntersectList.size(); ++i) {
     IntersectNode *iNode = m_IntersectList[i];
     {
@@ -2785,18 +2793,18 @@ void Clipper::ProcessIntersectList() {
 }
 //------------------------------------------------------------------------------
 
-bool IntersectListSort(IntersectNode *node1, IntersectNode *node2) {
+bool IntersectListSort(IntersectNode *node1, IntersectNode *node2) noexcept {
   return node2->Pt.Y < node1->Pt.Y;
 }
 //------------------------------------------------------------------------------
 
-inline bool EdgesAdjacent(const IntersectNode &inode) {
+inline bool EdgesAdjacent(const IntersectNode &inode) noexcept {
   return (inode.Edge1->NextInSEL == inode.Edge2) ||
          (inode.Edge1->PrevInSEL == inode.Edge2);
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::FixupIntersectionOrder() {
+bool Clipper::FixupIntersectionOrder() noexcept {
   // pre-condition: intersections are sorted Bottom-most first.
   // Now it's crucial that intersections are made only between adjacent edges,
   // so to ensure this the order of intersections may need adjusting ...
@@ -2960,7 +2968,7 @@ void Clipper::ProcessEdgesAtTopOfScanbeam(const cInt topY) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::FixupOutPolyline(OutRec &outrec) {
+void Clipper::FixupOutPolyline(OutRec &outrec) noexcept {
   OutPt *pp = outrec.Pts;
   OutPt *lastPP = pp->Prev;
   while (pp != lastPP) {
@@ -2984,7 +2992,7 @@ void Clipper::FixupOutPolyline(OutRec &outrec) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::FixupOutPolygon(OutRec &outrec) {
+void Clipper::FixupOutPolygon(OutRec &outrec) noexcept {
   // FixupOutPolygon() - removes duplicate points and simplifies consecutive
   // parallel edges by removing the middle vertex.
   OutPt *lastOK = 0;
@@ -3022,7 +3030,7 @@ void Clipper::FixupOutPolygon(OutRec &outrec) {
 }
 //------------------------------------------------------------------------------
 
-int PointCount(OutPt *Pts) {
+int PointCount(OutPt *Pts) noexcept {
   if (!Pts)
     return 0;
   int result = 0;
@@ -3035,7 +3043,7 @@ int PointCount(OutPt *Pts) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::BuildResult(Paths &polys) {
+void Clipper::BuildResult(Paths &polys) noexcept {
   polys.reserve(m_PolyOuts.size());
   for (PolyOutList::size_type i = 0; i < m_PolyOuts.size(); ++i) {
     if (!m_PolyOuts[i]->Pts)
@@ -3055,7 +3063,7 @@ void Clipper::BuildResult(Paths &polys) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::BuildResult2(PolyTree &polytree) {
+void Clipper::BuildResult2(PolyTree &polytree) noexcept {
   polytree.Clear();
   polytree.AllNodes.reserve(m_PolyOuts.size());
   // add each output polygon/contour to polytree ...
@@ -3096,7 +3104,7 @@ void Clipper::BuildResult2(PolyTree &polytree) {
 }
 //------------------------------------------------------------------------------
 
-void SwapIntersectNodes(IntersectNode &int1, IntersectNode &int2) {
+void SwapIntersectNodes(IntersectNode &int1, IntersectNode &int2) noexcept {
   // just swap the contents (because fIntersectNodes is a single-linked-list)
   IntersectNode inode = int1; // gets a copy of Int1
   int1.Edge1 = int2.Edge1;
@@ -3108,7 +3116,7 @@ void SwapIntersectNodes(IntersectNode &int1, IntersectNode &int2) {
 }
 //------------------------------------------------------------------------------
 
-inline bool E2InsertsBeforeE1(TEdge &e1, TEdge &e2) {
+inline bool E2InsertsBeforeE1(TEdge &e1, TEdge &e2) noexcept {
   if (e2.Curr.X == e1.Curr.X) {
     if (e2.Top.Y > e1.Top.Y)
       return e2.Top.X < TopX(e1, e2.Top.Y);
@@ -3120,7 +3128,7 @@ inline bool E2InsertsBeforeE1(TEdge &e1, TEdge &e2) {
 //------------------------------------------------------------------------------
 
 bool GetOverlap(const cInt a1, const cInt a2, const cInt b1, const cInt b2,
-                cInt &Left, cInt &Right) {
+                cInt &Left, cInt &Right) noexcept {
   if (a1 < a2) {
     if (b1 < b2) {
       Left = std::max(a1, b1);
@@ -3142,7 +3150,7 @@ bool GetOverlap(const cInt a1, const cInt a2, const cInt b1, const cInt b2,
 }
 //------------------------------------------------------------------------------
 
-inline void UpdateOutPtIdxs(OutRec &outrec) {
+inline void UpdateOutPtIdxs(OutRec &outrec) noexcept {
   OutPt *op = outrec.Pts;
   do {
     op->Idx = outrec.Idx;
@@ -3151,7 +3159,7 @@ inline void UpdateOutPtIdxs(OutRec &outrec) {
 }
 //------------------------------------------------------------------------------
 
-void Clipper::InsertEdgeIntoAEL(TEdge *edge, TEdge *startEdge) {
+void Clipper::InsertEdgeIntoAEL(TEdge *edge, TEdge *startEdge) noexcept {
   if (!m_ActiveEdges) {
     edge->PrevInAEL = 0;
     edge->NextInAEL = 0;
@@ -3176,7 +3184,7 @@ void Clipper::InsertEdgeIntoAEL(TEdge *edge, TEdge *startEdge) {
 }
 //----------------------------------------------------------------------
 
-OutPt *DupOutPt(OutPt *outPt, bool InsertAfter) {
+OutPt *DupOutPt(OutPt *outPt, bool InsertAfter) noexcept {
   OutPt *result = new OutPt;
   result->Pt = outPt->Pt;
   result->Idx = outPt->Idx;
@@ -3196,7 +3204,7 @@ OutPt *DupOutPt(OutPt *outPt, bool InsertAfter) {
 //------------------------------------------------------------------------------
 
 bool JoinHorz(OutPt *op1, OutPt *op1b, OutPt *op2, OutPt *op2b,
-              const IntPoint Pt, bool DiscardLeft) {
+              const IntPoint Pt, bool DiscardLeft) noexcept {
   Direction Dir1 = (op1->Pt.X > op1b->Pt.X ? dRightToLeft : dLeftToRight);
   Direction Dir2 = (op2->Pt.X > op2b->Pt.X ? dRightToLeft : dLeftToRight);
   if (Dir1 == Dir2)
@@ -3274,7 +3282,7 @@ bool JoinHorz(OutPt *op1, OutPt *op1b, OutPt *op2, OutPt *op2b,
 }
 //------------------------------------------------------------------------------
 
-bool Clipper::JoinPoints(Join *j, OutRec *outRec1, OutRec *outRec2) {
+bool Clipper::JoinPoints(Join *j, OutRec *outRec1, OutRec *outRec2) noexcept {
   OutPt *op1 = j->OutPt1, *op1b;
   OutPt *op2 = j->OutPt2, *op2b;
 
@@ -3436,14 +3444,14 @@ bool Clipper::JoinPoints(Join *j, OutRec *outRec1, OutRec *outRec2) {
 }
 //----------------------------------------------------------------------
 
-static OutRec *ParseFirstLeft(OutRec *FirstLeft) {
+static OutRec *ParseFirstLeft(OutRec *FirstLeft) noexcept {
   while (FirstLeft && !FirstLeft->Pts)
     FirstLeft = FirstLeft->FirstLeft;
   return FirstLeft;
 }
 //------------------------------------------------------------------------------
 
-void Clipper::FixupFirstLefts1(OutRec *OldOutRec, OutRec *NewOutRec) {
+void Clipper::FixupFirstLefts1(OutRec *OldOutRec, OutRec *NewOutRec) noexcept {
   // tests if NewOutRec contains the polygon before reassigning FirstLeft
   for (PolyOutList::size_type i = 0; i < m_PolyOuts.size(); ++i) {
     OutRec *outRec = m_PolyOuts[i];
@@ -3456,7 +3464,8 @@ void Clipper::FixupFirstLefts1(OutRec *OldOutRec, OutRec *NewOutRec) {
 }
 //----------------------------------------------------------------------
 
-void Clipper::FixupFirstLefts2(OutRec *InnerOutRec, OutRec *OuterOutRec) {
+void Clipper::FixupFirstLefts2(OutRec *InnerOutRec,
+                               OutRec *OuterOutRec) noexcept {
   // A polygon has split into two such that one is now the inner of the other.
   // It's possible that these polygons now wrap around other polygons, so check
   // every polygon that's also contained by OuterOutRec's FirstLeft container
@@ -3481,7 +3490,7 @@ void Clipper::FixupFirstLefts2(OutRec *InnerOutRec, OutRec *OuterOutRec) {
   }
 }
 //----------------------------------------------------------------------
-void Clipper::FixupFirstLefts3(OutRec *OldOutRec, OutRec *NewOutRec) {
+void Clipper::FixupFirstLefts3(OutRec *OldOutRec, OutRec *NewOutRec) noexcept {
   // reassigns FirstLeft WITHOUT testing if NewOutRec contains the polygon
   for (PolyOutList::size_type i = 0; i < m_PolyOuts.size(); ++i) {
     OutRec *outRec = m_PolyOuts[i];
@@ -3492,8 +3501,8 @@ void Clipper::FixupFirstLefts3(OutRec *OldOutRec, OutRec *NewOutRec) {
 }
 //----------------------------------------------------------------------
 
-void Clipper::JoinCommonEdges() {
-  for (JoinList::size_type i = 0; i < m_Joins.size(); i++) {
+void Clipper::JoinCommonEdges() noexcept {
+  for (JoinList::size_type i = 0; i < m_Joins.size(); ++i) {
     Join *join = m_Joins[i];
 
     OutRec *outRec1 = GetOutRec(join->OutPt1->Idx);
@@ -3585,7 +3594,7 @@ void Clipper::JoinCommonEdges() {
 // ClipperOffset support functions ...
 //------------------------------------------------------------------------------
 
-DoublePoint GetUnitNormal(const IntPoint &pt1, const IntPoint &pt2) {
+DoublePoint GetUnitNormal(const IntPoint &pt1, const IntPoint &pt2) noexcept {
   if (pt2.X == pt1.X && pt2.Y == pt1.Y)
     return DoublePoint(0, 0);
 
@@ -3601,7 +3610,7 @@ DoublePoint GetUnitNormal(const IntPoint &pt1, const IntPoint &pt2) {
 // ClipperOffset class
 //------------------------------------------------------------------------------
 
-ClipperOffset::ClipperOffset(double miterLimit, double arcTolerance) {
+ClipperOffset::ClipperOffset(double miterLimit, double arcTolerance) noexcept {
   this->MiterLimit = miterLimit;
   this->ArcTolerance = arcTolerance;
   m_lowest.X = -1;
@@ -3611,7 +3620,7 @@ ClipperOffset::ClipperOffset(double miterLimit, double arcTolerance) {
 ClipperOffset::~ClipperOffset() { Clear(); }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::Clear() {
+void ClipperOffset::Clear() noexcept {
   for (int i = 0; i < m_polyNodes.ChildCount(); ++i)
     delete m_polyNodes.Childs[i];
   m_polyNodes.Childs.clear();
@@ -3620,7 +3629,7 @@ void ClipperOffset::Clear() {
 //------------------------------------------------------------------------------
 
 void ClipperOffset::AddPath(const Path &path, JoinType joinType,
-                            EndType endType) {
+                            EndType endType) noexcept {
   int highI = (int)path.size() - 1;
   if (highI < 0)
     return;
@@ -3665,13 +3674,13 @@ void ClipperOffset::AddPath(const Path &path, JoinType joinType,
 //------------------------------------------------------------------------------
 
 void ClipperOffset::AddPaths(const Paths &paths, JoinType joinType,
-                             EndType endType) {
+                             EndType endType) noexcept {
   for (Paths::size_type i = 0; i < paths.size(); ++i)
     AddPath(paths[i], joinType, endType);
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::FixOrientations() {
+void ClipperOffset::FixOrientations() noexcept {
   // fixup orientations of all closed paths if the orientation of the
   // closed path with the lowermost vertex is wrong ...
   if (m_lowest.X >= 0 &&
@@ -3692,69 +3701,83 @@ void ClipperOffset::FixOrientations() {
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::Execute(Paths &solution, double delta) {
+bool ClipperOffset::Execute(Paths &solution, double delta) noexcept {
   solution.clear();
   FixOrientations();
   DoOffset(delta);
 
-  // now clean up 'corners' ...
-  Clipper clpr;
-  clpr.AddPaths(m_destPolys, ptSubject, true);
-  if (delta > 0) {
-    clpr.Execute(ctUnion, solution, pftPositive, pftPositive);
-  } else {
-    IntRect r = clpr.GetBounds();
-    Path outer(4);
-    outer[0].reset(r.left - 10, r.bottom + 10);
-    outer[1].reset(r.right + 10, r.bottom + 10);
-    outer[2].reset(r.right + 10, r.top - 10);
-    outer[3].reset(r.left - 10, r.top - 10);
+  try {
+    // now clean up 'corners' ...
+    Clipper clpr;
+    clpr.AddPaths(m_destPolys, ptSubject, true);
+    if (delta > 0) {
+      clpr.Execute(ctUnion, solution, pftPositive, pftPositive);
+    } else {
+      IntRect r = clpr.GetBounds();
+      Path outer(4);
+      outer[0].reset(r.left - 10, r.bottom + 10);
+      outer[1].reset(r.right + 10, r.bottom + 10);
+      outer[2].reset(r.right + 10, r.top - 10);
+      outer[3].reset(r.left - 10, r.top - 10);
 
-    clpr.AddPath(outer, ptSubject, true);
-    clpr.ReverseSolution(true);
-    clpr.Execute(ctUnion, solution, pftNegative, pftNegative);
-    if (solution.size() > 0)
-      solution.erase(solution.begin());
+      clpr.AddPath(outer, ptSubject, true);
+      clpr.ReverseSolution(true);
+      clpr.Execute(ctUnion, solution, pftNegative, pftNegative);
+      if (solution.size() > 0)
+        solution.erase(solution.begin());
+    }
+    return true;
+  } catch (std::exception &e) {
+    fprintf(stderr, "%s\n", e.what());
+    fflush(stderr);
+    return false;
   }
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::Execute(PolyTree &solution, double delta) {
+bool ClipperOffset::Execute(PolyTree &solution, double delta) noexcept {
   solution.Clear();
   FixOrientations();
   DoOffset(delta);
 
-  // now clean up 'corners' ...
-  Clipper clpr;
-  clpr.AddPaths(m_destPolys, ptSubject, true);
-  if (delta > 0) {
-    clpr.Execute(ctUnion, solution, pftPositive, pftPositive);
-  } else {
-    IntRect r = clpr.GetBounds();
-    Path outer(4);
-    outer[0].reset(r.left - 10, r.bottom + 10);
-    outer[1].reset(r.right + 10, r.bottom + 10);
-    outer[2].reset(r.right + 10, r.top - 10);
-    outer[3].reset(r.left - 10, r.top - 10);
+  try {
+    // now clean up 'corners' ...
+    Clipper clpr;
+    clpr.AddPaths(m_destPolys, ptSubject, true);
+    if (delta > 0) {
+      clpr.Execute(ctUnion, solution, pftPositive, pftPositive);
+    } else {
+      IntRect r = clpr.GetBounds();
+      Path outer(4);
+      outer[0].reset(r.left - 10, r.bottom + 10);
+      outer[1].reset(r.right + 10, r.bottom + 10);
+      outer[2].reset(r.right + 10, r.top - 10);
+      outer[3].reset(r.left - 10, r.top - 10);
 
-    clpr.AddPath(outer, ptSubject, true);
-    clpr.ReverseSolution(true);
-    clpr.Execute(ctUnion, solution, pftNegative, pftNegative);
-    // remove the outer PolyNode rectangle ...
-    if (solution.ChildCount() == 1 && solution.Childs[0]->ChildCount() > 0) {
-      PolyNode *outerNode = solution.Childs[0];
-      solution.Childs.reserve(outerNode->ChildCount());
-      solution.Childs[0] = outerNode->Childs[0];
-      solution.Childs[0]->Parent = outerNode->Parent;
-      for (int i = 1; i < outerNode->ChildCount(); ++i)
-        solution.AddChild(*outerNode->Childs[i]);
-    } else
-      solution.Clear();
+      clpr.AddPath(outer, ptSubject, true);
+      clpr.ReverseSolution(true);
+      clpr.Execute(ctUnion, solution, pftNegative, pftNegative);
+      // remove the outer PolyNode rectangle ...
+      if (solution.ChildCount() == 1 && solution.Childs[0]->ChildCount() > 0) {
+        PolyNode *outerNode = solution.Childs[0];
+        solution.Childs.reserve(outerNode->ChildCount());
+        solution.Childs[0] = outerNode->Childs[0];
+        solution.Childs[0]->Parent = outerNode->Parent;
+        for (int i = 1; i < outerNode->ChildCount(); ++i)
+          solution.AddChild(*outerNode->Childs[i]);
+      } else
+        solution.Clear();
+    }
+    return true;
+  } catch (std::exception &e) {
+    fprintf(stderr, "%s\n", e.what());
+    fflush(stderr);
+    return false;
   }
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::DoOffset(double delta) {
+void ClipperOffset::DoOffset(double delta) noexcept {
   m_destPolys.clear();
   m_delta = delta;
 
@@ -3913,7 +3936,7 @@ void ClipperOffset::DoOffset(double delta) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::OffsetPoint(int j, int &k, JoinType jointype) {
+void ClipperOffset::OffsetPoint(int j, int &k, JoinType jointype) noexcept {
   // cross product ...
   m_sinA = (m_normals[k].X * m_normals[j].Y - m_normals[j].X * m_normals[k].Y);
   if (std::fabs(m_sinA * m_delta) < 1.0) {
@@ -3960,7 +3983,7 @@ void ClipperOffset::OffsetPoint(int j, int &k, JoinType jointype) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::DoSquare(int j, int k) {
+void ClipperOffset::DoSquare(int j, int k) noexcept {
   double dx = std::tan(std::atan2(m_sinA, m_normals[k].X * m_normals[j].X +
                                               m_normals[k].Y * m_normals[j].Y) /
                        4);
@@ -3973,7 +3996,7 @@ void ClipperOffset::DoSquare(int j, int k) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::DoMiter(int j, int k, double r) {
+void ClipperOffset::DoMiter(int j, int k, double r) noexcept {
   double q = m_delta / r;
   m_destPoly.emplace_back(
       Round(m_srcPoly[j].X + (m_normals[k].X + m_normals[j].X) * q),
@@ -3981,7 +4004,7 @@ void ClipperOffset::DoMiter(int j, int k, double r) {
 }
 //------------------------------------------------------------------------------
 
-void ClipperOffset::DoRound(int j, int k) {
+void ClipperOffset::DoRound(int j, int k) noexcept {
   double a = std::atan2(m_sinA, m_normals[k].X * m_normals[j].X +
                                     m_normals[k].Y * m_normals[j].Y);
   int steps = std::max((int)Round(m_StepsPerRad * std::fabs(a)), 1);
@@ -4002,7 +4025,7 @@ void ClipperOffset::DoRound(int j, int k) {
 // Miscellaneous public functions
 //------------------------------------------------------------------------------
 
-void Clipper::DoSimplePolygons() {
+void Clipper::DoSimplePolygons() noexcept {
   PolyOutList::size_type i = 0;
   while (i < m_PolyOuts.size()) {
     OutRec *outrec = m_PolyOuts[i++];
@@ -4057,15 +4080,16 @@ void Clipper::DoSimplePolygons() {
 }
 //------------------------------------------------------------------------------
 
-void ReversePath(Path &p) { std::reverse(p.begin(), p.end()); }
+void ReversePath(Path &p) noexcept { std::reverse(p.begin(), p.end()); }
 //------------------------------------------------------------------------------
 
-void ReversePaths(Paths &p) {
+void ReversePaths(Paths &p) noexcept {
   for (Paths::size_type i = 0; i < p.size(); ++i)
     ReversePath(p[i]);
 }
 //------------------------------------------------------------------------------
 
+#if 0
 void SimplifyPolygon(const Path &in_poly, Paths &out_polys,
                      PolyFillType fillType) {
   Clipper c;
@@ -4087,9 +4111,10 @@ void SimplifyPolygons(const Paths &in_polys, Paths &out_polys,
 void SimplifyPolygons(Paths &polys, PolyFillType fillType) {
   SimplifyPolygons(polys, polys, fillType);
 }
+#endif
 //------------------------------------------------------------------------------
 
-inline double DistanceSqrd(const IntPoint &pt1, const IntPoint &pt2) {
+inline double DistanceSqrd(const IntPoint &pt1, const IntPoint &pt2) noexcept {
   double Dx = ((double)pt1.X - pt2.X);
   double dy = ((double)pt1.Y - pt2.Y);
   return (Dx * Dx + dy * dy);
@@ -4097,7 +4122,7 @@ inline double DistanceSqrd(const IntPoint &pt1, const IntPoint &pt2) {
 //------------------------------------------------------------------------------
 
 double DistanceFromLineSqrd(const IntPoint &pt, const IntPoint &ln1,
-                            const IntPoint &ln2) {
+                            const IntPoint &ln2) noexcept {
   // The equation of a line in general form (Ax + By + C = 0)
   // given 2 points (x�,y�) & (x�,y�) is ...
   //(y� - y�)x + (x� - x�)y + (y� - y�)x� - (x� - x�)y� = 0
@@ -4113,7 +4138,7 @@ double DistanceFromLineSqrd(const IntPoint &pt, const IntPoint &ln1,
 //---------------------------------------------------------------------------
 
 bool SlopesNearCollinear(const IntPoint &pt1, const IntPoint &pt2,
-                         const IntPoint &pt3, double distSqrd) {
+                         const IntPoint &pt3, double distSqrd) noexcept {
   // this function is more accurate when the point that's geometrically
   // between the other 2 points is the one that's tested for distance.
   // ie makes it more likely to pick up 'spikes' ...
@@ -4135,14 +4160,14 @@ bool SlopesNearCollinear(const IntPoint &pt1, const IntPoint &pt2,
 }
 //------------------------------------------------------------------------------
 
-bool PointsAreClose(IntPoint &pt1, IntPoint &pt2, double distSqrd) {
+bool PointsAreClose(IntPoint &pt1, IntPoint &pt2, double distSqrd) noexcept {
   double Dx = (double)pt1.X - pt2.X;
   double dy = (double)pt1.Y - pt2.Y;
   return ((Dx * Dx) + (dy * dy) <= distSqrd);
 }
 //------------------------------------------------------------------------------
 
-OutPt *ExcludeOp(OutPt *op) {
+OutPt *ExcludeOp(OutPt *op) noexcept {
   OutPt *result = op->Prev;
   result->Next = op->Next;
   op->Next->Prev = result;
@@ -4151,7 +4176,8 @@ OutPt *ExcludeOp(OutPt *op) {
 }
 //------------------------------------------------------------------------------
 
-void CleanPolygon(const Path &in_poly, Path &out_poly, double distance) {
+void CleanPolygon(const Path &in_poly, Path &out_poly,
+                  double distance) noexcept {
   // distance = proximity in units/pixels below which vertices
   // will be stripped. Default ~= sqrt(2).
 
@@ -4201,25 +4227,26 @@ void CleanPolygon(const Path &in_poly, Path &out_poly, double distance) {
 }
 //------------------------------------------------------------------------------
 
-void CleanPolygon(Path &poly, double distance) {
+void CleanPolygon(Path &poly, double distance) noexcept {
   CleanPolygon(poly, poly, distance);
 }
 //------------------------------------------------------------------------------
 
-void CleanPolygons(const Paths &in_polys, Paths &out_polys, double distance) {
+void CleanPolygons(const Paths &in_polys, Paths &out_polys,
+                   double distance) noexcept {
   out_polys.resize(in_polys.size());
   for (Paths::size_type i = 0; i < in_polys.size(); ++i)
     CleanPolygon(in_polys[i], out_polys[i], distance);
 }
 //------------------------------------------------------------------------------
 
-void CleanPolygons(Paths &polys, double distance) {
+void CleanPolygons(Paths &polys, double distance) noexcept {
   CleanPolygons(polys, polys, distance);
 }
 //------------------------------------------------------------------------------
 
 void Minkowski(const Path &poly, const Path &path, Paths &solution, bool isSum,
-               bool isClosed) {
+               bool isClosed) noexcept {
   int delta = (isClosed ? 1 : 0);
   size_t polyCnt = poly.size();
   size_t pathCnt = path.size();
@@ -4259,6 +4286,7 @@ void Minkowski(const Path &poly, const Path &path, Paths &solution, bool isSum,
 }
 //------------------------------------------------------------------------------
 
+#if 0
 void MinkowskiSum(const Path &pattern, const Path &path, Paths &solution,
                   bool pathIsClosed) {
   Minkowski(pattern, path, solution, true, pathIsClosed);
@@ -4266,9 +4294,11 @@ void MinkowskiSum(const Path &pattern, const Path &path, Paths &solution,
   c.AddPaths(solution, ptSubject, true);
   c.Execute(ctUnion, solution, pftNonZero, pftNonZero);
 }
+#endif
 //------------------------------------------------------------------------------
 
-void TranslatePath(const Path &input, Path &output, const IntPoint &delta) {
+void TranslatePath(const Path &input, Path &output,
+                   const IntPoint &delta) noexcept {
   // precondition: input != output
   output.resize(input.size());
   for (size_t i = 0; i < input.size(); ++i)
@@ -4276,6 +4306,7 @@ void TranslatePath(const Path &input, Path &output, const IntPoint &delta) {
 }
 //------------------------------------------------------------------------------
 
+#if 0
 void MinkowskiSum(const Path &pattern, const Paths &paths, Paths &solution,
                   bool pathIsClosed) {
   Clipper c;
@@ -4300,11 +4331,12 @@ void MinkowskiDiff(const Path &poly1, const Path &poly2, Paths &solution) {
   c.Execute(ctUnion, solution, pftNonZero, pftNonZero);
 }
 //------------------------------------------------------------------------------
+#endif
 
 enum NodeType { ntAny, ntOpen, ntClosed };
 
 void AddPolyNodeToPaths(const PolyNode &polynode, NodeType nodetype,
-                        Paths &paths) {
+                        Paths &paths) noexcept {
   bool match = true;
   if (nodetype == ntClosed)
     match = !polynode.IsOpen();
@@ -4318,21 +4350,21 @@ void AddPolyNodeToPaths(const PolyNode &polynode, NodeType nodetype,
 }
 //------------------------------------------------------------------------------
 
-void PolyTreeToPaths(const PolyTree &polytree, Paths &paths) {
+void PolyTreeToPaths(const PolyTree &polytree, Paths &paths) noexcept {
   paths.resize(0);
   paths.reserve(polytree.Total());
   AddPolyNodeToPaths(polytree, ntAny, paths);
 }
 //------------------------------------------------------------------------------
 
-void ClosedPathsFromPolyTree(const PolyTree &polytree, Paths &paths) {
+void ClosedPathsFromPolyTree(const PolyTree &polytree, Paths &paths) noexcept {
   paths.resize(0);
   paths.reserve(polytree.Total());
   AddPolyNodeToPaths(polytree, ntClosed, paths);
 }
 //------------------------------------------------------------------------------
 
-void OpenPathsFromPolyTree(PolyTree &polytree, Paths &paths) {
+void OpenPathsFromPolyTree(PolyTree &polytree, Paths &paths) noexcept {
   paths.resize(0);
   paths.reserve(polytree.Total());
   // Open paths are top level only, so ...
@@ -4342,13 +4374,13 @@ void OpenPathsFromPolyTree(PolyTree &polytree, Paths &paths) {
 }
 //------------------------------------------------------------------------------
 
-std::ostream &operator<<(std::ostream &s, const IntPoint &p) {
+std::ostream &operator<<(std::ostream &s, const IntPoint &p) noexcept {
   s << "(" << p.X << "," << p.Y << ")";
   return s;
 }
 //------------------------------------------------------------------------------
 
-std::ostream &operator<<(std::ostream &s, const Path &p) {
+std::ostream &operator<<(std::ostream &s, const Path &p) noexcept {
   if (p.empty())
     return s;
   Path::size_type last = p.size() - 1;
@@ -4359,7 +4391,7 @@ std::ostream &operator<<(std::ostream &s, const Path &p) {
 }
 //------------------------------------------------------------------------------
 
-std::ostream &operator<<(std::ostream &s, const Paths &p) {
+std::ostream &operator<<(std::ostream &s, const Paths &p) noexcept {
   for (Paths::size_type i = 0; i < p.size(); ++i)
     s << p[i];
   s << "\n";

--- a/deploy/cpp_infer/src/ocr_cls.cpp
+++ b/deploy/cpp_infer/src/ocr_cls.cpp
@@ -19,7 +19,7 @@ namespace PaddleOCR {
 void Classifier::Run(const std::vector<cv::Mat> &img_list,
                      std::vector<int> &cls_labels,
                      std::vector<float> &cls_scores,
-                     std::vector<double> &times) {
+                     std::vector<double> &times) noexcept {
   std::chrono::duration<float> preprocess_diff =
       std::chrono::duration<float>::zero();
   std::chrono::duration<float> inference_diff =
@@ -101,7 +101,7 @@ void Classifier::Run(const std::vector<cv::Mat> &img_list,
   times.emplace_back(postprocess_diff.count() * 1000);
 }
 
-void Classifier::LoadModel(const std::string &model_dir) {
+void Classifier::LoadModel(const std::string &model_dir) noexcept {
   paddle_infer::Config config;
   config.SetModel(model_dir + "/inference.pdmodel",
                   model_dir + "/inference.pdiparams");

--- a/deploy/cpp_infer/src/ocr_det.cpp
+++ b/deploy/cpp_infer/src/ocr_det.cpp
@@ -16,7 +16,7 @@
 
 namespace PaddleOCR {
 
-void DBDetector::LoadModel(const std::string &model_dir) {
+void DBDetector::LoadModel(const std::string &model_dir) noexcept {
   //   AnalysisConfig config;
   paddle_infer::Config config;
   config.SetModel(model_dir + "/inference.pdmodel",
@@ -65,7 +65,7 @@ void DBDetector::LoadModel(const std::string &model_dir) {
 
 void DBDetector::Run(const cv::Mat &img,
                      std::vector<std::vector<std::vector<int>>> &boxes,
-                     std::vector<double> &times) {
+                     std::vector<double> &times) noexcept {
   float ratio_h{};
   float ratio_w{};
 

--- a/deploy/cpp_infer/src/ocr_rec.cpp
+++ b/deploy/cpp_infer/src/ocr_rec.cpp
@@ -19,7 +19,7 @@ namespace PaddleOCR {
 void CRNNRecognizer::Run(const std::vector<cv::Mat> &img_list,
                          std::vector<std::string> &rec_texts,
                          std::vector<float> &rec_text_scores,
-                         std::vector<double> &times) {
+                         std::vector<double> &times) noexcept {
   std::chrono::duration<float> preprocess_diff =
       std::chrono::duration<float>::zero();
   std::chrono::duration<float> inference_diff =
@@ -129,7 +129,7 @@ void CRNNRecognizer::Run(const std::vector<cv::Mat> &img_list,
   times.emplace_back(postprocess_diff.count() * 1000);
 }
 
-void CRNNRecognizer::LoadModel(const std::string &model_dir) {
+void CRNNRecognizer::LoadModel(const std::string &model_dir) noexcept {
   paddle_infer::Config config;
   config.SetModel(model_dir + "/inference.pdmodel",
                   model_dir + "/inference.pdiparams");

--- a/deploy/cpp_infer/src/paddleocr.cpp
+++ b/deploy/cpp_infer/src/paddleocr.cpp
@@ -19,7 +19,7 @@
 
 namespace PaddleOCR {
 
-PPOCR::PPOCR() {
+PPOCR::PPOCR() noexcept {
   if (FLAGS_det) {
     this->detector_.reset(new DBDetector(
         FLAGS_det_model_dir, FLAGS_use_gpu, FLAGS_gpu_id, FLAGS_gpu_mem,
@@ -45,7 +45,8 @@ PPOCR::PPOCR() {
 }
 
 std::vector<std::vector<OCRPredictResult>>
-PPOCR::ocr(const std::vector<cv::Mat> &img_list, bool det, bool rec, bool cls) {
+PPOCR::ocr(const std::vector<cv::Mat> &img_list, bool det, bool rec,
+           bool cls) noexcept {
   std::vector<std::vector<OCRPredictResult>> ocr_results;
 
   if (!det) {
@@ -77,7 +78,7 @@ PPOCR::ocr(const std::vector<cv::Mat> &img_list, bool det, bool rec, bool cls) {
 }
 
 std::vector<OCRPredictResult> PPOCR::ocr(const cv::Mat &img, bool det, bool rec,
-                                         bool cls) {
+                                         bool cls) noexcept {
 
   std::vector<OCRPredictResult> ocr_result;
   // det
@@ -106,7 +107,7 @@ std::vector<OCRPredictResult> PPOCR::ocr(const cv::Mat &img, bool det, bool rec,
 }
 
 void PPOCR::det(const cv::Mat &img,
-                std::vector<OCRPredictResult> &ocr_results) {
+                std::vector<OCRPredictResult> &ocr_results) noexcept {
   std::vector<std::vector<std::vector<int>>> boxes;
   std::vector<double> det_times;
 
@@ -125,7 +126,7 @@ void PPOCR::det(const cv::Mat &img,
 }
 
 void PPOCR::rec(const std::vector<cv::Mat> &img_list,
-                std::vector<OCRPredictResult> &ocr_results) {
+                std::vector<OCRPredictResult> &ocr_results) noexcept {
   std::vector<std::string> rec_texts(img_list.size(), std::string());
   std::vector<float> rec_text_scores(img_list.size(), 0);
   std::vector<double> rec_times;
@@ -141,7 +142,7 @@ void PPOCR::rec(const std::vector<cv::Mat> &img_list,
 }
 
 void PPOCR::cls(const std::vector<cv::Mat> &img_list,
-                std::vector<OCRPredictResult> &ocr_results) {
+                std::vector<OCRPredictResult> &ocr_results) noexcept {
   std::vector<int> cls_labels(img_list.size(), 0);
   std::vector<float> cls_scores(img_list.size(), 0);
   std::vector<double> cls_times;
@@ -156,13 +157,13 @@ void PPOCR::cls(const std::vector<cv::Mat> &img_list,
   this->time_info_cls[2] += cls_times[2];
 }
 
-void PPOCR::reset_timer() {
+void PPOCR::reset_timer() noexcept {
   this->time_info_det = {0, 0, 0};
   this->time_info_rec = {0, 0, 0};
   this->time_info_cls = {0, 0, 0};
 }
 
-void PPOCR::benchmark_log(int img_num) {
+void PPOCR::benchmark_log(int img_num) noexcept {
   if (this->time_info_det[0] + this->time_info_det[1] + this->time_info_det[2] >
       0) {
     AutoLogger autolog_det("ocr_det", FLAGS_use_gpu, FLAGS_use_tensorrt,

--- a/deploy/cpp_infer/src/paddlestructure.cpp
+++ b/deploy/cpp_infer/src/paddlestructure.cpp
@@ -19,7 +19,7 @@
 
 namespace PaddleOCR {
 
-PaddleStructure::PaddleStructure() {
+PaddleStructure::PaddleStructure() noexcept {
   if (FLAGS_layout) {
     this->layout_model_.reset(new StructureLayoutRecognizer(
         FLAGS_layout_model_dir, FLAGS_use_gpu, FLAGS_gpu_id, FLAGS_gpu_mem,
@@ -38,7 +38,7 @@ PaddleStructure::PaddleStructure() {
 
 std::vector<StructurePredictResult>
 PaddleStructure::structure(const cv::Mat &srcimg, bool layout, bool table,
-                           bool ocr) {
+                           bool ocr) noexcept {
   cv::Mat img;
   srcimg.copyTo(img);
 
@@ -70,7 +70,8 @@ PaddleStructure::structure(const cv::Mat &srcimg, bool layout, bool table,
 }
 
 void PaddleStructure::layout(
-    const cv::Mat &img, std::vector<StructurePredictResult> &structure_result) {
+    const cv::Mat &img,
+    std::vector<StructurePredictResult> &structure_result) noexcept {
   std::vector<double> layout_times;
   this->layout_model_->Run(img, structure_result, layout_times);
 
@@ -80,7 +81,7 @@ void PaddleStructure::layout(
 }
 
 void PaddleStructure::table(const cv::Mat &img,
-                            StructurePredictResult &structure_result) {
+                            StructurePredictResult &structure_result) noexcept {
   // predict structure
   std::vector<std::vector<std::string>> structure_html_tags;
   std::vector<float> structure_scores(1, 0);
@@ -96,7 +97,6 @@ void PaddleStructure::table(const cv::Mat &img,
   this->time_info_table[2] += structure_times[2];
 
   std::vector<OCRPredictResult> ocr_result;
-  std::string html;
   int expand_pixel = 3;
 
   for (int i = 0; i < img_list.size(); ++i) {
@@ -128,7 +128,7 @@ void PaddleStructure::table(const cv::Mat &img,
 std::string PaddleStructure::rebuild_table(
     const std::vector<std::string> &structure_html_tags,
     const std::vector<std::vector<int>> &structure_boxes,
-    std::vector<OCRPredictResult> &ocr_result) {
+    std::vector<OCRPredictResult> &ocr_result) noexcept {
   // match text in same cell
   std::vector<std::vector<std::string>> matched(structure_boxes.size(),
                                                 std::vector<std::string>());
@@ -217,7 +217,7 @@ std::string PaddleStructure::rebuild_table(
 }
 
 float PaddleStructure::dis(const std::vector<int> &box1,
-                           const std::vector<int> &box2) {
+                           const std::vector<int> &box2) noexcept {
   int x1_1 = box1[0];
   int y1_1 = box1[1];
   int x2_1 = box1[2];
@@ -235,7 +235,7 @@ float PaddleStructure::dis(const std::vector<int> &box1,
   return dis + std::min(dis_2, dis_3);
 }
 
-void PaddleStructure::reset_timer() {
+void PaddleStructure::reset_timer() noexcept {
   this->time_info_det = {0, 0, 0};
   this->time_info_rec = {0, 0, 0};
   this->time_info_cls = {0, 0, 0};
@@ -243,7 +243,7 @@ void PaddleStructure::reset_timer() {
   this->time_info_layout = {0, 0, 0};
 }
 
-void PaddleStructure::benchmark_log(int img_num) {
+void PaddleStructure::benchmark_log(int img_num) noexcept {
   if (this->time_info_det[0] + this->time_info_det[1] + this->time_info_det[2] >
       0) {
     AutoLogger autolog_det("ocr_det", FLAGS_use_gpu, FLAGS_use_tensorrt,

--- a/deploy/cpp_infer/src/preprocess_op.cpp
+++ b/deploy/cpp_infer/src/preprocess_op.cpp
@@ -16,7 +16,7 @@
 
 namespace PaddleOCR {
 
-void Permute::Run(const cv::Mat &im, float *data) {
+void Permute::Run(const cv::Mat &im, float *data) noexcept {
   int rh = im.rows;
   int rw = im.cols;
   int rc = im.channels();
@@ -25,7 +25,7 @@ void Permute::Run(const cv::Mat &im, float *data) {
   }
 }
 
-void PermuteBatch::Run(const std::vector<cv::Mat> &imgs, float *data) {
+void PermuteBatch::Run(const std::vector<cv::Mat> &imgs, float *data) noexcept {
   for (int j = 0; j < imgs.size(); j++) {
     int rh = imgs[j].rows;
     int rw = imgs[j].cols;
@@ -38,7 +38,8 @@ void PermuteBatch::Run(const std::vector<cv::Mat> &imgs, float *data) {
 }
 
 void Normalize::Run(cv::Mat &im, const std::vector<float> &mean,
-                    const std::vector<float> &scale, const bool is_scale) {
+                    const std::vector<float> &scale,
+                    const bool is_scale) noexcept {
   double e = 1.0;
   if (is_scale) {
     e /= 255.0;
@@ -55,7 +56,8 @@ void Normalize::Run(cv::Mat &im, const std::vector<float> &mean,
 
 void ResizeImgType0::Run(const cv::Mat &img, cv::Mat &resize_img,
                          const std::string &limit_type, int limit_side_len,
-                         float &ratio_h, float &ratio_w, bool use_tensorrt) {
+                         float &ratio_h, float &ratio_w,
+                         bool use_tensorrt) noexcept {
   int w = img.cols;
   int h = img.rows;
   float ratio = 1.f;
@@ -92,7 +94,7 @@ void ResizeImgType0::Run(const cv::Mat &img, cv::Mat &resize_img,
 
 void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
                         bool use_tensorrt,
-                        const std::vector<int> &rec_image_shape) {
+                        const std::vector<int> &rec_image_shape) noexcept {
   int imgC, imgH, imgW;
   imgC = rec_image_shape[0];
   imgH = rec_image_shape[1];
@@ -117,7 +119,7 @@ void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
 
 void ClsResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,
                        bool use_tensorrt,
-                       const std::vector<int> &rec_image_shape) {
+                       const std::vector<int> &rec_image_shape) noexcept {
   int imgC, imgH, imgW;
   imgC = rec_image_shape[0];
   imgH = rec_image_shape[1];
@@ -135,7 +137,7 @@ void ClsResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,
 }
 
 void TableResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,
-                         const int max_len) {
+                         const int max_len) noexcept {
   int w = img.cols;
   int h = img.rows;
 
@@ -149,7 +151,7 @@ void TableResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,
 }
 
 void TablePadImg::Run(const cv::Mat &img, cv::Mat &resize_img,
-                      const int max_len) {
+                      const int max_len) noexcept {
   int w = img.cols;
   int h = img.rows;
   cv::copyMakeBorder(img, resize_img, 0, max_len - h, 0, max_len - w,
@@ -157,7 +159,7 @@ void TablePadImg::Run(const cv::Mat &img, cv::Mat &resize_img,
 }
 
 void Resize::Run(const cv::Mat &img, cv::Mat &resize_img, const int h,
-                 const int w) {
+                 const int w) noexcept {
   cv::resize(img, resize_img, cv::Size(w, h));
 }
 

--- a/deploy/cpp_infer/src/structure_layout.cpp
+++ b/deploy/cpp_infer/src/structure_layout.cpp
@@ -18,7 +18,7 @@ namespace PaddleOCR {
 
 void StructureLayoutRecognizer::Run(const cv::Mat &img,
                                     std::vector<StructurePredictResult> &result,
-                                    std::vector<double> &times) {
+                                    std::vector<double> &times) noexcept {
   std::chrono::duration<float> preprocess_diff =
       std::chrono::steady_clock::now() - std::chrono::steady_clock::now();
   std::chrono::duration<float> inference_diff =
@@ -93,7 +93,8 @@ void StructureLayoutRecognizer::Run(const cv::Mat &img,
   times.emplace_back(postprocess_diff.count() * 1000);
 }
 
-void StructureLayoutRecognizer::LoadModel(const std::string &model_dir) {
+void StructureLayoutRecognizer::LoadModel(
+    const std::string &model_dir) noexcept {
   paddle_infer::Config config;
   if (Utility::PathExists(model_dir + "/inference.pdmodel") &&
       Utility::PathExists(model_dir + "/inference.pdiparams")) {

--- a/deploy/cpp_infer/src/structure_table.cpp
+++ b/deploy/cpp_infer/src/structure_table.cpp
@@ -21,7 +21,7 @@ void StructureTableRecognizer::Run(
     std::vector<std::vector<std::string>> &structure_html_tags,
     std::vector<float> &structure_scores,
     std::vector<std::vector<std::vector<int>>> &structure_boxes,
-    std::vector<double> &times) {
+    std::vector<double> &times) noexcept {
   std::chrono::duration<float> preprocess_diff =
       std::chrono::steady_clock::now() - std::chrono::steady_clock::now();
   std::chrono::duration<float> inference_diff =
@@ -117,7 +117,8 @@ void StructureTableRecognizer::Run(
   }
 }
 
-void StructureTableRecognizer::LoadModel(const std::string &model_dir) {
+void StructureTableRecognizer::LoadModel(
+    const std::string &model_dir) noexcept {
   paddle_infer::Config config;
   config.SetModel(model_dir + "/inference.pdmodel",
                   model_dir + "/inference.pdiparams");

--- a/deploy/cpp_infer/src/utility.cpp
+++ b/deploy/cpp_infer/src/utility.cpp
@@ -19,15 +19,16 @@
 
 #include <vector>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <direct.h>
 #else
 #include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 namespace PaddleOCR {
 
-std::vector<std::string> Utility::ReadDict(const std::string &path) {
+std::vector<std::string> Utility::ReadDict(const std::string &path) noexcept {
   std::vector<std::string> m_vec;
   std::ifstream in(path);
   if (in) {
@@ -47,7 +48,7 @@ std::vector<std::string> Utility::ReadDict(const std::string &path) {
 
 void Utility::VisualizeBboxes(const cv::Mat &srcimg,
                               const std::vector<OCRPredictResult> &ocr_result,
-                              const std::string &save_path) {
+                              const std::string &save_path) noexcept {
   cv::Mat img_vis;
   srcimg.copyTo(img_vis);
   for (int n = 0; n < ocr_result.size(); ++n) {
@@ -69,7 +70,7 @@ void Utility::VisualizeBboxes(const cv::Mat &srcimg,
 
 void Utility::VisualizeBboxes(const cv::Mat &srcimg,
                               const StructurePredictResult &structure_result,
-                              const std::string &save_path) {
+                              const std::string &save_path) noexcept {
   cv::Mat img_vis;
   srcimg.copyTo(img_vis);
   img_vis = crop_image(img_vis, structure_result.box);
@@ -101,7 +102,7 @@ void Utility::VisualizeBboxes(const cv::Mat &srcimg,
 
 // list all files under a directory
 void Utility::GetAllFiles(const char *dir_name,
-                          std::vector<std::string> &all_inputs) {
+                          std::vector<std::string> &all_inputs) noexcept {
   if (NULL == dir_name) {
     std::cout << " dir_name is null ! " << std::endl;
     return;
@@ -132,8 +133,9 @@ void Utility::GetAllFiles(const char *dir_name,
   }
 }
 
-cv::Mat Utility::GetRotateCropImage(const cv::Mat &srcimage,
-                                    const std::vector<std::vector<int>> &box) {
+cv::Mat
+Utility::GetRotateCropImage(const cv::Mat &srcimage,
+                            const std::vector<std::vector<int>> &box) noexcept {
   cv::Mat image;
   srcimage.copyTo(image);
   std::vector<std::vector<int>> points = box;
@@ -187,7 +189,7 @@ cv::Mat Utility::GetRotateCropImage(const cv::Mat &srcimage,
   }
 }
 
-std::vector<int> Utility::argsort(const std::vector<float> &array) {
+std::vector<int> Utility::argsort(const std::vector<float> &array) noexcept {
   std::vector<int> array_index(array.size(), 0);
   for (int i = 0; i < array.size(); ++i)
     array_index[i] = i;
@@ -199,7 +201,7 @@ std::vector<int> Utility::argsort(const std::vector<float> &array) {
   return array_index;
 }
 
-std::string Utility::basename(const std::string &filename) {
+std::string Utility::basename(const std::string &filename) noexcept {
   if (filename.empty()) {
     return "";
   }
@@ -234,7 +236,7 @@ std::string Utility::basename(const std::string &filename) {
   return filename.substr(index + 1, len - index);
 }
 
-bool Utility::PathExists(const std::string &path) {
+bool Utility::PathExists(const std::string &path) noexcept {
 #ifdef _WIN32
   struct _stat buffer;
   return (_stat(path.c_str(), &buffer) == 0);
@@ -244,7 +246,7 @@ bool Utility::PathExists(const std::string &path) {
 #endif // !_WIN32
 }
 
-void Utility::CreateDir(const std::string &path) {
+void Utility::CreateDir(const std::string &path) noexcept {
 #ifdef _MSC_VER
   _mkdir(path.c_str());
 #elif defined __MINGW32__
@@ -254,7 +256,8 @@ void Utility::CreateDir(const std::string &path) {
 #endif // !_WIN32
 }
 
-void Utility::print_result(const std::vector<OCRPredictResult> &ocr_result) {
+void Utility::print_result(
+    const std::vector<OCRPredictResult> &ocr_result) noexcept {
   for (int i = 0; i < ocr_result.size(); ++i) {
     std::cout << i << "\t";
     // det
@@ -284,7 +287,8 @@ void Utility::print_result(const std::vector<OCRPredictResult> &ocr_result) {
   }
 }
 
-cv::Mat Utility::crop_image(cv::Mat &img, const std::vector<int> &box) {
+cv::Mat Utility::crop_image(cv::Mat &img,
+                            const std::vector<int> &box) noexcept {
   cv::Mat crop_im = cv::Mat::zeros(box[3] - box[1], box[2] - box[0], 16);
   int crop_x1 = std::max(0, box[0]);
   int crop_y1 = std::max(0, box[1]);
@@ -300,13 +304,14 @@ cv::Mat Utility::crop_image(cv::Mat &img, const std::vector<int> &box) {
   return crop_im;
 }
 
-cv::Mat Utility::crop_image(cv::Mat &img, const std::vector<float> &box) {
+cv::Mat Utility::crop_image(cv::Mat &img,
+                            const std::vector<float> &box) noexcept {
   std::vector<int> box_int = {(int)box[0], (int)box[1], (int)box[2],
                               (int)box[3]};
   return crop_image(img, box_int);
 }
 
-void Utility::sorted_boxes(std::vector<OCRPredictResult> &ocr_result) {
+void Utility::sorted_boxes(std::vector<OCRPredictResult> &ocr_result) noexcept {
   std::sort(ocr_result.begin(), ocr_result.end(), Utility::comparison_box);
   if (ocr_result.size() > 0) {
     for (int i = 0; i < ocr_result.size() - 1; ++i) {
@@ -321,7 +326,7 @@ void Utility::sorted_boxes(std::vector<OCRPredictResult> &ocr_result) {
 }
 
 std::vector<int>
-Utility::xyxyxyxy2xyxy(const std::vector<std::vector<int>> &box) {
+Utility::xyxyxyxy2xyxy(const std::vector<std::vector<int>> &box) noexcept {
   int x_collect[4] = {box[0][0], box[1][0], box[2][0], box[3][0]};
   int y_collect[4] = {box[0][1], box[1][1], box[2][1], box[3][1]};
   int left = int(*std::min_element(x_collect, x_collect + 4));
@@ -336,7 +341,7 @@ Utility::xyxyxyxy2xyxy(const std::vector<std::vector<int>> &box) {
   return box1;
 }
 
-std::vector<int> Utility::xyxyxyxy2xyxy(const std::vector<int> &box) {
+std::vector<int> Utility::xyxyxyxy2xyxy(const std::vector<int> &box) noexcept {
   int x_collect[4] = {box[0], box[2], box[4], box[6]};
   int y_collect[4] = {box[1], box[3], box[5], box[7]};
   int left = int(*std::min_element(x_collect, x_collect + 4));
@@ -351,7 +356,7 @@ std::vector<int> Utility::xyxyxyxy2xyxy(const std::vector<int> &box) {
   return box1;
 }
 
-float Utility::fast_exp(float x) {
+float Utility::fast_exp(float x) noexcept {
   union {
     uint32_t i;
     float f;
@@ -361,7 +366,7 @@ float Utility::fast_exp(float x) {
 }
 
 std::vector<float>
-Utility::activation_function_softmax(std::vector<float> &src) {
+Utility::activation_function_softmax(std::vector<float> &src) noexcept {
   int length = src.size();
   std::vector<float> dst;
   dst.resize(length);
@@ -379,7 +384,7 @@ Utility::activation_function_softmax(std::vector<float> &src) {
   return dst;
 }
 
-float Utility::iou(std::vector<int> &box1, std::vector<int> &box2) {
+float Utility::iou(std::vector<int> &box1, std::vector<int> &box2) noexcept {
   int area1 = std::max(0, box1[2] - box1[0]) * std::max(0, box1[3] - box1[1]);
   int area2 = std::max(0, box2[2] - box2[0]) * std::max(0, box2[3] - box2[1]);
 
@@ -401,7 +406,8 @@ float Utility::iou(std::vector<int> &box1, std::vector<int> &box2) {
   }
 }
 
-float Utility::iou(std::vector<float> &box1, std::vector<float> &box2) {
+float Utility::iou(std::vector<float> &box1,
+                   std::vector<float> &box2) noexcept {
   float area1 = std::max((float)0.0, box1[2] - box1[0]) *
                 std::max((float)0.0, box1[3] - box1[1]);
   float area2 = std::max((float)0.0, box2[2] - box2[0]) *


### PR DESCRIPTION
When exception caught in ClipperLib::ClipperOffset::Execute, just printf the what message to stderr and return false. When DBPostProcessor::UnClip failed in calling ClipperLib::ClipperOffset::Execute, just return (empty or null) cv::RotatedRect(). 