### PR TITLE
feat: add lychee for checking broken url

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,35 @@
+name: Link Checker
+
+on:
+  repository_dispatch:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * 6"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+            args: --verbose --no-progress --max-redirects 8 './**/*.md'
+            format: markdown
+            fail: false
+            output: lychee/results.md
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/results.md
+          labels: report, automated issue

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+zhuanlan.zhihu.com/*
+https://demo.doctrp.top/
+http://127.0.0.1:8001/
+http://localhost:9003


### PR DESCRIPTION
添加自动检测项目下死链的CI

添加之后，会定期扫描仓库下所有url，给出哪些不可用来，便于针对性修复。类似：[link](https://github.com/RapidAI/RapidOCRDocs/issues/11)
