### PR TITLE
unlock albumentations version

### DIFF
--- a/ppocr/data/imaug/iaa_augment.py
+++ b/ppocr/data/imaug/iaa_augment.py
@@ -24,14 +24,16 @@ import numpy as np
 import albumentations as A
 from albumentations.core.transforms_interface import DualTransform
 from albumentations.augmentations.geometric import functional as fgeometric
+from packaging import version
+
+ALBU_VERSION = version.parse(A.__version__)
+IS_ALBU_NEW_VERSION = ALBU_VERSION >= version.parse("1.4.15")
 
 
 # Custom resize transformation mimicking Imgaug's behavior with scaling
 class ImgaugLikeResize(DualTransform):
-    def __init__(
-        self, scale_range=(0.5, 3.0), interpolation=1, always_apply=False, p=1.0
-    ):
-        super(ImgaugLikeResize, self).__init__(always_apply, p)
+    def __init__(self, scale_range=(0.5, 3.0), interpolation=1, p=1.0):
+        super(ImgaugLikeResize, self).__init__(p)
         self.scale_range = scale_range
         self.interpolation = interpolation
 
@@ -41,11 +43,10 @@ class ImgaugLikeResize(DualTransform):
         new_height = int(height * scale)
         new_width = int(width * scale)
 
-        # For compatibility with Albumentations 1.4.15 and later
-        # return fgeometric.resize(
-        #     img, (new_height, new_width), interpolation=self.interpolation
-        # )
-
+        if IS_ALBU_NEW_VERSION:
+            return fgeometric.resize(
+                img, (new_height, new_width), interpolation=self.interpolation
+            )
         return fgeometric.resize(
             img, new_height, new_width, interpolation=self.interpolation
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ dependencies = [
     "fonttools>=4.24.0",
     "fire>=0.3.0",
     "requests",
-    "albumentations==1.4.10",
+    "albumentations",
     # to be compatible with albumentations
-    "albucore==0.0.13"
+    "albucore"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cython
 Pillow
 pyyaml
 requests
-albumentations==1.4.10
+albumentations
 # to be compatible with albumentations
-albucore==0.0.13
+albucore
 packaging


### PR DESCRIPTION
This pull request includes updates to handle compatibility with different versions of the `albumentations` library and simplifies the dependency management in `pyproject.toml`.

### Compatibility Updates:

* [`ppocr/data/imaug/iaa_augment.py`](diffhunk://#diff-cfb976e0fb8bb05e4bca0b6b32b49a42f55d1ff7266ec93d6bac9baabfa2716dR27-R36): Introduced version checking for `albumentations` and adjusted the `ImgaugLikeResize` class to handle different versions. [[1]](diffhunk://#diff-cfb976e0fb8bb05e4bca0b6b32b49a42f55d1ff7266ec93d6bac9baabfa2716dR27-R36) [[2]](diffhunk://#diff-cfb976e0fb8bb05e4bca0b6b32b49a42f55d1ff7266ec93d6bac9baabfa2716dL44-R49)

### Dependency Management:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L59-R61): Updated the `albumentations` and `albucore` dependencies to be version-agnostic, allowing for greater flexibility in dependency resolution.

Closes #14708 