### PR TITLE
fix: release memory after predict for 2.9 / (restored from v2.7 commit 15963b0d242867a4cc4d76445626dc8965509b2f

### DIFF
--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -795,6 +795,7 @@ class TextRecognizer(object):
                     for output_tensor in self.output_tensors:
                         output = output_tensor.copy_to_cpu()
                         outputs.append(output)
+                    self.predictor.try_shrink_memory()
                     if self.benchmark:
                         self.autolog.times.stamp()
                     if len(outputs) != 1:


### PR DESCRIPTION
#15344 - V2.8