### PR TITLE
Parse all local OCR result batches instead of only the first

### DIFF
--- a/mcp_server/paddleocr_mcp/pipelines.py
+++ b/mcp_server/paddleocr_mcp/pipelines.py
@@ -561,24 +561,24 @@ class OCRHandler(SimpleInferencePipelineHandler):
         }
 
     async def _parse_local_result(self, local_result: Dict, ctx: Context) -> Dict:
-        result = local_result[0]
-        texts = result["rec_texts"]
-        scores = result["rec_scores"]
-        boxes = result["rec_boxes"]
-
         clean_texts, confidences, text_lines = [], [], []
 
-        for i, text in enumerate(texts):
-            if text and text.strip():
-                conf = scores[i] if i < len(scores) else 0
-                clean_texts.append(text.strip())
-                confidences.append(conf)
-                instance = {
-                    "text": text.strip(),
-                    "confidence": round(conf, 3),
-                    "bbox": boxes[i].tolist(),
-                }
-                text_lines.append(instance)
+        for result in local_result:
+            texts = result["rec_texts"]
+            scores = result["rec_scores"]
+            boxes = result["rec_boxes"]
+
+            for i, text in enumerate(texts):
+                if text and text.strip():
+                    conf = scores[i] if i < len(scores) else 0
+                    clean_texts.append(text.strip())
+                    confidences.append(conf)
+                    instance = {
+                        "text": text.strip(),
+                        "confidence": round(conf, 3),
+                        "bbox": boxes[i].tolist(),
+                    }
+                    text_lines.append(instance)
 
         return {
             "text": "\n".join(clean_texts),


### PR DESCRIPTION
Fix #16755

This change ensures that the local MCP server processes all pages of a multi-page PDF, matching the behavior of the standard server mode.

Previously, when using the MCP server in local (stdio) mode, only the first page of a PDF was processed and returned.
With this fix, all recognized pages are now aggregated into a single result, consistent with the paddleocr CLI and MCP server behavior.

Example output (from the PDF in issue #16755):

```
This is the first page
This is the second page
This is the third page
This is the fourth page

📊 Confidence: 95.3% | 4 text lines
```