### PR TITLE
修复3.x版本中参数对应问题

### DIFF
--- a/docs/version3.x/module_usage/doc_img_orientation_classification.en.md
+++ b/docs/version3.x/module_usage/doc_img_orientation_classification.en.md
@@ -120,51 +120,96 @@ The explanations of relevant methods and parameters are as follows:
 * Instantiate the document image orientation classification model with `DocImgOrientationClassification` (taking `PP-LCNet_x1_0_doc_ori` as an example here). The specific explanations are as follows:
 
 <table>
-<thead>
-<tr>
-<th>Parameter</th>
-<th>Description</th>
-<th>Parameter Type</th>
-<th>Options</th>
-<th>Default Value</th>
-</tr>
-</thead>
-<tr>
-<td><code>model_name</code></td>
-<td>Model name</td>
-<td><code>str</code></td>
-<td>None</td>
-<td><code>None</code></td>
-</tr>
-<tr>
-<td><code>model_dir</code></td>
-<td>Model storage path</td>
-<td><code>str</code></td>
-<td>None</td>
-<td>None</td>
-</tr>
-<tr>
-<td><code>device</code></td>
-<td>Model inference device</td>
-<td><code>str</code></td>
-<td>Supports specifying the specific card number of GPU, such as "gpu:0", specific card numbers of other hardware, such as "npu:0", and CPU, such as "cpu".</td>
-<td><code>gpu:0</code></td>
-</tr>
-<tr>
-<td><code>use_hpip</code></td>
-<td>Whether to enable the high-performance inference plugin</td>
-<td><code>bool</code></td>
-<td>None</td>
-<td><code>False</code></td>
-</tr>
-<tr>
-<td><code>hpi_config</code></td>
-<td>High-performance inference configuration</td>
-<td><code>dict</code> | <code>None</code></td>
-<td>None</td>
-<td><code>None</code></td>
-</tr>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+      <th>Parameter Type</th>
+      <th>Options</th>
+      <th>Default Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>model_name</code></td>
+      <td>Name of the model; if not specified, the default model of the class will be used</td>
+      <td><code>str</code></td>
+      <td>None</td>
+      <td><code>"PP-LCNet_x1_0_doc_ori"</code></td>
+    </tr>
+    <tr>
+      <td><code>model_dir</code></td>
+      <td>Path to the local model directory</td>
+      <td><code>str</code></td>
+      <td>None</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>device</code></td>
+      <td>Device for model inference</td>
+      <td><code>str</code></td>
+      <td>Supports values like <code>"gpu:0"</code>, <code>"npu:0"</code>, <code>"cpu"</code></td>
+      <td><code>"cpu"</code></td>
+    </tr>
+    <tr>
+      <td><code>enable_hpi</code></td>
+      <td>Whether to enable the high-performance inference (HPI) plugin</td>
+      <td><code>bool</code></td>
+      <td><code>True</code> / <code>False</code></td>
+      <td><code>False</code></td>
+    </tr>
+    <tr>
+      <td><code>hpi_config</code></td>
+      <td>Configuration dictionary for the high-performance inference plugin</td>
+      <td><code>dict</code> | <code>None</code></td>
+      <td>None</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>topk</code></td>
+      <td>Return the top-k prediction results; <code>None</code> returns all results</td>
+      <td><code>int</code> | <code>None</code></td>
+      <td>Positive integers such as <code>1</code>, <code>5</code>, etc.</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>use_tensorrt</code></td>
+      <td>Whether to enable TensorRT acceleration</td>
+      <td><code>bool</code></td>
+      <td><code>True</code> / <code>False</code></td>
+      <td><code>False</code></td>
+    </tr>
+    <tr>
+      <td><code>min_subgraph_size</code></td>
+      <td>Minimum subgraph size for TensorRT fusion</td>
+      <td><code>int</code></td>
+      <td>Positive integer &gt; 0</td>
+      <td><code>30</code></td>
+    </tr>
+    <tr>
+      <td><code>precision</code></td>
+      <td>Precision for TensorRT inference</td>
+      <td><code>str</code></td>
+      <td><code>"fp32"</code>, <code>"fp16"</code>, <code>"int8"</code></td>
+      <td><code>"fp32"</code></td>
+    </tr>
+    <tr>
+      <td><code>enable_mkldnn</code></td>
+      <td>Whether to enable oneDNN (MKL-DNN) acceleration (only effective for CPU)</td>
+      <td><code>bool</code></td>
+      <td><code>True</code> / <code>False</code></td>
+      <td><code>True</code></td>
+    </tr>
+    <tr>
+      <td><code>cpu_threads</code></td>
+      <td>Number of CPU threads used for inference</td>
+      <td><code>int</code></td>
+      <td>Integer &ge; 1</td>
+      <td><code>10</code></td>
+    </tr>
+  </tbody>
 </table>
+
 
 * Among them, `model_name` must be specified. After specifying `model_name`, the model parameters built into PaddleX are used by default. On this basis, when `model_dir` is specified, the user-defined model is used.
 

--- a/docs/version3.x/module_usage/doc_img_orientation_classification.md
+++ b/docs/version3.x/module_usage/doc_img_orientation_classification.md
@@ -122,51 +122,97 @@ for res in output:
 
 * `DocImgOrientationClassification`实例化文档图像方向分类模型（此处以`PP-LCNet_x1_0_doc_ori`为例），具体说明如下：
 <table>
-<thead>
-<tr>
-<th>参数</th>
-<th>参数说明</th>
-<th>参数类型</th>
-<th>可选项</th>
-<th>默认值</th>
-</tr>
-</thead>
-<tr>
-<td><code>model_name</code></td>
-<td>模型名称</td>
-<td><code>str</code></td>
-<td>无</td>
-<td><code>无</code></td>
-</tr>
-<tr>
-<td><code>model_dir</code></td>
-<td>模型存储路径</td>
-<td><code>str</code></td>
-<td>无</td>
-<td>无</td>
-</tr>
-<tr>
-<td><code>device</code></td>
-<td>模型推理设备</td>
-<td><code>str</code></td>
-<td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号，如“npu:0”，CPU如“cpu”。</td>
-<td><code>gpu:0</code></td>
-</tr>
-<tr>
-<td><code>use_hpip</code></td>
-<td>是否启用高性能推理插件</td>
-<td><code>bool</code></td>
-<td>无</td>
-<td><code>False</code></td>
-</tr>
-<tr>
-<td><code>hpi_config</code></td>
-<td>高性能推理配置</td>
-<td><code>dict</code> | <code>None</code></td>
-<td>无</td>
-<td><code>None</code></td>
-</tr>
+  <thead>
+    <tr>
+      <th>参数</th>
+      <th>参数说明</th>
+      <th>参数类型</th>
+      <th>可选项</th>
+      <th>默认值</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>model_name</code></td>
+      <td>模型名称；留空时自动使用类属性 <code>default_model_name</code></td>
+      <td><code>str</code></td>
+      <td>无</td>
+      <td><code>"PP-LCNet_x1_0_doc_ori"</code></td>
+    </tr>
+    <tr>
+      <td><code>model_dir</code></td>
+      <td>模型存储路径</td>
+      <td><code>str</code></td>
+      <td>无</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>device</code></td>
+      <td>模型推理设备</td>
+      <td><code>str</code></td>
+      <td>支持指定 GPU 卡号（如 <code>"gpu:0"</code>）、NPU 卡号（如 <code>"npu:0"</code>）、或 <code>"cpu"</code></td>
+      <td><code>"cpu"</code></td>
+    </tr>
+    <tr>
+      <td><code>enable_hpi</code></td>
+      <td>是否启用高性能推理插件（HPI）</td>
+      <td><code>bool</code></td>
+      <td>无</td>
+      <td><code>False</code></td>
+    </tr>
+    <tr>
+      <td><code>hpi_config</code></td>
+      <td>高性能推理配置</td>
+      <td><code>dict</code> | <code>None</code></td>
+      <td>无</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>topk</code></td>
+      <td>返回前 top-k 个预测结果，用于控制输出的类别数量</td>
+      <td><code>int</code> | <code>None</code></td>
+      <td>如 <code>1</code>、<code>5</code> 等正整数</td>
+      <td><code>None</code></td>
+    </tr>
+    <tr>
+      <td><code>use_tensorrt</code></td>
+      <td>是否启用 TensorRT 加速</td>
+      <td><code>bool</code></td>
+      <td><code>True</code> / <code>False</code></td>
+      <td><code>False</code></td>
+    </tr>
+    <tr>
+      <td><code>min_subgraph_size</code></td>
+      <td>TensorRT 子图最小节点数</td>
+      <td><code>int</code></td>
+      <td>&gt; 0 的正整数</td>
+      <td><code>30</code></td>
+    </tr>
+    <tr>
+      <td><code>precision</code></td>
+      <td>TensorRT 精度</td>
+      <td><code>str</code></td>
+      <td><code>"fp32"</code> / <code>"fp16"</code> / <code>"int8"</code></td>
+      <td><code>"fp32"</code></td>
+    </tr>
+    <tr>
+      <td><code>enable_mkldnn</code></td>
+      <td>是否启用 oneDNN（MKL-DNN）加速（仅 CPU 有效）</td>
+      <td><code>bool</code></td>
+      <td><code>True</code> / <code>False</code></td>
+      <td><code>True</code></td>
+    </tr>
+    <tr>
+      <td><code>cpu_threads</code></td>
+      <td>CPU 线程数</td>
+      <td><code>int</code></td>
+      <td>&gt;= 1</td>
+      <td><code>10</code></td>
+    </tr>
+  </tbody>
 </table>
