### PR TITLE
Add missing languages to documentation

### DIFF
--- a/docs/ppocr/blog/multi_languages.en.md
+++ b/docs/ppocr/blog/multi_languages.en.md
@@ -221,3 +221,5 @@ If necessary, you can read related documents:
 |Vietnamese |vi| |Nagpur |sck|
 |Mongolian |mn| |Newari |new|
 |Abaza |abq| |Goan Konkani|gom|
+|Chechen |che| |Pali |pi|
+|Haryanvi |bgc| |Latin |la|

--- a/docs/ppocr/blog/multi_languages.md
+++ b/docs/ppocr/blog/multi_languages.md
@@ -271,3 +271,5 @@ python3 -m paddle.distributed.launch --gpus '0,1,2,3'  tools/train.py -c configs
 | 乌兹别克文|Uzbek |uz| | 阿瓦尔文|Avar |ava|
 | 越南文|Vietnamese |vi| | 阿瓦尔文|Avar |ava|
 | 蒙古文|Mongolian |mn| | 阿迪赫文|Adyghe |ady|
+| 车臣文 |Chechen |che| | 巴利文 |Pali |pi|
+| 哈里亚纳语 |Haryanvi |bgc| | 拉丁文 |Latin |la|


### PR DESCRIPTION
I noticed that not all supported languages are listed in the table for supported languages and abbreviations. I compared them against the one listed in the `paddleocr.py` file and added the missing ones to the table.

Now the table should be complete! :-)