### PR TITLE
[Fix] Set subcommand as required

### DIFF
--- a/paddleocr/_cli.py
+++ b/paddleocr/_cli.py
@@ -97,14 +97,14 @@ def _register_install_hpi_deps_command(subparsers):
     subparser.set_defaults(executor=_install_hpi_deps)
 
 
-def _parse_args():
+def _get_parser():
     parser = argparse.ArgumentParser(prog="paddleocr")
     parser.add_argument("--version", action="version", version=f"%(prog)s {version}")
-    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
     _register_pipelines(subparsers)
     _register_models(subparsers)
     _register_install_hpi_deps_command(subparsers)
-    return parser.parse_args()
+    return parser
 
 
 def _execute(args):
@@ -114,5 +114,6 @@ def _execute(args):
 def main():
     logger.setLevel(logging.INFO)
     warnings.filterwarnings("default", category=CLIDeprecationWarning)
-    args = _parse_args()
+    parser = _get_parser()
+    args = parser.parse_args()
     _execute(args)

--- a/paddleocr/_cli.py
+++ b/paddleocr/_cli.py
@@ -99,8 +99,10 @@ def _register_install_hpi_deps_command(subparsers):
 
 def _get_parser():
     parser = argparse.ArgumentParser(prog="paddleocr")
-    parser.add_argument("--version", action="version", version=f"%(prog)s {version}")
-    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"%(prog)s {version}"
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
     _register_pipelines(subparsers)
     _register_models(subparsers)
     _register_install_hpi_deps_command(subparsers)
@@ -116,4 +118,7 @@ def main():
     warnings.filterwarnings("default", category=CLIDeprecationWarning)
     parser = _get_parser()
     args = parser.parse_args()
+    if args.subcommand is None:
+        parser.print_usage()
+        sys.exit(2)
     _execute(args)


### PR DESCRIPTION
```bash
paddleocr
```

```
usage: paddleocr [-h] [-v]
                 {doc_preprocessor,doc_understanding,formula_recognition_pipeline,ocr,pp_chatocrv4_doc,pp_structurev3,seal_recognition,table_recognition_v2,doc_img_orientation_classification,doc_vlm,formula_recognition,layout_detection,seal_text_detection,table_cells_detection,table_classification,table_structure_recognition,text_detection,text_image_unwarping,text_line_orientation_classification,text_recognition,install_hpi_deps}
                 ...
```
