### PR TITLE
fix: Prevent SIGBUS on large images by applying safe default resize in OCR pipeline on macOS

### DIFF
--- a/paddleocr/_pipelines/ocr.py
+++ b/paddleocr/_pipelines/ocr.py
@@ -17,6 +17,7 @@
 # maintainability?
 
 import sys
+import platform
 import warnings
 
 from .._utils.cli import (
@@ -181,6 +182,17 @@ class PaddleOCR(PaddleXPipelineWrapper):
         text_rec_score_thresh=None,
         return_word_box=None,
     ):
+        # On macOS, very large images can trigger a low-level bus error in
+        # underlying inference libs. Apply a safe default downscale to keep
+        # # the long edge within 1280 unless the user explicitly overrides.
+        if (
+            platform.system() == "Darwin"
+            and text_det_limit_side_len is None
+            and text_det_limit_type is None
+        ):
+            text_det_limit_side_len = 1280
+            text_det_limit_type = "max"
+
         return self.paddlex_pipeline.predict(
             input,
             use_doc_orientation_classify=use_doc_orientation_classify,


### PR DESCRIPTION
### Summary

* Fixes a **macOS-only crash** (#16457 ) during OCR when processing large images (> 1296×1296).
* Introduces a **platform-guarded default** that caps the long edge at 1280 pixels using a `max` constraint, but only when users have not set their own detection size limits.

---

### Root Cause

* On macOS, forwarding large images directly to the detector causes a **low-level crash in the underlying C/C++ inference stack** during detection preprocessing/inference.
* The Python API passed full-resolution images by default when `text_det_limit_side_len` and `text_det_limit_type` were unset.
* This failure occurs outside Python’s exception handling and results in a hard crash.

---

### Fix

* Add a Darwin-specific safety fallback inside `PaddleOCR.predict_iter`:

  * If both `text_det_limit_side_len` and `text_det_limit_type` are `None`, set:

    * `text_det_limit_side_len = 1280`
    * `text_det_limit_type = "max"`
* File modified:

  * `paddleocr/_pipelines/ocr.py:185`

---

### Impact

* **User experience**: Prevents sudden process termination on macOS when handling large input images.
* **Behavioral change**:

  * Linux/Windows remain unaffected.
  * macOS applies safe defaults **only when user has not provided explicit values**.
* **Backwards compatibility**: Fully preserved — explicit user configs override defaults.

---