+
+
 
 * 其中，`model_name` 必须指定，指定 `model_name` 后，默认使用 PaddleX 内置的模型参数，在此基础上，指定 `model_dir` 时，使用用户自定义的模型。
 

--- a/docs/version3.x/module_usage/doc_vlm.en.md
+++ b/docs/version3.x/module_usage/doc_vlm.en.md
@@ -110,38 +110,73 @@ Explanations of related methods, parameters, etc., are as follows:
 </thead>
 <tr>
 <td><code>model_name</code></td>
-<td>Model Name</td>
+<td>Name of the model, e.g. <code>PP-DocBee2-3B</code></td>
 <td><code>str</code></td>
 <td>None</td>
 <td><code>None</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
-<td>Model Storage Path</td>
+<td>Path to the model directory</td>
 <td><code>str</code></td>
 <td>None</td>
-<td>None</td>
+<td><code>None</code></td>
 </tr>
 <tr>
 <td><code>device</code></td>
-<td>Model Inference Device</td>
+<td>Device for model inference</td>
 <td><code>str</code></td>
-<td>Supports specifying specific GPU card number, such as "gpu:0", other hardware specific card numbers, such as "npu:0", CPU such as "cpu".</td>
-<td><code>gpu:0</code></td>
+<td>Supports specifying a specific device such as <code>gpu:0</code>, <code>npu:0</code>, or <code>cpu</code></td>
+<td><code>cpu</code></td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
-<td>Whether to enable high-performance inference plugin. Currently not supported.</td>
+<td><code>enable_hpi</code></td>
+<td>Whether to enable high-performance inference (HPI)</td>
 <td><code>bool</code></td>
-<td>None</td>
+<td><code>True</code> / <code>False</code></td>
 <td><code>False</code></td>
 </tr>
 <tr>
 <td><code>hpi_config</code></td>
-<td>High-performance inference configuration. Currently not supported.</td>
+<td>Configuration for high-performance inference</td>
 <td><code>dict</code> | <code>None</code></td>
 <td>None</td>
 <td><code>None</code></td>
+</tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>Whether to enable TensorRT acceleration</td>
+<td><code>bool</code></td>
+<td><code>True</code> / <code>False</code></td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>Minimum subgraph size for TensorRT optimization</td>
+<td><code>int</code></td>
+<td>&ge; 1</td>
+<td><code>30</code></td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>Precision type for TensorRT</td>
+<td><code>str</code></td>
+<td><code>fp32</code> / <code>fp16</code> / <code>int8</code></td>
+<td><code>fp32</code></td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>Whether to enable oneDNN (only effective on CPU)</td>
+<td><code>bool</code></td>
+<td><code>True</code> / <code>False</code></td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>Number of threads to use for CPU inference</td>
+<td><code>int</code></td>
+<td>&ge; 1</td>
+<td><code>10</code></td>
 </tr>
 </table>
 

--- a/docs/version3.x/module_usage/doc_vlm.md
+++ b/docs/version3.x/module_usage/doc_vlm.md
@@ -113,7 +113,7 @@ for res in results:
 </thead>
 <tr>
 <td><code>model_name</code></td>
-<td>模型名称</td>
+<td>模型名称，如 <code>PP-DocBee2-3B</code> 等</td>
 <td><code>str</code></td>
 <td>无</td>
 <td><code>无</code></td>
@@ -123,28 +123,63 @@ for res in results:
 <td>模型存储路径</td>
 <td><code>str</code></td>
 <td>无</td>
-<td>无</td>
+<td><code>None</code></td>
 </tr>
 <tr>
 <td><code>device</code></td>
 <td>模型推理设备</td>
 <td><code>str</code></td>
-<td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号，如“npu:0”，CPU如“cpu”。</td>
-<td><code>gpu:0</code></td>
+<td>支持指定 GPU 具体卡号，如 <code>gpu:0</code>，其他硬件如 <code>npu:0</code>，CPU 如 <code>cpu</code></td>
+<td><code>cpu</code></td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
-<td>是否启用高性能推理插件。目前暂不支持。</td>
+<td><code>enable_hpi</code></td>
+<td>是否启用高性能推理插件（HPI）</td>
 <td><code>bool</code></td>
-<td>无</td>
+<td><code>True</code> / <code>False</code></td>
 <td><code>False</code></td>
 </tr>
 <tr>
 <td><code>hpi_config</code></td>
-<td>高性能推理配置。目前暂不支持。</td>
+<td>高性能推理插件的配置</td>
 <td><code>dict</code> | <code>None</code></td>
 <td>无</td>
 <td><code>None</code></td>
+</tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>是否启用 TensorRT 加速</td>
+<td><code>bool</code></td>
+<td><code>True</code> / <code>False</code></td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>TensorRT 子图最小节点数</td>
+<td><code>int</code></td>
+<td>&ge; 1</td>
+<td><code>30</code></td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>TensorRT 精度类型</td>
+<td><code>str</code></td>
+<td><code>fp32</code> / <code>fp16</code> / <code>int8</code></td>
+<td><code>fp32</code></td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>是否启用 oneDNN（仅在 CPU 推理时生效）</td>
+<td><code>bool</code></td>
+<td><code>True</code> / <code>False</code></td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>CPU 推理线程数</td>
+<td><code>int</code></td>
+<td>&ge; 1</td>
+<td><code>10</code></td>
 </tr>
 </table>
 

--- a/docs/version3.x/module_usage/formula_recognition.en.md
+++ b/docs/version3.x/module_usage/formula_recognition.en.md
@@ -174,38 +174,74 @@ Related methods and parameter descriptions are as follows:
 <td><code>model_name</code></td>
 <td>Model name</td>
 <td><code>str</code></td>
