### PR TITLE
fix `OverflowError` in text_visual func

### DIFF
--- a/tools/infer/utility.py
+++ b/tools/infer/utility.py
@@ -621,7 +621,7 @@ def text_visual(
         ), "The number of txts and corresponding scores must match"
 
     def create_blank_img():
-        blank_img = np.ones(shape=[img_h, img_w], dtype=np.int8) * 255
+        blank_img = np.ones(shape=[img_h, img_w], dtype=np.uint8) * 255
         blank_img[:, img_w - 1 :] = 0
         blank_img = Image.fromarray(blank_img).convert("RGB")
         draw_txt = ImageDraw.Draw(blank_img)


### PR DESCRIPTION
This pull request includes an important change to the `tools/infer/utility.py` file, specifically in the `text_visual` method. The change modifies the data type used to create a blank image, ensuring compatibility and correctness in image processing.

* [`tools/infer/utility.py`](diffhunk://#diff-c44b96eb71070ae776b3d092254a8ee3298eef0bdda6e9a68b001040524cd367L624-R624): Changed the data type from `np.int8` to `np.uint8` in the `create_blank_img` function to correctly handle image data.
* `np.int8` is a signed 8-bit integer, meaning it can store values from -128 to 127.
* The value 255 exceeds the maximum limit of 127 for `np.int8`, causing an overflow. When NumPy tries to compute 1 * 255 and store the result (255) in an int8 array, it raises the OverflowError because 255 is out of bounds.