### PR TITLE
Fixed deduplication in picodet_postprocess

### DIFF
--- a/ppocr/postprocess/picodet_postprocess.py
+++ b/ppocr/postprocess/picodet_postprocess.py
@@ -292,6 +292,7 @@ class PicoDetPostProcess(object):
                         key=lambda x: x[1]["score"],
                         reverse=True,
                     )[0][0]
-                duplicate_idx.extend([x for x in overlaps if x != keep])
+                if keep != i:
+                    duplicate_idx.append(i)
         results = [x for i, x in enumerate(results) if i not in duplicate_idx]
         return results


### PR DESCRIPTION
Hi,

When I tested your OCR with layout analysis I ran into a weird bug. I had this image:
![Input image](https://github.com/user-attachments/assets/de7830e9-f5ca-44ac-ab36-8ab5cc5ef2a8)
Firstly, I ran the model with a score threshold 0.4 and the output was this image:
![result_0 4](https://github.com/user-attachments/assets/3a84d562-002d-46d1-b58a-26a7fbb7a4db)
I was a little bit upset that the model did not find the title with high confidence so I lowered the threshold to 0.3 and the result is this image:
![result_0 3](https://github.com/user-attachments/assets/40be3252-c5c1-47d3-a02c-3e051cbb5534)
When I saw it, I knew that something was going wrong. When the threshold is lowered, the same or more bboxes can appear, but they cannot disappear.

I thought there was some bug in the nms function but I found a bug in the deduplication function. The function iterates bboxes and computes iou with all other bboxes. If there are overlapping bboxes one persists and the other is removed (marked as duplicate) but this approach is wrong. For example in this case:
![result](https://github.com/user-attachments/assets/3a288c82-6879-414c-a8f0-60dec0bcb4e1)
In the first loop iteration, bboxes 0, 1, and  3 are removed. This does not make any sense. Bboxes 1 and 3 do not overlap at all. Additionally these bboxes overlap with only bbox 0 which is removed in the same iteration as well. The correct approach is to remove only tested bbox 0.

After this fix, the output is as expected:
![result](https://github.com/user-attachments/assets/e04f33eb-a365-40e2-b114-7655eadbbae8)
