### PR TITLE
use the env variable PADDLE_OCR_BASE_DIR if it exists to download models

### DIFF
--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -24,7 +24,10 @@ from tqdm import tqdm
 
 from ppocr.utils.logging import get_logger
 
-MODELS_DIR = os.path.expanduser("~/.paddleocr/models/")
+MODELS_DIR = (
+    os.environ.get("PADDLE_OCR_BASE_DIR", os.path.expanduser("~/.paddleocr/"))
+    + "/models/"
+)
 DOWNLOAD_RETRY_LIMIT = 3
 
 

--- a/ppocr/utils/network.py
+++ b/ppocr/utils/network.py
@@ -24,9 +24,8 @@ from tqdm import tqdm
 
 from ppocr.utils.logging import get_logger
 
-MODELS_DIR = (
-    os.environ.get("PADDLE_OCR_BASE_DIR", os.path.expanduser("~/.paddleocr/"))
-    + "/models/"
+MODELS_DIR = os.path.join(
+    os.environ.get("PADDLE_OCR_BASE_DIR", os.path.expanduser("~/.paddleocr/")), "models"
 )
 DOWNLOAD_RETRY_LIMIT = 3
 


### PR DESCRIPTION
Sorry for the second PR on this topic, I noticed afterward that another path (`MODELS_DIR`) was also hardcoded for downloading models. It will now use the environment variable  `PADDLE_OCR_BASE_DIR` if this one exists.