### PR TITLE
docs: correct gpu_mem parameter description

### DIFF
--- a/deploy/cpp_infer/src/args.cpp
+++ b/deploy/cpp_infer/src/args.cpp
@@ -18,7 +18,7 @@
 DEFINE_bool(use_gpu, false, "Inferring with GPU or CPU.");
 DEFINE_bool(use_tensorrt, false, "Whether use tensorrt.");
 DEFINE_int32(gpu_id, 0, "Device id of GPU to execute.");
-DEFINE_int32(gpu_mem, 4000, "GPU id when inferring with GPU.");
+DEFINE_int32(gpu_mem, 4000, "GPU memory size (MB) to use.");
 DEFINE_int32(cpu_threads, 10, "Num of threads with CPU.");
 DEFINE_bool(enable_mkldnn, false, "Whether use mkldnn with CPU.");
 DEFINE_string(precision, "fp32", "Precision be one of fp32/fp16/int8");


### PR DESCRIPTION
## 📖 Documentation Fix
### Issue Description
The parameter `gpu_mem` was incorrectly described as "GPU id" while it actually specifies GPU memory allocation.

### Changes Made
- Updated description to accurately reflect parameter usage
- Old: "GPU id when inferring with GPU"
- New: "GPU memory size (MB) to use"

### Testing Verification
- [x] No functionality affected (documentation-only change)
- [x] Verified parameter usage in related GPU memory management code

### Additional Context
This correction matches the actual memory allocation behavior in the inference pipeline.