### PR TITLE
fix onnx in latexocr

### DIFF
--- a/ppocr/modeling/heads/rec_latexocr_head.py
+++ b/ppocr/modeling/heads/rec_latexocr_head.py
@@ -907,14 +907,7 @@ class LaTeXOCRHead(nn.Layer):
             x = out[:, -self.max_seq_len :]
             mask = mask[:, -self.max_seq_len :]
             logits = self.net(x, mask=mask, **kwargs)[:, -1, :]
-            if filter_logits_fn in {top_k, top_p}:
-                filtered_logits = filter_logits_fn(logits, thres=filter_thres)
-
-                probs = F.softmax(filtered_logits / temperature, axis=-1)
-            else:
-                raise NotImplementedError("The filter_logits_fn is not supported ")
-
-            sample = paddle.multinomial(probs, 1)
+            sample = paddle.argmax(logits, axis=1).reshape([-1, 1])
             out = paddle.concat((out, sample), axis=-1)
             pad_mask = paddle.full(shape=[mask.shape[0], 1], fill_value=1, dtype="bool")
             mask = paddle.concat((mask, pad_mask), axis=1)
@@ -966,12 +959,7 @@ class LaTeXOCRHead(nn.Layer):
             logits = self.net(x, mask=mask, context=context, seq_len=i_idx, **kwargs)[
                 :, -1, :
             ]
-            if filter_logits_fn in {top_k, top_p}:
-                filtered_logits = filter_logits_fn(logits, thres=filter_thres)
-
-                probs = F.softmax(filtered_logits / temperature, axis=-1)
-
-            sample = paddle.multinomial(probs, 1)
+            sample = paddle.argmax(logits, axis=1).reshape([-1, 1])
             out = paddle.concat((out, sample), axis=-1)
 
             pad_mask = paddle.full(shape=[mask.shape[0], 1], fill_value=1, dtype="bool")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pyyaml
 requests
 albumentations
 # to be compatible with albumentations
-albucore
+albucore==0.0.16
 packaging


### PR DESCRIPTION
1. paddle.multinomial 在onnxruntime 中存在bug，使用paddle.argmax替换，经验证精度符合预期
2. albumentations默认装albucore=0.24 会报错，将其降级