### PR TITLE
Add multilingual PP-OCRv5 model support in text recognition inference

### DIFF
--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -44,6 +44,9 @@ class TextRecognizer(object):
             if model_name and model_name not in [
                 "PP-OCRv5_mobile_rec",
                 "PP-OCRv5_server_rec",
+                "korean_PP-OCRv5_mobile_rec",
+                "eslav_PP-OCRv5_mobile_rec",
+                "latin_PP-OCRv5_mobile_rec",
             ]:
                 raise ValueError(
                     f"{model_name} is not supported. Please check if the model is supported by the PaddleOCR wheel."


### PR DESCRIPTION
After the 3.1.0 version release, the inference recognition files don't work with multilingual models. I've added support for them.

After Added multilingual PP-OCRv5 model's names, Now It works!

## Error

```python
Traceback (most recent call last):
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 896, in <module>
    main(utility.parse_args())
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 858, in main
    text_recognizer = TextRecognizer(args)
                      ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 48, in __init__
    raise ValueError(
ValueError: korean_PP-OCRv5_mobile_rec is not supported. Please check if the model is supported by the PaddleOCR wheel.
```

```python
Traceback (most recent call last):
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 899, in <module>
    main(utility.parse_args())
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 861, in main
    text_recognizer = TextRecognizer(args)
                      ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 51, in __init__
    raise ValueError(
ValueError: latin_PP-OCRv5_mobile_rec is not supported. Please check if the model is supported by the PaddleOCR wheel.
```

```python
Traceback (most recent call last):
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 899, in <module>
    main(utility.parse_args())
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 861, in main
    text_recognizer = TextRecognizer(args)
                      ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\khmoon\assign\base\PaddleOCR\tools\infer\predict_rec.py", line 51, in __init__
    raise ValueError(
ValueError: eslav_PP-OCRv5_mobile_rec is not supported. Please check if the model is supported by the PaddleOCR wheel.
```

## After Added

```python
[2025/07/13 00:40:34] ppocr INFO: Predicts of ./ko_pp/00010.png:('여기인가', 0.9998766183853149)
```

```python
[2025/07/13 01:19:47] ppocr INFO: Predicts of ./ko_pp/latin.png:("l'épaule", 0.9976184368133545)
```

```python
[2025/07/13 01:21:39] ppocr INFO: Predicts of ./ko_pp/eslav.png:('АБВГ', 0.910905122756958)
```