### PR TITLE
fix train.log output (#14846)

### DIFF
--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -32,7 +32,7 @@ try:
 
     encrypted = encryption.is_encryption_needed()
 except ImportError:
-    get_logger().warning("Skipping import of the encryption module.")
+    print("Skipping import of the encryption module.")
     encrypted = False  # Encryption is not needed if the module cannot be imported
 
 __all__ = ["load_model"]


### PR DESCRIPTION
The bug was introduced in commit e3145103 ("import encryption for aistudio & fix sync bn"), where the following snippet:
```
try:
    import encryption  # Attempt to import the encryption module for AIStudio's encryption model

    encrypted = encryption.is_encryption_needed()
except ImportError:
    get_logger().warning("Skipping import of the encryption module.")
    encrypted = False  # Encryption is not needed if the module cannot be imported
```
caused `get_logger()` to be called too early, initializing the logger before the training arguments were passed. As a result, the training process skipped proper log redirection, and `train.log` was not created.

This patch replaces the warning with a simple `print()` statement, ensuring the logger is only initialized after training args are passed.

Fixes #14846