### PR TITLE
Add multi-instance deployment and load balancing configuration

### DIFF
--- a/deploy/paddleocr_vl_docker/README.multi_instance.md
+++ b/deploy/paddleocr_vl_docker/README.multi_instance.md
@@ -1,0 +1,49 @@
+# 多实例部署与负载均衡示例
+
+本目录下提供了 `compose.multi_instance.yaml.example` 与 `nginx.multi_instance.conf`，用于演示如何在 **单个 vLLM 推理服务** 之上，通过多个 `paddlex --serve` API 实例来提升并发处理能力。请根据自身 GPU / 服务器资源调整配置。
+
+## 1. 准备工作
+
+1. **配置产线参数**
+   - 为每个 API 实例准备的产线配置中，将 `VLRecognition.genai_config.server_url` 指向同一个 vLLM 服务。
+   - 调整 `VLRecognition.genai_config.max_concurrency`，确保单个 vLLM 显存可以容纳该并发（通常 4~16 之间，视显存与 `max-num-seqs` 而定）。
+   - vLLM 端的 `backend_config`（如 `max-num-seqs`、`gpu-memory-utilization`）也需要同步修改，允许来自多个 API 的请求同时执行。
+
+2. **Nginx（可选）**
+   - `nginx.multi_instance.conf` 通过轮询方式将请求均衡到多个 API 实例。
+   - 该配置已增加超时时间与请求体大小限制，适合大 PDF / 图像推理场景，可根据实际情况继续调整。
+
+## 2. 启动示例
+
+1. 复制示例 compose 文件，并根据需求修改端口、设备 ID 等：
+
+   ```bash
+   cp deploy/paddleocr_vl_docker/compose.multi_instance.yaml.example compose.yaml
+   ```
+
+2. （可选）如需使用 Nginx 负载均衡，将配置复制到当前目录：
+
+   ```bash
+   cp deploy/paddleocr_vl_docker/nginx.multi_instance.conf nginx.conf
+   ```
+
+3. 启动服务：
+
+   ```bash
+   docker compose up -d
+   ```
+
+   - `paddleocr-vlm-server`：单个 vLLM 推理服务，供多个 API 共用。
+   - `paddleocr-vl-api-*`：多个 `paddlex --serve` 实例，分别暴露不同端口（示例中为 8081、8082 等）。
+   - `paddleocr-vl-nginx-lb`（可选）：监听 8080，将请求轮询到后台 API。
+
+4. 客户端调用
+   - 直接访问某个 API 端口（例如 `http://host:8081`），或通过 Nginx 暴露的统一入口（例如 `http://host:8080`）。
+
+## 3. 扩展建议
+
+- **增加 API 实例**：复制 `paddleocr-vl-api-*` 服务定义并修改端口即可。记得同步更新 Nginx upstream 列表。
+- **GPU 资源隔离**：若单卡无法满足多 API 并发，可按 GPU 拆分多个 vLLM 服务，每张卡构建一对 “API + VLM”，再使用上层负载均衡。
+- **监控与稳定性**：建议结合容器 healthcheck、Prometheus/Grafana 等监控方案，持续观察显存/延迟，必要时自动重启异常实例。
+
+按照上述步骤即可快速启动“多 API + 单 VLM”的并行推理集群，适用于批量 PDF/图片的高并发处理场景。根据生产环境需求，继续扩容或调整配置即可。

