### PR TITLE
fix: Correctly handle 'GRAY' mode in DecodeImage operator

### DIFF
--- a/ppocr/data/imaug/operators.py
+++ b/ppocr/data/imaug/operators.py
@@ -40,10 +40,18 @@ class DecodeImage(object):
         img = data["image"]
         assert type(img) is bytes and len(img) > 0, "invalid input 'img' in DecodeImage"
         img = np.frombuffer(img, dtype="uint8")
-        if self.ignore_orientation:
-            img = cv2.imdecode(img, cv2.IMREAD_IGNORE_ORIENTATION | cv2.IMREAD_COLOR)
+        if self.img_mode == 'GRAY':
+            # For GRAY mode, decode directly to a single-channel grayscale image.
+            decode_flag = cv2.IMREAD_GRAYSCALE
         else:
-            img = cv2.imdecode(img, 1)
+            # For RGB mode, decode to a 3-channel color image.
+            decode_flag = cv2.IMREAD_COLOR
+
+        if self.ignore_orientation:
+            decode_flag |= cv2.IMREAD_IGNORE_ORIENTATION
+        
+        img = cv2.imdecode(img, decode_flag)
+        
         if img is None:
             return None
         if self.img_mode == "GRAY":


### PR DESCRIPTION
🐛 Problem
The previous implementation of the DecodeImage operator would crash with a cv2.error when initialized with img_mode="GRAY".

The root cause was that the image was always decoded into a 3-channel color format using cv2.imdecode(..., cv2.IMREAD_COLOR). This 3-channel output was then passed to cv2.cvtColor(..., cv2.COLOR_GRAY2BGR), which strictly requires a single-channel input, causing the error.

💡 Solution
This PR fixes the issue by making the decoding logic dependent on the img_mode.

The operator now checks img_mode before decoding.

If img_mode is "GRAY", it uses the cv2.IMREAD_GRAYSCALE flag to ensure the image is decoded into a single channel.

If img_mode is "RGB", it continues to use cv2.IMREAD_COLOR as before.

This change ensures that all subsequent processing steps receive an image with the correct number of channels, making the operator robust for both color and grayscale modes.