-<td>All model names supported by PaddleX</td>
-<td>None</td>
+<td>All model names supported by Paddleocr</td>
+<td><code>PP-FormulaNet_plus-M</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
 <td>Model storage path</td>
 <td><code>str</code></td>
 <td>None</td>
-<td>None</td>
+<td><code>None</code></td>
 </tr>
 <tr>
 <td><code>device</code></td>
 <td>Device used for model inference</td>
 <td><code>str</code></td>
-<td>Supports specifying a specific GPU card such as \"gpu:0\", other hardware card such as \"npu:0\", and CPU such as \"cpu\".</td>
-<td><code>gpu:0</code></td>
+<td>Supports specifying a specific GPU card such as "gpu:0", other hardware like "npu:0", or "cpu".</td>
+<td><code>cpu</code></td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
-<td>Whether to enable high-performance inference plugin</td>
+<td><code>enable_hpi</code></td>
+<td>Whether to enable high-performance inference plugin (HPI)</td>
 <td><code>bool</code></td>
-<td>None</td>
+<td>True / False</td>
 <td><code>False</code></td>
 </tr>
 <tr>
 <td><code>hpi_config</code></td>
-<td>High-performance inference configuration</td>
+<td>Configuration for high-performance inference plugin</td>
 <td><code>dict</code> | <code>None</code></td>
 <td>None</td>
 <td><code>None</code></td>
 </tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>Whether to enable TensorRT acceleration</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>Minimum number of ops in a subgraph to use TensorRT</td>
+<td><code>int</code></td>
+<td>&gt;0</td>
+<td><code>30</code></td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>Precision used for TensorRT inference</td>
+<td><code>str</code></td>
+<td><code>fp32</code>, <code>fp16</code>, <code>int8</code></td>
+<td><code>fp32</code></td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>Enable oneDNN acceleration (CPU only)</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>Number of threads for CPU inference</td>
+<td><code>int</code></td>
+<td>&gt;=1</td>
+<td><code>10</code></td>
+</tr>
 </table>
+
 
 * Among these, `model_name` must be specified. When `model_name` is provided, the built-in model parameters from PaddleX are used by default. If `model_dir` is also specified, it will use the user-defined model instead.
 

--- a/docs/version3.x/module_usage/formula_recognition.md
+++ b/docs/version3.x/module_usage/formula_recognition.md
@@ -186,28 +186,28 @@ sudo apt-get install texlive texlive-latex-base texlive-xetex latex-cjk-all texl
 <td><code>model_name</code></td>
 <td>模型名称</td>
 <td><code>str</code></td>
-<td>所有PaddleX支持的模型名称</td>
-<td>无</td>
+<td>模型名称</td>
+<td><code>PP-FormulaNet_plus-M</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
 <td>模型存储路径</td>
 <td><code>str</code></td>
 <td>无</td>
-<td>无</td>
+<td><code>None</code></td>
 </tr>
 <tr>
 <td><code>device</code></td>
 <td>模型推理设备</td>
 <td><code>str</code></td>
-<td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号，如“npu:0”，CPU如“cpu”。</td>
-<td><code>gpu:0</code></td>
+<td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号如“npu:0”，CPU如“cpu”。</td>
+<td><code>cpu</code></td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
+<td><code>enable_hpi</code></td>
 <td>是否启用高性能推理插件</td>
 <td><code>bool</code></td>
-<td>无</td>
+<td>True / False</td>
 <td><code>False</code></td>
 </tr>
 <tr>
@@ -217,7 +217,43 @@ sudo apt-get install texlive texlive-latex-base texlive-xetex latex-cjk-all texl
 <td>无</td>
 <td><code>None</code></td>
 </tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>是否启用 TensorRT 加速</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>TensorRT 子图最小节点数</td>
+<td><code>int</code></td>
+<td>&gt;0</td>
+<td><code>30</code></td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>TensorRT 推理精度</td>
+<td><code>str</code></td>
+<td><code>fp32</code>, <code>fp16</code>, <code>int8</code></td>
+<td><code>fp32</code></td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>是否启用 oneDNN（仅在 CPU 下有效）</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>CPU 推理线程数</td>
+<td><code>int</code></td>
+<td>&gt;=1</td>
+<td><code>10</code></td>
+</tr>
 </table>
+
 
 * 其中，`model_name` 必须指定，指定 `model_name` 后，默认使用 PaddleX 内置的模型参数，在此基础上，指定 `model_dir` 时，使用用户自定义的模型。
 

--- a/docs/version3.x/module_usage/layout_detection.en.md
+++ b/docs/version3.x/module_usage/layout_detection.en.md
@@ -460,16 +460,14 @@ Relevant methods, parameters, and explanations are as follows:
 </thead>
 <tr>
 <td><code>input</code></td>
-<td>Data for prediction, supporting multiple input types</td>
-<td><code>Python Var</code>/<code>str</code>/<code>list</code></td>
+<td>Data to be predicted; multiple formats are supported</td>
+<td><code>Python Var/str/list</code></td>
 <td>