--- a/deploy/paddleocr_vl_docker/compose.multi.yaml
+++ b/deploy/paddleocr_vl_docker/compose.multi.yaml
@@ -1,0 +1,207 @@
+version: "3.9"
+
+x-api-base: &api-base
+  image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-vl:${API_IMAGE_TAG_SUFFIX:-latest}
+  restart: unless-stopped
+  user: root
+  environment:
+    - VLM_BACKEND=${VLM_BACKEND:-vllm}
+  command: /bin/bash -c "paddlex --serve --pipeline /home/paddleocr/pipeline_config_${VLM_BACKEND}.yaml"
+  healthcheck:
+    test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+
+x-vlm-base: &vlm-base
+  image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-genai-${VLM_BACKEND}-server:${VLM_IMAGE_TAG_SUFFIX:-latest}
+  restart: unless-stopped
+  user: root
+  healthcheck:
+    test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+
+services:
+  paddleocr-vl-api-gpu0:
+    <<: *api-base
+    container_name: paddleocr-vl-api-gpu0
+    depends_on:
+      paddleocr-vlm-server-gpu0:
+        condition: service_healthy
+    ports:
+      - "18080:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu0:
+        aliases:
+          - paddleocr-vl-api
+
+  paddleocr-vlm-server-gpu0:
+    <<: *vlm-base
+    container_name: paddleocr-vlm-server-gpu0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu0:
+        aliases:
+          - paddleocr-vlm-server
+
+  paddleocr-vl-api-gpu1:
+    <<: *api-base
+    container_name: paddleocr-vl-api-gpu1
+    depends_on:
+      paddleocr-vlm-server-gpu1:
+        condition: service_healthy
+    ports:
+      - "18081:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu1:
+        aliases:
+          - paddleocr-vl-api
+
+  paddleocr-vlm-server-gpu1:
+    <<: *vlm-base
+    container_name: paddleocr-vlm-server-gpu1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu1:
+        aliases:
+          - paddleocr-vlm-server
+
+  paddleocr-vl-api-gpu2:
+    <<: *api-base
+    container_name: paddleocr-vl-api-gpu2
+    depends_on:
+      paddleocr-vlm-server-gpu2:
+        condition: service_healthy
+    ports:
+      - "18082:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["2"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu2:
+        aliases:
+          - paddleocr-vl-api
+
+  paddleocr-vlm-server-gpu2:
+    <<: *vlm-base
+    container_name: paddleocr-vlm-server-gpu2
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["2"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu2:
+        aliases:
+          - paddleocr-vlm-server
+
+  paddleocr-vl-api-gpu3:
+    <<: *api-base
+    container_name: paddleocr-vl-api-gpu3
+    depends_on:
+      paddleocr-vlm-server-gpu3:
+        condition: service_healthy
+    ports:
+      - "18083:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["3"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu3:
+        aliases:
+          - paddleocr-vl-api
+
+  paddleocr-vlm-server-gpu3:
+    <<: *vlm-base
+    container_name: paddleocr-vlm-server-gpu3
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["3"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu3:
+        aliases:
+          - paddleocr-vlm-server
+
+  paddleocr-vl-api-gpu4:
+    <<: *api-base
+    container_name: paddleocr-vl-api-gpu4
+    depends_on:
+      paddleocr-vlm-server-gpu4:
+        condition: service_healthy
+    ports:
+      - "18084:8080"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["4"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu4:
+        aliases:
+          - paddleocr-vl-api
+
+  paddleocr-vlm-server-gpu4:
+    <<: *vlm-base
+    container_name: paddleocr-vlm-server-gpu4
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["4"]
+              capabilities: [gpu]
+    networks:
+      paddleocr-vl-gpu4:
+        aliases:
+          - paddleocr-vlm-server
+
+networks:
+  paddleocr-vl-gpu0:
+  paddleocr-vl-gpu1:
+  paddleocr-vl-gpu2:
+  paddleocr-vl-gpu3:
+  paddleocr-vl-gpu4:

--- a/deploy/paddleocr_vl_docker/compose.multi_instance.yaml.example
+++ b/deploy/paddleocr_vl_docker/compose.multi_instance.yaml.example
@@ -1,0 +1,82 @@
+# 多实例部署示例：多个 PaddleOCR API 共享单个 VLM 推理服务
+# 使用方式：
+#   1. 将本文件复制为 compose.yaml（或在 docker compose 命令中通过 -f 指定）。
+#   2. 启动服务：docker compose up -d
+#   3.（可选）结合 nginx.multi_instance.conf 通过 Nginx 对多个 API 实例做负载均衡。
+
+services:
+  paddleocr-vl-api-1:
+    image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-vl:${API_IMAGE_TAG_SUFFIX:-latest}
+    container_name: paddleocr-vl-api-1
+    ports:
+      - "8081:8080"
+    depends_on:
+      paddleocr-vlm-server:
+        condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    user: root
+    restart: unless-stopped
+    environment:
+      - VLM_BACKEND=${VLM_BACKEND:-vllm}
+    command: /bin/bash -c "paddlex --serve --pipeline /home/paddleocr/pipeline_config_${VLM_BACKEND}.yaml"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+
+  paddleocr-vl-api-2:
+    image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-vl:${API_IMAGE_TAG_SUFFIX:-latest}
+    container_name: paddleocr-vl-api-2
+    ports:
+      - "8082:8080"
+    depends_on:
+      paddleocr-vlm-server:
+        condition: service_healthy
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    user: root
+    restart: unless-stopped
+    environment:
+      - VLM_BACKEND=${VLM_BACKEND:-vllm}
+    command: /bin/bash -c "paddlex --serve --pipeline /home/paddleocr/pipeline_config_${VLM_BACKEND}.yaml"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+
+  # 如需更多实例，可参考上述配置增添 paddleocr-vl-api-3、-4 ...
+
+  nginx-lb:
+    image: nginx:alpine
+    container_name: paddleocr-vl-nginx-lb
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.multi_instance.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - paddleocr-vl-api-1
+      - paddleocr-vl-api-2
+    restart: unless-stopped
+
+  paddleocr-vlm-server:
+    image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-genai-${VLM_BACKEND:-vllm}-server:${VLM_IMAGE_TAG_SUFFIX:-latest}
+    container_name: paddleocr-vlm-server
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    user: root
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      start_period: 300s

--- a/deploy/paddleocr_vl_docker/nginx.multi_instance.conf
+++ b/deploy/paddleocr_vl_docker/nginx.multi_instance.conf
@@ -1,0 +1,48 @@
+# 示例：Nginx 负载均衡配置
+# 将此文件复制为 nginx.conf 并与 compose.multi_instance.yaml.example 搭配使用
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream paddleocr_vl_backend {
+        # 采用轮询调度，将请求分发到多个 API 实例
+        server paddleocr-vl-api-1:8080;
+        server paddleocr-vl-api-2:8080;
+        # 如有更多实例可在此处继续添加
+        # server paddleocr-vl-api-3:8080;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        # PDF 推理耗时较长，需要拉长超时时间
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        send_timeout 300s;
+
+        # PDF/图片较大时放宽请求体限制
+        client_max_body_size 100M;
+
+        location / {
+            proxy_pass http://paddleocr_vl_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # 如需 WebSocket，可保持以下设置
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        # 负载均衡器的 /health 直接透传到后端实例
+        location /health {
+            proxy_pass http://paddleocr_vl_backend/health;
+        }
+    }
+}


### PR DESCRIPTION
- Introduced `compose.multi_instance.yaml.example` for deploying multiple PaddleOCR API instances with a shared VLM inference service.
- Added `nginx.multi_instance.conf` for Nginx load balancing configuration to distribute requests across API instances.
- Created `README.multi_instance.md` to guide users on setting up and using the multi-instance deployment with Nginx.