### PR TITLE
fix bug: train logger cannot save to train.log file

### DIFF
--- a/tools/program.py
+++ b/tools/program.py
@@ -825,7 +825,7 @@ def preprocess(is_train=False):
         log_file = None
 
     log_ranks = config["Global"].get("log_ranks", "0")
-    logger = get_logger(log_file=log_file, log_ranks=log_ranks)
+    logger = get_logger(name="ppocr_train", log_file=log_file, log_ranks=log_ranks)
 
     # check if set use_gpu=True in paddlepaddle cpu version
     use_gpu = config["Global"].get("use_gpu", False)


### PR DESCRIPTION
修复bug：训练日志 logger 无法保存到文件 train.log
原因：由于 save_load 文件第35行创建了同名的无文件日志，在训练时 get_logger返回了改同名日志对象
修复方法：重命名训练日志对象为 “ppocr_train"