### PR TITLE
​fix: prevent pipeline stop after first request by correcting lifespa…

### DIFF
--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paddleocr_mcp"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.5.0",


### PR DESCRIPTION
Fixes #16515

Problem: The server's _lifespan async context manager was incorrectly invoked on every client request, causing the pipeline_handler to be stopped after the first request.

Solution: 
• Removed the problematic _lifespan function
• Initialized pipeline_handler globally during server startup
• Made the pipeline instance persistent across all requests

Testing: 
• Verified multiple consecutive client requests now complete successfully
• No more "Pipeline handler has already been stopped" errors

Type of change: Bug fix (non-breaking change which fixes an issue)