### PR TITLE
Fix memory leak when mkldnn is enabled

### DIFF
--- a/paddleocr/_common_args.py
+++ b/paddleocr/_common_args.py
@@ -79,6 +79,8 @@ def prepare_common_init_args(model_name, common_args):
         enable_mkldnn = common_args["enable_mkldnn"]
         if enable_mkldnn:
             pp_option.run_mode = "mkldnn"
+            # cache 10 different shapes for mkldnn to avoid memory leak
+            pp_option.mkldnn_cache_capacity = 10
         else:
             pp_option.run_mode = "paddle"
     pp_option.cpu_threads = common_args["cpu_threads"]


### PR DESCRIPTION
This PR sets a reasonable cache capacity when enabling mkldnn. Previously the cache capacity was set to unlimited, resulting in memory leaks. The chosen cache limit "10" is the same value that was previously used in PaddleOCR 2.10:

https://github.com/PaddlePaddle/PaddleOCR/blob/75526f0a5052a7ea90c012560aadc68f67024157/tools/infer/utility.py#L334-L335

Depends on: https://github.com/PaddlePaddle/PaddleX/pull/4148

Fixes #15631