### PR TITLE
docs: Fix formatting of a Markdown List

### DIFF
--- a/docs/paddlex/quick_start.en.md
+++ b/docs/paddlex/quick_start.en.md
@@ -36,6 +36,7 @@ paddlex --pipeline [Pipeline Name] --input [Input Image] --device [Running Devic
 ```
 
 Each Pipeline in PaddleX corresponds to specific parameters, which you can view in the respective Pipeline documentation for detailed explanations. Each Pipeline requires specifying three necessary parameters:
+
 * `pipeline`: The name of the Pipeline or the configuration file of the Pipeline
 * `input`: The local path, directory, or URL of the input file (e.g., an image) to be processed
 * `device`: The hardware device and its index to use (e.g., `gpu:0` indicates using the 0th GPU), or you can choose to use NPU (`npu:0`), XPU (`xpu:0`), CPU (`cpu`), etc.


### PR DESCRIPTION
This should fix the display of the list.

Currently, it looks like this:

![image](https://github.com/user-attachments/assets/9836f9ff-359b-414f-b6af-b5e6fbe02056)

Should look like this:

![image](https://github.com/user-attachments/assets/6ef8a282-ca02-49c3-ae5d-fa6f306ad1d3)

Thanks! 🚀