### PR TITLE
fix: release memory after predict / (restored from v2.7 commit 15963b…

### DIFF
--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -321,7 +321,7 @@ class TextRecognizer(object):
             resize_w = min(imgW_max, resize_w)
         resized_image = cv2.resize(img, (resize_w, imgH))
         resized_image = resized_image.astype('float32')
-        # norm 
+        # norm
         if image_shape[0] == 1:
             resized_image = resized_image / 255
             resized_image = resized_image[np.newaxis, :]
@@ -672,6 +672,7 @@ class TextRecognizer(object):
                     for output_tensor in self.output_tensors:
                         output = output_tensor.copy_to_cpu()
                         outputs.append(output)
+                    self.predictor.try_shrink_memory()
                     if self.benchmark:
                         self.autolog.times.stamp()
                     if len(outputs) != 1:


### PR DESCRIPTION
fix: release memory after predict / (restored from v2.7 commit 15963b0d242867a4cc4d76445626dc8965509b2f

Not sure why, but the fix was not carried to the newer versions after 2.7. Faces OOM on v2.8.1. Added the suggested fix, the problem was solved.