### PR TITLE
Add english docu for CMAKE compilation on windows

### DIFF
--- a/deploy/cpp_infer/docs/windows_vs2019_build.md
+++ b/deploy/cpp_infer/docs/windows_vs2019_build.md
@@ -1,3 +1,5 @@
+[English](windows_vs2022_build.md) | 简体中文
+
 - [Visual Studio 2019 Community CMake 编译指南](#visual-studio-2019-community-cmake-编译指南)
   - [1. 环境准备](#1-环境准备)
     - [1.1 安装必须环境](#11-安装必须环境)

--- a/deploy/cpp_infer/docs/windows_vs2022_build.md
+++ b/deploy/cpp_infer/docs/windows_vs2022_build.md
@@ -1,6 +1,4 @@
----
-comments: true
----
+English | [简体中文](windows_vs2019_build.md)
 
 # Visual Studio 2022 Community CMake Compilation Guide
 
@@ -53,13 +51,13 @@ git checkout develop
 
 Once CMake is installed, open the `cmake-gui` application. Specify the source code directory in the first input box and the build output directory in the second input box.
 
-![step1](./images/cmake_step1.png)
+![step1](imgs/cmake_step1.png)
 
 ### Step 2: Run CMake Configuration
 
 Click the `Configure` button at the bottom of the interface. The first time you run it, a prompt will appear asking for the Visual Studio configuration. Select your `Visual Studio` version and set the target platform to `x64`. Click `Finish` to start the configuration process.
 
-![step2](./images/cmake_step2.jpg)
+![step2](imgs/cmake_step2.png)
 
 The first run will result in errors, which is expected. You now need to configure OpenCV and the prediction library.
 
@@ -79,7 +77,7 @@ The first run will result in errors, which is expected. You now need to configur
 
 Example configuration:
 
-![step3](./images/cmake_step3.jpg)
+![step3](imgs/cmake_step3.png)
 
 Once configured, click `Configure` again.
 
@@ -91,10 +89,10 @@ Once configured, click `Configure` again.
 ### Step 3: Generate Visual Studio Project
 
 Click `Generate` to create the `.sln` file for the Visual Studio project.
-![step4](./images/cmake_step4.jpg)
+![step4](imgs/cmake_step4.png)
 
 Click `Open Project` to launch the project in Visual Studio. The interface should look like this:
-![step5](./images/vs_step1.jpg)
+![step5](imgs/vs_step1.png)
 
 Before building the solution, perform the following steps:
 
@@ -121,7 +119,7 @@ The compiled executable is located in the `build/Release/` directory. Open `cmd`
 cd /d D:\projects\cpp\PaddleOCR\deploy\cpp_infer
 ```
 
-Run the prediction using `ppocr.exe`. For more usage details, refer to the to the [Instructions](./cpp_infer.en.md) section of running the demo.
+Run the prediction using `ppocr.exe`. For more usage details, refer to the [documentation](../readme_ch.md).
 
 ```shell
 # Switch terminal encoding to UTF-8
@@ -137,7 +135,7 @@ $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Obj
 <br>
 
 ## Sample result:
-![result](./images/result.jpg)
+![result](imgs/result.jpg)
 
 ## FAQ
 

--- a/deploy/cpp_infer/readme.md
+++ b/deploy/cpp_infer/readme.md
@@ -14,7 +14,7 @@ English | [简体中文](readme_ch.md)
 
 
 This chapter introduces the C++ deployment steps of the PaddleOCR model. C++ is better than Python in terms of performance. Therefore, in CPU and GPU deployment scenarios, C++ deployment is mostly used.
-This section will introduce how to configure the C++ environment and deploy PaddleOCR in Linux (CPU\GPU) environment. For Windows deployment please refer to [Windows](./docs/windows_vs2019_build.md) compilation guidelines.
+This section will introduce how to configure the C++ environment and deploy PaddleOCR in Linux (CPU\GPU) environment. For Windows deployment please refer to [Windows](./docs/windows_vs2022_build.md) compilation guidelines.
 
 
 <a name="1"></a>


### PR DESCRIPTION
Hi!

Last week I wanted to try out the C++ inference version of PaddleOCR and noticed that the compilation guide for windows only existed in chinese and it was also quite outdated aswell.

So after I got it working and compiled paddleocr successfully on windows I took the time to write an english cmake compilation guide and updated it with my recent findings.

I've also changed the link in the cpp infer readme to link now to the english version that I created because it itself was written in english. On top of the readme of both CMAKE compilation guides I added buttons to switch between the languages.

I hope you like it!