### PR TITLE
Fix dead link for diving into OCR

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -85,7 +85,7 @@ PaddleX provides a one-stop full-process high-efficiency development platform fo
 
 ## 📚 E-book: *Dive Into OCR*
 
-- [Dive Into OCR](./doc/doc_en/ocr_book_en.md)
+- [Dive Into OCR](https://paddlepaddle.github.io/PaddleOCR/latest/en/ppocr/blog/ocr_book.html)
 
 ## 🎖 Contributors
 


### PR DESCRIPTION
I found a dead link in the Readme on the start page of the repository.
I updated it with the correct link.