### PR TITLE
Fix IndexError in NMS when detection output is 1-dimensional

### DIFF
--- a/ppocr/postprocess/picodet_postprocess.py
+++ b/ppocr/postprocess/picodet_postprocess.py
@@ -26,6 +26,10 @@ def hard_nms(box_scores, iou_threshold, top_k=-1, candidate_size=200):
     Returns:
          picked: a list of indexes of the kept boxes
     """
+    if box_scores.size == 0:
+        return np.empty((0, box_scores.shape[-1] if box_scores.ndim == 2 else 0))
+    if box_scores.ndim == 1:
+        box_scores = box_scores.reshape(1, -1)
     scores = box_scores[:, -1]
     boxes = box_scores[:, :-1]
     picked = []
@@ -238,6 +242,8 @@ class PicoDetPostProcess(object):
 
             else:
                 picked_box_probs = np.concatenate(picked_box_probs)
+                if picked_box_probs.ndim == 1:
+                    picked_box_probs = picked_box_probs.reshape(1, -1)
 
                 # resize output boxes
                 picked_box_probs[:, :4] = self.warp_boxes(


### PR DESCRIPTION
## Summary
- Fixes #17446
- When PPStructureV3 detects zero or one object, the `boxes` array output from the model can be 1-dimensional, causing an `IndexError: too many indices for array` during NMS postprocessing when 2D slicing (e.g., `boxes[:, -1]`) is applied.
- Added shape guards in `hard_nms()` to return an empty array for size-0 input and reshape 1D input to 2D for single-detection edge cases.
- Added a similar guard after `np.concatenate(picked_box_probs)` in `PicoDetPostProcess.__call__` to ensure the concatenated result is always 2D.

## Changes
- `ppocr/postprocess/picodet_postprocess.py`:
  - `hard_nms`: early return for empty input; reshape 1D to `(1, -1)` before slicing.
  - `PicoDetPostProcess.__call__`: reshape concatenated `picked_box_probs` if it becomes 1D.

## Test plan
- [x] Verified with unit tests that `hard_nms` handles empty (0,5), 1D (5,), single 2D (1,5), and multi-box (N,5) inputs correctly.
- [ ] Run PPStructureV3 inference on an image that produces 0 or 1 detections to confirm the IndexError no longer occurs.