### PR TITLE
docs: update quick_start doc

### DIFF
--- a/docs/quick_start.en.md
+++ b/docs/quick_start.en.md
@@ -24,7 +24,8 @@ hide:
     python -m pip install paddlepaddle-gpu==3.0.0rc1 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
     ```
 
-You can customize the storage location for OCR models by setting the environment variable `PADDLE_OCR_BASE_DIR`. If this variable is not set, the models will be downloaded to the following default locations:
+NOTE: You can customize the storage location for OCR models by setting the environment variable `PADDLE_OCR_BASE_DIR`. If this variable is not set, the models will be downloaded to the following default locations:
+
 - On Linux/macOS: `${HOME}/.paddleocr`
 - On Windows: `C:\Users\{username}\.paddleocr`
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -31,6 +31,11 @@ hide:
 pip install paddleocr
 ```
 
+NOTE: 可以通过设置环境变量 `PADDLE_OCR_BASE_DIR` 来自定义 OCR 模型的存储位置。如果未设置此变量，模型将下载到以下默认位置：
+
+- 在Linux/macOS上路径为：`${HOME}/.paddleocr`
+- 在Windows上路径为：`C:\Users\{username}\.paddleocr`
+
 ### Python脚本使用
 
 === "文本检测+方向分类+文本识别"
@@ -213,7 +218,7 @@ paddleocr -h
     ......
     ```
 
-    还支持pdf文件，您可以使用`page_num`参数推断前几页，默认值为0，这意味着识别全部页面
+    还支持 PDF 文件，可以通过设置 `page_num` 参数来推理前几页，默认值为 0，这意味着处理全部页面。
 
     ```bash linenums="1"
     paddleocr --image_dir ./xxx.pdf --use_angle_cls true --use_gpu false --page_num 2


### PR DESCRIPTION
This pull request includes updates to the documentation files to enhance clarity and provide additional information about the OCR model storage location and usage instructions.

Documentation improvements:

* [`docs/quick_start.en.md`](diffhunk://#diff-f58e63a359fbb494c2bec6911b2110f031ff8f30a0a4f19f703e35ed6ce7054bL27-R28): Added a note to clarify how to customize the storage location for OCR models by setting the `PADDLE_OCR_BASE_DIR` environment variable.
* [`docs/quick_start.md`](diffhunk://#diff-61f4196322cfa9f52c5f548f13b7f781243b2cae898862a8688462d914ba7173R34-R38): Added a note in Chinese to explain how to customize the storage location for OCR models by setting the `PADDLE_OCR_BASE_DIR` environment variable, including the default storage paths for Linux/macOS and Windows.
* [`docs/quick_start.md`](diffhunk://#diff-61f4196322cfa9f52c5f548f13b7f781243b2cae898862a8688462d914ba7173L216-R221): Improved the explanation for using the `page_num` parameter to process specific pages of a PDF file, including formatting enhancements for clarity.