### PR TITLE
Replace border padding color from black to gray for improved OCR accuracy

### DIFF
--- a/deploy/cpp_infer/src/preprocess_op.cpp
+++ b/deploy/cpp_infer/src/preprocess_op.cpp
@@ -114,7 +114,7 @@ void CrnnResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img, float wh_ratio,
              cv::INTER_LINEAR);
   cv::copyMakeBorder(resize_img, resize_img, 0, 0, 0,
                      int(imgW - resize_img.cols), cv::BORDER_CONSTANT,
-                     {0, 0, 0});
+                     {128, 128, 128});
 }
 
 void ClsResizeImg::Run(const cv::Mat &img, cv::Mat &resize_img,


### PR DESCRIPTION
Problem: Black padding ({0,0,0}) creates high-contrast artificial edges around resized images. These edges may interfere with text feature extraction, especially for edge-based models or images with dark backgrounds.

Solution: Using neutral gray padding ({128,128,128}) reduces abrupt pixel value transitions. This aligns better with normalized input distributions (common in CNNs) and minimizes artifacts that degrade recognition accuracy.

Impact: Gray padding improves model robustness by simulating more natural background conditions, leading to higher accuracy on real-world images.