### PR TITLE
Add language support check for PP-OCRv5 model in PaddleOCR

### DIFF
--- a/paddleocr/_pipelines/ocr.py
+++ b/paddleocr/_pipelines/ocr.py
@@ -284,7 +284,11 @@ class PaddleOCR(PaddleXPipelineWrapper):
             ppocr_version = "PP-OCRv5"
 
         if ppocr_version == "PP-OCRv5":
-            return "PP-OCRv5_mobile_det", "PP-OCRv5_mobile_rec"
+            V5_SUPPORTED_LANGS = {"ch", "chinese_cht", "en", "japan"}
+            if lang in V5_SUPPORTED_LANGS:
+                return "PP-OCRv5_mobile_det", "PP-OCRv5_mobile_rec"
+            else:
+                return None, None
         elif ppocr_version == "PP-OCRv4":
             if lang == "ch":
                 return "PP-OCRv4_mobile_det", "PP-OCRv4_mobile_rec"


### PR DESCRIPTION
Introduce a check for language support in the PP-OCRv5 model
context: https://github.com/PaddlePaddle/PaddleOCR/issues/15373

The language check for v5 is based on the readme documentation that says "🌐 Single-model support for five text types - eamlessly process Simplified Chinese, Traditional Chinese, Simplified Chinese Pinyin, English and Japanse within a single model."