-<ul>
-<li><b>Python Variable</b>, such as image data represented by <code>numpy.ndarray</code></li>
-<li><b>File Path</b>, such as the local path of an image file: <code>/root/data/img.jpg</code></li>
-<li><b>URL link</b>, such as the network URL of an image file: <a href = "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg">示例</a></li>
-<li><b>Local Directory</b>, the directory should contain the data files to be predicted, such as the local path: <code>/root/data/</code></li>
-<li><b>List</b>, the elements of the list should be of the above-mentioned data types, such as <code>[numpy.ndarray, numpy.ndarray]</code>, <code>[\"/root/data/img1.jpg\", \"/root/data/img2.jpg\"]</code>, <code>[\"/root/data1\", \"/root/data2\"]</code></li>
-</ul>
+Python objects such as <code>numpy.ndarray</code><br>
+File path, e.g. <code>/root/data/img.jpg</code><br>
+URL of an image<br>
+Local directory containing image files<br>
+List whose elements are any of the above
 </td>
 <td>None</td>
 </tr>
@@ -477,61 +475,68 @@ Relevant methods, parameters, and explanations are as follows:
 <td><code>batch_size</code></td>
 <td>Batch size</td>
 <td><code>int</code></td>
-<td>Any integer greater than 0</td>
+<td>Any integer &gt; 0</td>
 <td>1</td>
 </tr>
 <tr>
 <td><code>threshold</code></td>
-<td>Threshold for filtering low-confidence prediction results</td>
+<td>Confidence threshold for filtering predictions</td>
 <td><code>float/dict/None</code></td>
 <td>
 <ul>
-<li><b>float</b>, e.g., 0.2, means filtering out all bounding boxes with a confidence score less than 0.2</li>
-<li><b>Dictionary</b>, with keys as <b>int</b> representing <code>cls_id</code> and values as <b>float</b> thresholds. For example, <code>{0: 0.45, 2: 0.48, 7: 0.4}</code> means applying a threshold of 0.45 for cls_id 0, 0.48 for cls_id 2, and 0.4 for cls_id 7</li>
-<li><b>None</b>, not specified, will use the <code>threshold</code> parameter specified in <code>create_model</code>. If not specified in <code>create_model</code>, the default PaddleX official model configuration will be used</li>
+<li><b>float</b>, e.g.&nbsp;0.2 → drop boxes with score&nbsp;&lt;&nbsp;0.2</li>
+<li><b>dict</b>, keys as <b>int</b> (<code>cls_id</code>), values as <b>float</b>, e.g.&nbsp;<code>{0: 0.45, 2: 0.48}</code></li>
+<li><b>None</b></li>
 </ul>
 </td>
+<td><b>None<sup>＊</sup></b></td>
 </tr>
 <tr>
 <td><code>layout_nms</code></td>
-<td>Whether to use NMS post-processing to filter overlapping boxes; if not specified, the default PaddleX official model configuration will be used</td>
+<td>Apply NMS to filter overlapping boxes</td>
 <td><code>bool/None</code></td>
 <td>
 <ul>
-<li><b>bool</b>, True/False, indicates whether to use NMS for post-processing to filter overlapping boxes</li>
-<li><b>None</b>, not specified, will use the <code>layout_nms</code> parameter specified in <code>create_model</code>. If not specified in <code>create_model</code>, the default PaddleX official model configuration will be used</li>
+<li><b>True / False</b></li>
+<li><b>None</b></li>
 </ul>
 </td>
-<td>None</td>
+<td><b>None<sup>＊</sup></b></td>
 </tr>
 <tr>
 <td><code>layout_unclip_ratio</code></td>
-<td>Scaling factor for the side length of the detection box; if not specified, the default PaddleX official model configuration will be used</td>
+<td>Scaling ratio for detected boxes</td>
 <td><code>float/list/dict/None</code></td>
 <td>
 <ul>
-<li><b>float</b>, a positive float number, e.g., 1.1, means expanding the width and height of the detection box by 1.1 times while keeping the center unchanged</li>
-<li><b>List</b>, e.g., [1.2, 1.5], means expanding the width by 1.2 times and the height by 1.5 times while keeping the center unchanged</li>
-<li><b>dict</b>, keys as <b>int</b> representing <code>cls_id</code>, values as float scaling factors, e.g., <code>{0: (1.1, 2.0)}</code> means cls_id 0 expanding the width by 1.1 times and the height by 2.0 times while keeping the center unchanged</li>
-<li><b>None</b>, not specified, will use the <code>layout_unclip_ratio</code> parameter specified in <code>create_model</code>. If not specified in <code>create_model</code>, the default PaddleX official model configuration will be used</li>
+<li><b>float</b>, e.g.&nbsp;1.1</li>
+<li><b>list</b>, e.g.&nbsp;[1.2,&nbsp;1.5]</li>
+<li><b>dict</b>, e.g.&nbsp;<code>{0: (1.1, 2.0)}</code></li>
+<li><b>None</b></li>
 </ul>
 </td>
+<td><b>None<sup>＊</sup></b></td>
+</tr>
 <tr>
 <td><code>layout_merge_bboxes_mode</code></td>
-<td>Merging mode for the detection boxes output by the model; if not specified, the default PaddleX official model configuration will be used</td>
+<td>Merging mode for overlapping boxes</td>
 <td><code>string/dict/None</code></td>
 <td>
 <ul>
-<li><b>large</b>, when set to large, only the largest external box will be retained for overlapping detection boxes, and the internal overlapping boxes will be deleted</li>
-<li><b>small</b>, when set to small, only the smallest internal box will be retained for overlapping detection boxes, and the external overlapping boxes will be deleted</li>
-<li><b>union</b>, no filtering of boxes will be performed, and both internal and external boxes will be retained</li>
-<li><b>dict</b>, keys as <b>int</b> representing <code>cls_id</code> and values as merging modes, e.g., <code>{0: "large", 2: "small"}</li>
-<li><b>None</b>, not specified, will use the <code>layout_merge_bboxes_mode</code> parameter specified in <code>create_model</code>. If not specified in <code>create_model</code>, the default PaddleX official model configuration will be used</li>
+<li><b>large</b>: keep outer box</li>
+<li><b>small</b>: keep inner box</li>
+<li><b>union</b>: keep all</li>
+<li><b>dict</b>, e.g.&nbsp;<code>{0:"large", 2:"small"}</code></li>
+<li><b>None</b></li>
 </ul>
 </td>
-<td>None</td>
+<td><b>None<sup>＊</sup></b></td>
 </tr>
-</tr></table>
+</table>
+
+<p><sup>＊</sup> If <code>None</code> is passed to <code>predict()</code>, the value set during model instantiation (<code>__init__</code>) will be used; if it was also <code>None</code> there, the framework defaults are applied:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<code>threshold=0.5</code>, <code>layout_nms=False</code>, <code>layout_unclip_ratio=1.0</code>, <code>layout_merge_bboxes_mode="union"</code>.</p>
+
 
 * Process the prediction results, with each sample's prediction result being the corresponding Result object, and supporting operations such as printing, saving as an image, and saving as a 'json' file:
 

--- a/docs/version3.x/module_usage/layout_detection.md
+++ b/docs/version3.x/module_usage/layout_detection.md
@@ -349,90 +349,91 @@ for res in output:
 <td>模型名称</td>
 <td><code>str</code></td>
 <td>无</td>
-<td>无</td>
+<td><code>PP-DocLayout-L</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
 <td>模型存储路径</td>
 <td><code>str</code></td>
 <td>无</td>
-<td>无</td>
+<td><code>None</code></td>
 </tr>
 <tr>
 <td><code>device</code></td>
 <td>模型推理设备</td>
 <td><code>str</code></td>
 <td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号，如“npu:0”，CPU如“cpu”。</td>
-<td><code>gpu:0</code></td>
+<td><code>cpu</code></td>
 </tr>
 <tr>
 <td><code>img_size</code></td>
-<td>输入图像大小；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>输入图像大小；如果不指定，将使用模型默认配置</td>
 <td><code>int/list/None</code></td>
 <td>
 <ul>
 <li><b>int</b>, 如 640 , 表示将输入图像resize到640x640大小</li>
 <li><b>列表</b>, 如 [640, 512] , 表示将输入图像resize到宽为640，高为512大小</li>
-<li><b>None</b>, 不指定，将默认使用PaddleX官方模型配置</li>
+<li><b>None</b>, 不指定，将使用模型默认配置</li>
 </ul>
 </td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>threshold</code></td>
-<td>用于过滤掉低置信度预测结果的阈值；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>用于过滤掉低置信度预测结果的阈值；如果不指定，将使用模型默认配置</td>
 <td><code>float/dict/None</code></td>
 <td>
 <ul>
 <li><b>float</b>，如 0.2， 表示过滤掉所有阈值小于0.2的目标框</li>
-<li><b>字典</b>，字典的key为<b>int</b>类型，代表<code>cls_id</code>，val为<b>float</b>类型阈值。如 <code>{0: 0.45, 2: 0.48, 7: 0.4}</code>，表示对cls_id为0的类别应用阈值0.45、cls_id为1的类别应用阈值0.48、cls_id为7的类别应用阈值0.4</li>
-<li><b>None</b>, 不指定，将默认使用PaddleX官方模型配置</li>
+<li><b>字典</b>，字典的key为<b>int</b>类型，代表<code>cls_id</code>，val为<b>float</b>类型阈值。如 <code>{0: 0.45, 2: 0.48, 7: 0.4}</code></li>
+<li><b>None</b>, 不指定，将使用模型默认配置</li>
 </ul>
 </td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>layout_nms</code></td>
-<td>是否使用NMS后处理，过滤重叠框；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>是否使用NMS后处理，过滤重叠框；如果不指定，将使用模型默认配置</td>
 <td><code>bool/None</code></td>
 <td>
 <ul>
-<li><b>bool</b>, True/False , 表示使用/不使用NMS进行检测框的后处理过滤重叠框</li>
-<li><b>None</b>, 不指定，将默认使用PaddleX官方模型配置</li>
+<li><b>bool</b>, True/False , 表示使用/不使用NMS进行检测框的后处理</li>
+<li><b>None</b>, 不指定，将使用模型默认配置</li>
 </ul>
 </td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>layout_unclip_ratio</code></td>
-<td>检测框的边长缩放倍数；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>检测框的边长缩放倍数；如果不指定，将使用模型默认配置</td>
 <td><code>float/list/dict/None</code></td>
 <td>
 <ul>
-<li><b>float</b>, 大于0的浮点数，如 1.1 , 表示将模型输出的检测框中心不变，宽和高都扩张1.1倍</li>
-<li><b>列表</b>, 如 [1.2, 1.5] , 表示将模型输出的检测框中心不变，宽度扩张1.2倍，高度扩张1.5倍</li>
-<li><b>字典</b>, 字典的key为<b>int</b>类型，代表<code>cls_id</code>, value为<b>tuple</b>类型，如<code>{0: (1.1, 2.0)}</code>, 表示将模型输出的第0类别检测框中心不变，宽度扩张1.1倍，高度扩张2.0倍</li>
-<li><b>None</b>, 不指定，将默认使用PaddleX官方模型配置</li>
-</ul>
-</td>
-<tr>
-<td><code>layout_merge_bboxes_mode</code></td>
-<td>模型输出的检测框的合并处理模式；如果不指定，将默认使用PaddleX官方模型配置</td>
-<td><code>string/dict/None</code></td>
-<td>
-<ul>
-<li><b>large</b>, 设置为large时，表示在模型输出的检测框中，对于互相重叠包含的检测框，只保留外部最大的框，删除重叠的内部框。</li>
-<li><b>small</b>, 设置为small，表示在模型输出的检测框中，对于互相重叠包含的检测框，只保留内部被包含的小框，删除重叠的外部框。</li>
-<li><b>union</b>, 不进行框的过滤处理，内外框都保留</li>
-<li><b>dict</b>, 字典的key为<b>int</b>类型，代表<code>cls_id</code>, value为<b>str</b>类型, 如<code>{0: "large", 2: "small"}</code>, 表示对第0类别检测框使用large模式，对第2类别检测框使用small模式</li>
-<li><b>None</b>, 不指定，将默认使用PaddleX官方模型配置</li>
+<li><b>float</b>, 如 1.1 , 表示宽和高都扩张1.1倍</li>
+<li><b>列表</b>, 如 [1.2, 1.5] , 表示宽度扩张1.2倍，高度扩张1.5倍</li>
+<li><b>字典</b>, 如<code>{0: (1.1, 2.0)}</code>, 表示对cls_id=0的框宽扩张1.1倍，高扩张2.0倍</li>
+<li><b>None</b>, 不指定，将使用模型默认配置</li>
 </ul>
 </td>
 <td>None</td>
 </tr>
+<tr>
+<td><code>layout_merge_bboxes_mode</code></td>
+<td>模型输出的检测框的合并处理模式；如果不指定，将使用模型默认配置</td>
+<td><code>string/dict/None</code></td>
+<td>
+<ul>
+<li><b>large</b>: 保留最大外部框，删除内部重叠框</li>
+<li><b>small</b>: 保留被包含的小框，删除外部框</li>
+<li><b>union</b>: 不进行过滤</li>
+<li><b>dict</b>: 如<code>{0: "large", 2: "small"}</code></li>
+<li><b>None</b>: 不指定，使用模型默认</li>
+</ul>
+</td>
+<td>None</td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
+<td><code>enable_hpi</code></td>
 <td>是否启用高性能推理插件</td>
 <td><code>bool</code></td>
 <td>无</td>
@@ -446,6 +447,7 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 </table>
+
 
 * 其中，`model_name` 必须指定，指定 `model_name` 后，默认使用 PaddleX 内置的模型参数，在此基础上，指定 `model_dir` 时，使用用户自定义的模型。
 
@@ -464,15 +466,13 @@ for res in output:
 <tr>
 <td><code>input</code></td>
 <td>待预测数据，支持多种输入类型</td>
-<td><code>Python Var</code>/<code>str</code>/<code>list</code></td>
+<td><code>Python Var/str/list</code></td>
 <td>
-<ul>
-  <li><b>Python变量</b>，如<code>numpy.ndarray</code>表示的图像数据</li>
-  <li><b>文件路径</b>，如图像文件的本地路径：<code>/root/data/img.jpg</code></li>
-  <li><b>URL链接</b>，如图像文件的网络URL：<a href = "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg">示例</a></li>
-  <li><b>本地目录</b>，该目录下需包含待预测数据文件，如本地路径：<code>/root/data/</code></li>
-  <li><b>列表</b>，列表元素需为上述类型数据，如<code>[numpy.ndarray, numpy.ndarray]</code>，<code>["/root/data/img1.jpg", "/root/data/img2.jpg"]</code>，<code>["/root/data1", "/root/data2"]</code></li>
-</ul>
+Python变量，如 <code>numpy.ndarray</code><br>
+文件路径，如 <code>/root/data/img.jpg</code><br>
+URL链接，如网络图像 URL<br>
+本地目录，目录下需包含待预测文件<br>
+列表，元素可为上述任意类型
 </td>
 <td>无</td>
 </tr>
@@ -489,51 +489,59 @@ for res in output:
 <td><code>float/dict/None</code></td>
 <td>
 <ul>
-<li><b>float</b>，如 0.2， 表示过滤掉所有阈值小于0.2的目标框</li>
-<li><b>字典</b>，字典的key为<b>int</b>类型，代表<code>cls_id</code>，val为<b>float</b>类型阈值。如 <code>{0: 0.45, 2: 0.48, 7: 0.4}</code>，表示对cls_id为0的类别应用阈值0.45、cls_id为1的类别应用阈值0.48、cls_id为7的类别应用阈值0.4</li>
-<li><b>None</b>, 不指定，将默认使用 <code>creat_model</code> 指定的 <code>threshold</code> 参数，如果 <code>creat_model</code> 也没有指定，则默认使用PaddleX官方模型配置</li>
+<li><b>float</b>，如 0.2，过滤掉得分&nbsp;&lt;&nbsp;0.2 的检测框</li>
+<li><b>dict</b>，键为 <b>int</b> (cls_id)，值为 <b>float</b> 阈值，如 <code>{0: 0.45, 2: 0.48}</code></li>
+<li><b>None</b>，说明见默认值</li>
 </ul>
 </td>
+<td><b>None<sup>①</sup></b></td>
+</tr>
 <tr>
 <td><code>layout_nms</code></td>
-<td>是否使用NMS后处理，过滤重叠框；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>是否使用 NMS 后处理，过滤重叠框</td>
 <td><code>bool/None</code></td>
 <td>
 <ul>
-<li><b>bool</b>, True/False , 表示使用/不使用NMS进行检测框的后处理过滤重叠框</li>
-<li><b>None</b>, 不指定，将默认使用 <code>creat_model</code> 指定的 <code>layout_nms</code> 参数，如果 <code>creat_model</code> 也没有指定，则默认使用PaddleX官方模型配置</li>
+<li><b>bool</b>，True / False</li>
+<li><b>None</b>，说明见默认值</li>
 </ul>
 </td>
-<td>None</td>
+<td><b>None<sup>①</sup></b></td>
 </tr>
 <tr>
 <td><code>layout_unclip_ratio</code></td>
-<td>检测框的边长缩放倍数；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>检测框的边长缩放倍数</td>
 <td><code>float/list/dict/None</code></td>
 <td>
 <ul>
-<li><b>float</b>, 大于0的浮点数，如 1.1 , 表示将模型输出的检测框中心不变，宽和高都扩张1.1倍</li>
-<li><b>列表</b>, 如 [1.2, 1.5] , 表示将模型输出的检测框中心不变，宽度扩张1.2倍，高度扩张1.5倍</li>
-<li><b>字典</b>, 字典的key为<b>int</b>类型，代表<code>cls_id</code>, value为<b>tuple</b>类型，如<code>{0: (1.1, 2.0)}</code>, 表示将模型输出的第0类别检测框中心不变，宽度扩张1.1倍，高度扩张2.0</li>
-<li><b>None</b>, 不指定，将默认使用 <code>creat_model</code> 指定的 <code>layout_unclip_ratio</code> 参数，如果 <code>creat_model</code> 也没有指定，则默认使用PaddleX官方模型配置</li>
+<li><b>float</b>，如 1.1</li>
+<li><b>list</b>，如 [1.2,&nbsp;1.5]</li>
+<li><b>dict</b>，如 <code>{0: (1.1, 2.0)}</code></li>
+<li><b>None</b></li>
 </ul>
 </td>
+<td><b>None<sup>①</sup></b></td>
+</tr>
 <tr>
 <td><code>layout_merge_bboxes_mode</code></td>
-<td>模型输出的检测框的合并处理模式；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td>检测框合并处理模式</td>
 <td><code>string/dict/None</code></td>
 <td>
 <ul>
-<li><b>large</b>, 设置为large时，表示在模型输出的检测框中，对于互相重叠包含的检测框，只保留外部最大的框，删除重叠的内部框。</li>
-<li><b>small</b>, 设置为small，表示在模型输出的检测框中，对于互相重叠包含的检测框，只保留内部被包含的小框，删除重叠的外部框。</li>
-<li><b>union</b>, 不进行框的过滤处理，内外框都保留</li>
-<li><b>dict</b>, 字典的key为<b>int</b>类型，代表<code>cls_id</code>, value为<b>str</b>类型, 如<code>{0: "large", 2: "small"}</code>, 表示对第0类别检测框使用large模式，对第2类别检测框使用small模式</li>
-<li><b>None</b>, 不指定，将默认使用 <code>creat_model</code> 指定的 <code>layout_merge_bboxes_mode</code> 参数，如果 <code>creat_model</code> 也没有指定，则默认使用PaddleX官方模型配置</li>
+<li><b>large</b>：保留外部大框</li>
+<li><b>small</b>：保留内部小框</li>
+<li><b>union</b>：保留全部</li>
+<li><b>dict</b>，如 <code>{0:"large", 2:"small"}</code></li>
+<li><b>None</b></li>
 </ul>
 </td>
-<td>无</td>
+<td><b>None<sup>①</sup></b></td>
 </tr>
-</tr></tr></table>
+</table>
+
+<p><sup>①</sup> 当调用 <code>predict()</code> 时该参数为 <code>None</code> 时，将继承模型实例化 (<code>__init__</code>) 时对应参数的值；若实例化时也未显式指定，则使用框架默认：<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<code>threshold=0.5</code>，<code>layout_nms=False</code>，<code>layout_unclip_ratio=1.0</code>，<code>layout_merge_bboxes_mode="union"</code>。</p>
+
 
 * 对预测结果进行处理，每个样本的预测结果均为对应的Result对象，且支持打印、保存为图片、保存为`json`文件的操作:
 

--- a/docs/version3.x/module_usage/seal_text_detection.en.md
+++ b/docs/version3.x/module_usage/seal_text_detection.en.md
@@ -149,7 +149,7 @@ The explanations of related methods and parameters are as follows:
 <td>Name of the model</td>
 <td><code>str</code></td>
 <td>All model names supported by PaddleX for seal text detection</td>
-<td>None</td>
+<td><code>"PP-OCRv4_mobile_seal_det"</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
@@ -162,8 +162,8 @@ The explanations of related methods and parameters are as follows:
 <td><code>device</code></td>
 <td>The device used for model inference</td>
 <td><code>str</code></td>
-<td>It supports specifying specific GPU card numbers, such as "gpu:0", other hardware card numbers, such as "npu:0", or CPU, such as "cpu".</td>
-<td><code>gpu:0</code></td>
+<td>Supports GPU (e.g., "gpu:0"), NPU (e.g., "npu:0"), or CPU ("cpu")</td>
+<td><code>"cpu"</code></td>
 </tr>
 <tr>
 <td><code>limit_side_len</code></td>
@@ -171,9 +171,10 @@ The explanations of related methods and parameters are as follows:
 <td><code>int/None</code></td>
 <td>
 <ul>
-<li><b>int</b>: Any integer greater than 0
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
+<li><b>int</b>: Any integer greater than 0</li>
+<li><b>None</b>: Default is 736</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
@@ -182,83 +183,110 @@ The explanations of related methods and parameters are as follows:
 <td><code>str/None</code></td>
 <td>
 <ul>
-<li><b>str</b>: Supports min and max. min ensures the shortest side of the image is not less than det_limit_side_len, max ensures the longest side is not greater than limit_side_len
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
-
+<li><b>str</b>: "min" or "max"</li>
+<li><b>None</b>: Default is "min"</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>thresh</code></td>
-<td>In the output probability map, pixels with scores greater than this threshold will be considered as text pixels</td>
+<td>Threshold for classifying a pixel as text</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.2</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>box_thresh</code></td>
-<td>If the average score of all pixels within a detection result box is greater than this threshold, the result will be considered as a text region</td>
+<td>Threshold for considering a region as a text box</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
-<td>None</td>
-</tr>
-<tr>
-<td><code>max_candidates</code></td>
-<td>Maximum number of text boxes to output</td>
-<td><code>int/None</code></td>
-<td>
-<ul>
-<li><b>int</b>: Any integer greater than 0
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.6</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>unclip_ratio</code></td>
-<td>Expansion ratio for the Vatti clipping algorithm, used to expand the text region</td>
+<td>Expansion coefficient for Vatti clipping</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the default value from the official PaddleX model configuration will be used</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.5</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>use_dilation</code></td>
-<td>Whether to dilate the segmentation result</td>
-<td><code>bool/None</code></td>
-<td>True/False/None</td>
+<td><code>input_shape</code></td>
+<td>Input shape of the model as (C, H, W)</td>
+<td><code>tuple</code> / <code>None</code></td>
+<td>e.g., <code>(3, 960, 960)</code>, or None to use model default</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
-<td>Whether to enable the high-performance inference plugin</td>
+<td><code>enable_hpi</code></td>
+<td>Enable high-performance inference plugin (HPI)</td>
 <td><code>bool</code></td>
-<td>None</td>
+<td>True / False</td>
 <td><code>False</code></td>
 </tr>
 <tr>
 <td><code>hpi_config</code></td>
 <td>High-performance inference configuration</td>
-<td><code>dict</code> | <code>None</code></td>
+<td><code>dict</code> / <code>None</code></td>
 <td>None</td>
 <td><code>None</code></td>
 </tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>Enable TensorRT acceleration</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>False</td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>Precision type for TensorRT</td>
+<td><code>str</code></td>
+<td>"fp32", "fp16", or "int8"</td>
+<td>"fp32"</td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>Minimum subgraph size for TensorRT</td>
+<td><code>int</code></td>
+<td>Any integer greater than 0</td>
+<td>30</td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>Enable oneDNN (MKL-DNN) acceleration (CPU only)</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>True</td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>Number of CPU threads</td>
+<td><code>int</code></td>
+<td>Any integer greater than 0</td>
+<td>10</td>
+</tr>
 </table>
+
 
 * The `model_name` must be specified. After specifying `model_name`, the built-in model parameters of PaddleX will be used by default. On this basis, if `model_dir` is specified, the user-defined model will be used.
 
 * The `predict()` method of the seal text detection model is called for inference prediction. The parameters of the `predict()` method include `input`, `batch_size`, `limit_side_len`, `limit_type`, `thresh`, `box_thresh`, `max_candidates`, `unclip_ratio`, and `use_dilation`. The specific descriptions are as follows:
-
 <table>
 <thead>
 <tr>
@@ -270,36 +298,36 @@ The explanations of related methods and parameters are as follows:
 </tr>
 </thead>
 <tr>
-<td><code>input</code></td>
-<td>Data to be predicted, supporting multiple input types</td>
-<td><code>Python Var</code>/<code>str</code>/<code>dict</code>/<code>list</code></td>
-<td>
-<ul>
-<li><b>Python Variable</b>, such as image data represented by <code>numpy.ndarray</code></li>
-<li><b>File Path</b>, such as the local path of an image file: <code>/root/data/img.jpg</code></li>
-<li><b>URL Link</b>, such as the web URL of an image file: <a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/general_ocr_rec_001.png">Example</a></li>
-<li><b>Local Directory</b>, the directory should contain the data files to be predicted, such as the local path: <code>/root/data/</code></li>
-<li><b>List</b>, the elements of the list should be of the above-mentioned data types, such as <code>[numpy.ndarray, numpy.ndarray]</code>, <code>[\"/root/data/img1.jpg\", \"/root/data/img2.jpg\"]</code>, <code>[\"/root/data1\", \"/root/data2\"]</code></li>
-</ul>
-</td>
+<td><code>model_name</code></td>
+<td>Name of the model</td>
+<td><code>str</code></td>
+<td>All model names supported by PaddleX for seal text detection</td>
+<td><code>"PP-OCRv4_mobile_seal_det"</code></td>
+</tr>
+<tr>
+<td><code>model_dir</code></td>
+<td>Path to store the model</td>
+<td><code>str</code></td>
+<td>None</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>batch_size</code></td>
-<td>Batch size</td>
-<td><code>int</code></td>
-<td>Any integer greater than 0</td>
-<td>1</td>
+<td><code>device</code></td>
+<td>The device used for model inference</td>
+<td><code>str</code></td>
+<td>Supports GPU (e.g., "gpu:0"), NPU (e.g., "npu:0"), or CPU ("cpu")</td>
+<td><code>"cpu"</code></td>
 </tr>
 <tr>
 <td><code>limit_side_len</code></td>
-<td>Side length limit for detection</td>
+<td>Limit on the side length of the image for detection</td>
 <td><code>int/None</code></td>
 <td>
 <ul>
-<li><b>int</b>: Any integer greater than 0
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
+<li><b>int</b>: Any integer greater than 0</li>
+<li><b>None</b>: Default is 736</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
@@ -308,64 +336,106 @@ The explanations of related methods and parameters are as follows:
 <td><code>str/None</code></td>
 <td>
 <ul>
-<li><b>str</b>: Supports min and max. min indicates that the shortest side of the image is not less than det_limit_side_len, max indicates that the longest side of the image is not greater than limit_side_len
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
-
+<li><b>str</b>: "min" or "max"</li>
+<li><b>None</b>: Default is "min"</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>thresh</code></td>
-<td>In the output probability map, pixels with scores greater than this threshold will be considered as text pixels</td>
+<td>Threshold for classifying a pixel as text</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.2</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>box_thresh</code></td>
-<td>If the average score of all pixels within the detection result box is greater than this threshold, the result will be considered as a text area</td>
+<td>Threshold for considering a region as a text box</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
-<td>None</td>
-</tr>
-<tr>
-<td><code>max_candidates</code></td>
-<td>Maximum number of text boxes to be output</td>
-<td><code>int/None</code></td>
-<td>
-<ul>
-<li><b>int</b>: Any integer greater than 0
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.6</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>unclip_ratio</code></td>
-<td>Expansion coefficient of the Vatti clipping algorithm, used to expand the text area</td>
+<td>Expansion coefficient for Vatti clipping</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: Any float greater than 0
-<li><b>None</b>: If set to None, the parameter value initialized by the model will be used by default</li></li></ul></td>
-
+<li><b>float</b>: Any float greater than 0</li>
+<li><b>None</b>: Default is 0.5</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>use_dilation</code></td>
-<td>Whether to dilate the segmentation result</td>
-<td><code>bool/None</code></td>
-<td>True/False/None</td>
+<td><code>input_shape</code></td>
+<td>Input shape of the model as (C, H, W)</td>
+<td><code>tuple</code> / <code>None</code></td>
+<td>e.g., <code>(3, 960, 960)</code>, or None to use model default</td>
 <td>None</td>
 </tr>
+<tr>
+<td><code>enable_hpi</code></td>
+<td>Enable high-performance inference plugin (HPI)</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>hpi_config</code></td>
+<td>High-performance inference configuration</td>
+<td><code>dict</code> / <code>None</code></td>
+<td>None</td>
+<td><code>None</code></td>
+</tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>Enable TensorRT acceleration</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>False</td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>Precision type for TensorRT</td>
+<td><code>str</code></td>
+<td>"fp32", "fp16", or "int8"</td>
+<td>"fp32"</td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>Minimum subgraph size for TensorRT</td>
+<td><code>int</code></td>
+<td>Any integer greater than 0</td>
+<td>30</td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>Enable oneDNN (MKL-DNN) acceleration (CPU only)</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>True</td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>Number of CPU threads</td>
+<td><code>int</code></td>
+<td>Any integer greater than 0</td>
+<td>10</td>
+</tr>
 </table>
+
 
 * Process the prediction results. Each sample's prediction result is a corresponding Result object, and it supports operations such as printing, saving as an image, and saving as a `json` file:
 

--- a/docs/version3.x/module_usage/seal_text_detection.md
+++ b/docs/version3.x/module_usage/seal_text_detection.md
@@ -146,111 +146,140 @@ for res in output:
 <td>模型名称</td>
 <td><code>str</code></td>
 <td>所有PaddleX支持的印章文本检测模型名称</td>
-<td>无</td>
+<td><code>"PP-OCRv4_mobile_seal_det"</code></td>
 </tr>
 <tr>
 <td><code>model_dir</code></td>
 <td>模型存储路径</td>
 <td><code>str</code></td>
 <td>无</td>
-<td>无</td>
+<td>None</td>
 </tr>
 <tr>
 <td><code>device</code></td>
 <td>模型推理设备</td>
 <td><code>str</code></td>
 <td>支持指定GPU具体卡号，如“gpu:0”，其他硬件具体卡号，如“npu:0”，CPU如“cpu”。</td>
-<td><code>gpu:0</code></td>
+<td><code>"cpu"</code></td>
 </tr>
 <tr>
 <td><code>limit_side_len</code></td>
 <td>检测的图像边长限制</td>
-<td><code>int/None</code></td>
+<td><code>int</code> / <code>None</code></td>
 <td>
 <ul>
-<li><b>int</b>: 大于0的任意整数
-<li><b>None</b>: 如果设置为None, 将使用默认值：736</li></li></ul></td>
-
+<li><b>int</b>: 大于0的任意整数</li>
+<li><b>None</b>: 使用默认值736</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>limit_type</code></td>
-<td>检测的图像边长限制,检测的边长限制类型 </td>
-<td><code>str/None</code></td>
+<td>检测的图像边长限制,检测的边长限制类型	</td>
+<td><code>str</code> / <code>None</code></td>
 <td>
 <ul>
-<li><b>str</b>: 支持min和max. min表示保证图像最短边不小于det_limit_side_len, max: 表示保证图像最长边不大于limit_side_len
-<li><b>None</b>: 如果设置为None, 将使用默认值：“min”</li></li></ul></td>
-
-
+<li><b>str</b>: "min" / "max"</li>
+<li><b>None</b>: 使用默认值 "min"</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>thresh</code></td>
-<td>输出的概率图中，得分大于该阈值的像素点才会被认为是文字像素点 </td>
-<td><code>float/None</code></td>
+<td>输出的概率图中，得分大于该阈值的像素点才会被认为是文字像素点	</td>
+<td><code>float</code> / <code>None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将使用默认值：0.2</li></li></ul></td>
-
+<li><b>float</b>: > 0 的任意浮点数</li>
+<li><b>None</b>: 默认值 0.2</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>box_thresh</code></td>
-<td>检测结果边框内，所有像素点的平均得分大于该阈值时，该结果会被认为是文字区域 </td>
-<td><code>float/None</code></td>
+<td>检测结果边框内，所有像素点的平均得分大于该阈值时，该结果会被认为是文字区域	</td>
+<td><code>float</code> / <code>None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将使用默认值：0.6</li></li></ul></td>
-
-<td>None</td>
-</tr>
-<tr>
-<td><code>max_candidates</code></td>
-<td>输出的最大文本框数量 </td>
-<td><code>int/None</code></td>
-<td>
-<ul>
-<li><b>int</b>: 大于0的任意整数
-<li><b>None</b>: 如果设置为None, 将默认使用PaddleX官方模型配置中的该参数值</li></li></ul></td>
-
+<li><b>float</b>: > 0 的任意浮点数</li>
+<li><b>None</b>: 默认值 0.6</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>unclip_ratio</code></td>
-<td>Vatti clipping算法的扩张系数，使用该方法对文字区域进行扩张 </td>
-<td><code>float/None</code></td>
+<td>Vatti clipping算法的扩张系数，使用该方法对文字区域进行扩张	</td>
+<td><code>float</code> / <code>None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将使用默认值：0.5</li></li></ul></td>
-
+<li><b>float</b>: > 0 的任意浮点数</li>
+<li><b>None</b>: 默认值 0.5</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>use_dilation</code></td>
-<td>是否对分割结果进行膨胀 </td>
-<td><code>bool/None</code></td>
-<td>True/False/None</td>
+<td><code>input_shape</code></td>
+<td>模型输入尺寸 (C, H, W)</td>
+<td><code>tuple</code> / <code>None</code></td>
+<td>如 <code>(3, 960, 960)</code>，或None使用模型默认</td>
 <td>None</td>
 </tr>
 <tr>
-<td><code>use_hpip</code></td>
-<td>是否启用高性能推理插件</td>
+<td><code>enable_hpi</code></td>
+<td>是否启用高性能推理插件（HPI）</td>
 <td><code>bool</code></td>
-<td>无</td>
+<td>True / False</td>
 <td><code>False</code></td>
 </tr>
 <tr>
 <td><code>hpi_config</code></td>
-<td>高性能推理配置</td>
-<td><code>dict</code> | <code>None</code></td>
+<td>高性能推理插件配置</td>
+<td><code>dict</code> / <code>None</code></td>
 <td>无</td>
-<td><code>None</code></td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>use_tensorrt</code></td>
+<td>是否启用 TensorRT 加速</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>False</td>
+</tr>
+<tr>
+<td><code>precision</code></td>
+<td>TensorRT 精度类型</td>
+<td><code>str</code></td>
+<td>"fp32" / "fp16" / "int8"</td>
+<td>"fp32"</td>
+</tr>
+<tr>
+<td><code>min_subgraph_size</code></td>
+<td>TensorRT 最小子图节点数</td>
+<td><code>int</code></td>
+<td>大于0的整数</td>
+<td>30</td>
+</tr>
+<tr>
+<td><code>enable_mkldnn</code></td>
+<td>是否启用 oneDNN (MKL-DNN)</td>
+<td><code>bool</code></td>
+<td>True / False</td>
+<td>True</td>
+</tr>
+<tr>
+<td><code>cpu_threads</code></td>
+<td>CPU 线程数</td>
+<td><code>int</code></td>
+<td>大于0的整数</td>
+<td>10</td>
 </tr>
 </table>
+
 
 * 其中，`model_name` 必须指定，指定 `model_name` 后，默认使用 PaddleX 内置的模型参数，在此基础上，指定 `model_dir` 时，使用用户自定义的模型。
 
@@ -283,7 +312,7 @@ for res in output:
 </tr>
 <tr>
 <td><code>batch_size</code></td>
-<td>批大小</td>
+<td>批处理大小</td>
 <td><code>int</code></td>
 <td>大于0的任意整数</td>
 <td>1</td>
@@ -294,75 +323,81 @@ for res in output:
 <td><code>int/None</code></td>
 <td>
 <ul>
-<li><b>int</b>: 大于0的任意整数
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
+<li><b>int</b>: 大于0的任意整数</li>
+<li><b>None</b>: 若为None，则使用模型初始化参数</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>limit_type</code></td>
-<td>检测的图像边长限制,检测的边长限制类型 </td>
+<td>图像边长限制类型</td>
 <td><code>str/None</code></td>
 <td>
 <ul>
-<li><b>str</b>: 支持min和max. min表示保证图像最短边不小于det_limit_side_len, max: 表示保证图像最长边不大于limit_side_len
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
-
+<li><b>str</b>: "min" / "max"</li>
+<li><b>None</b>: 若为None，则使用模型初始化参数</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>thresh</code></td>
-<td>输出的概率图中，得分大于该阈值的像素点才会被认为是文字像素点 </td>
+<td>输出的概率图中，得分大于该阈值的像素点才会被认为是文字像素点	</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
+<li><b>float</b>: >0 的任意浮点数</li>
+<li><b>None</b>: 若为None，则使用模型初始化参数</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>box_thresh</code></td>
-<td>检测结果边框内，所有像素点的平均得分大于该阈值时，该结果会被认为是文字区域 </td>
+<td>检测结果边框内，所有像素点的平均得分大于该阈值时，该结果会被认为是文字区域	</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
+<li><b>float</b>: >0 的任意浮点数</li>
+<li><b>None</b>: 若为None，则使用模型初始化参数</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>max_candidates</code></td>
-<td>输出的最大文本框数量 </td>
+<td>输出的最大文本框数量</td>
 <td><code>int/None</code></td>
 <td>
 <ul>
-<li><b>int</b>: 大于0的任意整数
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
+<li><b>int</b>: >0 的任意整数</li>
+<li><b>None</b>: 使用模型默认</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>unclip_ratio</code></td>
-<td>Vatti clipping算法的扩张系数，使用该方法对文字区域进行扩张 </td>
+<td>Vatti clipping算法的扩张系数，使用该方法对文字区域进行扩张	</td>
 <td><code>float/None</code></td>
 <td>
 <ul>
-<li><b>float</b>: 大于0的任意浮点数
-<li><b>None</b>: 如果设置为None, 将默认使用模型初始化的该参数值</li></li></ul></td>
-
+<li><b>float</b>: >0 的任意浮点数</li>
+<li><b>None</b>: 使用模型初始化参数</li>
+</ul>
+</td>
 <td>None</td>
 </tr>
 <tr>
 <td><code>use_dilation</code></td>
-<td>是否对分割结果进行膨胀 </td>
+<td>是否对分割结果进行膨胀</td>
 <td><code>bool/None</code></td>
-<td>True/False/None</td>
+<td>True / False / None</td>
 <td>None</td>
 </tr>
 </table>
+
 
 * 对预测结果进行处理，每个样本的预测结果均为对应的Result对象，且支持打印、保存为图片、保存为`json`文件的操作:
 


### PR DESCRIPTION
module_usage 下[文档图像方向分类模块]
[文档类视觉语言模型模块]
[公式识别模块]
[版面区域检测模块]
[印章文本检测模块]
五个模块的api对应问题