### PR TITLE
Fix wrong date in newly added capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PaddleOCR 由 [PMC](https://github.com/PaddlePaddle/PaddleOCR/issues/12122) 监�
 
 ## 📣 近期更新([more](https://paddlepaddle.github.io/PaddleOCR/latest/update.html))
 
-- **🔥🔥2024.3.6 新增OCR领域自研重磅模型方案**
+- **🔥🔥2025.3.6 新增OCR领域自研重磅模型方案**
 
   - **重磅新增 OCR 领域 12 个自研单模型：**
     - **[版面区域检测](https://paddlepaddle.github.io/PaddleX/latest/module_usage/tutorials/ocr_modules/layout_detection.html)** 系列 3 个模型：PP-DocLayout-L、PP-DocLayout-M、PP-DocLayout-S，支持预测 23 个常见版面类别，中英论文、研报、试卷、书籍、杂志、合同、报纸等丰富类型的文档实现高质量版面检测，**mAP@0.5 最高达 90.4%，轻量模型端到端每秒处理超百页文档图像。**

--- a/README_en.md
+++ b/README_en.md
@@ -30,7 +30,7 @@ PaddleOCR is being oversight by a [PMC](https://github.com/PaddlePaddle/PaddleOC
 ## 📣 Recent updates ([more](https://paddlepaddle.github.io/PaddleOCR/latest/en/update.html))
 
 
-- **🔥🔥2024.3.6: Release of a New Self-Developed Major Model Solution in the OCR Field**
+- **🔥🔥2025.3.6: Release of a New Self-Developed Major Model Solution in the OCR Field**
 
   - **12 new self-developed single models:**
     - **[Layout Detection](https://paddlepaddle.github.io/PaddleX/latest/en/module_usage/tutorials/ocr_modules/layout_detection.html)** series with 3 models: PP-DocLayout-L, PP-DocLayout-M, PP-DocLayout-S, supporting prediction of 23 common layout categories. High-quality layout detection for various document types such as papers, reports, exams, books, magazines, contracts, newspapers in both English and Chinese. **mAP@0.5 reaches up to 90.4%, lightweight models can process over 100 pages of document images per second end-to-end.**

--- a/docs/update.en.md
+++ b/docs/update.en.md
@@ -7,7 +7,7 @@ hide:
 
 ### Recently Update
 
-#### **🔥🔥2024.3.6: Release of a New Self-Developed Major Model Solution in the OCR Field**
+#### **🔥🔥2025.3.6: Release of a New Self-Developed Major Model Solution in the OCR Field**
 
   - **12 new self-developed single models:**
     - **[Layout Detection](https://paddlepaddle.github.io/PaddleX/latest/en/module_usage/tutorials/ocr_modules/layout_detection.html)** series with 3 models: PP-DocLayout-L, PP-DocLayout-M, PP-DocLayout-S, supporting prediction of 23 common layout categories. High-quality layout detection for various document types such as papers, reports, exams, books, magazines, contracts, newspapers in both English and Chinese. **mAP@0.5 reaches up to 90.4%, lightweight models can process over 100 pages of document images per second end-to-end.**

--- a/docs/update.md
+++ b/docs/update.md
@@ -7,7 +7,7 @@ hide:
 
 ### 更新
 
-#### **🔥🔥2024.3.6 新增OCR领域自研重磅模型方案**
+#### **🔥🔥2025.3.6 新增OCR领域自研重磅模型方案**
 
   - **重磅新增 OCR 领域 12 个自研单模型：**
     - **[版面区域检测](https://paddlepaddle.github.io/PaddleX/latest/module_usage/tutorials/ocr_modules/layout_detection.html)** 系列 3 个模型：PP-DocLayout-L、PP-DocLayout-M、PP-DocLayout-S，支持预测 23 个常见版面类别，中英论文、研报、试卷、书籍、杂志、合同、报纸等丰富类型的文档实现高质量版面检测，**mAP@0.5 最高达 90.4%，轻量模型端到端每秒处理超百页文档图像。**


### PR DESCRIPTION
The last commit that described the newly added capabilities listed the previous year. ;-)

I've updated this to 2025.