### PR TITLE
fix: replace 44 bare except clauses with except Exception

### DIFF
--- a/benchmark/PaddleOCR_DBNet/base/base_dataset.py
+++ b/benchmark/PaddleOCR_DBNet/base/base_dataset.py
@@ -79,7 +79,7 @@ class BaseDataSet(Dataset):
                 return data_dict
             else:
                 return data
-        except:
+        except Exception:
             return self.__getitem__(np.random.randint(self.__len__()))
 
     def __len__(self):

--- a/benchmark/PaddleOCR_DBNet/data_loader/dataset.py
+++ b/benchmark/PaddleOCR_DBNet/data_loader/dataset.py
@@ -56,7 +56,7 @@ class ICDAR2015Dataset(BaseDataSet):
                         label = params[8]
                         texts.append(label)
                         ignores.append(label in self.ignore_tags)
-                except:
+                except Exception:
                     print("load label failed on {}".format(label_path))
         data = {
             "text_polys": np.array(boxes),

--- a/benchmark/PaddleOCR_DBNet/post_processing/__init__.py
+++ b/benchmark/PaddleOCR_DBNet/post_processing/__init__.py
@@ -9,5 +9,5 @@ def get_post_processing(config):
     try:
         cls = eval(config["type"])(**config["args"])
         return cls
-    except:
+    except Exception:
         return None

--- a/benchmark/PaddleOCR_DBNet/utils/cal_recall/rrc_evaluation_funcs.py
+++ b/benchmark/PaddleOCR_DBNet/utils/cal_recall/rrc_evaluation_funcs.py
@@ -29,7 +29,7 @@ def load_zip_file_keys(file, fileNameRegExp=""):
     """
     try:
         archive = zipfile.ZipFile(file, mode="r", allowZip64=True)
-    except:
+    except Exception:
         raise Exception("Error loading the ZIP archive.")
 
     pairs = []
@@ -59,7 +59,7 @@ def load_zip_file(file, fileNameRegExp="", allEntries=False):
     """
     try:
         archive = zipfile.ZipFile(file, mode="r", allowZip64=True)
-    except:
+    except Exception:
         raise Exception("Error loading the ZIP archive")
 
     pairs = []
@@ -121,7 +121,7 @@ def decode_utf8(raw):
         if raw.startswith(codecs.BOM_UTF8):
             raw = raw.replace(codecs.BOM_UTF8, "", 1)
         return raw.decode("utf-8")
-    except:
+    except Exception:
         return None
 
 

--- a/benchmark/PaddleOCR_DBNet/utils/cal_recall/script.py
+++ b/benchmark/PaddleOCR_DBNet/utils/cal_recall/script.py
@@ -117,7 +117,7 @@ def evaluate_method(gtFilePath, submFilePath, evaluationParams):
     def get_intersection_over_union(pD, pG):
         try:
             return get_intersection(pD, pG) / get_union(pD, pG)
-        except:
+        except Exception:
             return 0
 
     def get_intersection(pD, pG):

--- a/benchmark/PaddleOCR_DBNet/utils/metrics.py
+++ b/benchmark/PaddleOCR_DBNet/utils/metrics.py
@@ -27,7 +27,7 @@ class runningScore(object):
                 self.confusion_matrix += self._fast_hist(
                     lt.flatten(), lp.flatten(), self.n_classes
                 )
-            except:
+            except Exception:
                 pass
 
     def get_scores(self):

--- a/benchmark/PaddleOCR_DBNet/utils/ocr_metric/__init__.py
+++ b/benchmark/PaddleOCR_DBNet/utils/ocr_metric/__init__.py
@@ -15,5 +15,5 @@ def get_metric(config):
         else:
             cls = eval(config["type"])(args)
         return cls
-    except:
+    except Exception:
         return None

--- a/benchmark/analysis.py
+++ b/benchmark/analysis.py
@@ -299,7 +299,7 @@ if __name__ == "__main__":
                     or int(run_info["FINAL_RESULT"]) == 0
                 ):
                     run_info["JOB_FAIL_FLAG"] = 1
-            except:
+            except Exception:
                 pass
         elif args.index == 3:
             run_info["FINAL_RESULT"] = {}

--- a/deploy/hubserving/kie_ser/module.py
+++ b/deploy/hubserving/kie_ser/module.py
@@ -60,7 +60,7 @@ class KIESer(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/kie_ser_re/module.py
+++ b/deploy/hubserving/kie_ser_re/module.py
@@ -60,7 +60,7 @@ class KIESerRE(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/ocr_cls/module.py
+++ b/deploy/hubserving/ocr_cls/module.py
@@ -56,7 +56,7 @@ class OCRCls(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/ocr_det/module.py
+++ b/deploy/hubserving/ocr_det/module.py
@@ -58,7 +58,7 @@ class OCRDet(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/ocr_rec/module.py
+++ b/deploy/hubserving/ocr_rec/module.py
@@ -56,7 +56,7 @@ class OCRRec(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/ocr_system/module.py
+++ b/deploy/hubserving/ocr_system/module.py
@@ -59,7 +59,7 @@ class OCRSystem(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/structure_layout/module.py
+++ b/deploy/hubserving/structure_layout/module.py
@@ -57,7 +57,7 @@ class LayoutPredictor(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/structure_system/module.py
+++ b/deploy/hubserving/structure_system/module.py
@@ -60,7 +60,7 @@ class StructureSystem(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/hubserving/structure_table/module.py
+++ b/deploy/hubserving/structure_table/module.py
@@ -59,7 +59,7 @@ class TableSystem(hub.Module):
                 print("use gpu: ", use_gpu)
                 print("CUDA_VISIBLE_DEVICES: ", _places)
                 cfg.gpu_mem = 8000
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Environment Variable CUDA_VISIBLE_DEVICES is not set correctly. If you wanna use gpu, please set CUDA_VISIBLE_DEVICES via export CUDA_VISIBLE_DEVICES=cuda_device_id."
                 )

--- a/deploy/slim/auto_compression/ppocrv4_det_server_dataset_process.py
+++ b/deploy/slim/auto_compression/ppocrv4_det_server_dataset_process.py
@@ -29,5 +29,5 @@ for i, line in enumerate(lines):
                 cv2.imwrite(small_image_path, image)
                 with open(new_annotation_file, "a") as f:
                     f.write(f"{line}")
-    except:
+    except Exception:
         continue

--- a/deploy/slim/auto_compression/run.py
+++ b/deploy/slim/auto_compression/run.py
@@ -83,7 +83,7 @@ def eval_function(exe, compiled_test_program, test_feed_names, test_fetch_list):
                     feed={test_feed_names[0]: images},
                     fetch_list=test_fetch_list,
                 )
-            except:
+            except Exception:
                 preds, _ = exe.run(
                     compiled_test_program,
                     feed={test_feed_names[0]: images},

--- a/ppocr/data/imaug/fce_aug.py
+++ b/ppocr/data/imaug/fce_aug.py
@@ -564,7 +564,7 @@ class SquareResizePad:
         try:
             polygons[:, :, 0::2] = polygons[:, :, 0::2] * out_size[1] / w + offset[0]
             polygons[:, :, 1::2] = polygons[:, :, 1::2] * out_size[0] / h + offset[1]
-        except:
+        except Exception:
             pass
         results["polys"] = polygons
 

--- a/ppocr/data/imaug/make_pse_gt.py
+++ b/ppocr/data/imaug/make_pse_gt.py
@@ -96,7 +96,7 @@ class MakePseGt(object):
                 continue
             try:
                 shrunk = np.array(shrunk[0]).reshape(-1, 2)
-            except:
+            except Exception:
                 if ignore_tags is not None:
                     ignore_tags[i] = True
                 continue

--- a/ppocr/data/imaug/operators.py
+++ b/ppocr/data/imaug/operators.py
@@ -307,7 +307,7 @@ class DetResizeForTest(object):
             if int(resize_w) <= 0 or int(resize_h) <= 0:
                 return None, (None, None)
             img = cv2.resize(img, (int(resize_w), int(resize_h)))
-        except:
+        except Exception:
             print(img.shape, resize_w, resize_h)
             sys.exit(0)
         ratio_h = resize_h / float(h)

--- a/ppocr/data/imaug/rec_img_aug.py
+++ b/ppocr/data/imaug/rec_img_aug.py
@@ -925,7 +925,7 @@ def get_warpR(config):
         dy = -r1
         T1 = np.float32([[1.0, 0, dx], [0, 1.0, dy], [0, 0, 1.0 / ratio]])
         ret = T1.dot(warpR)
-    except:
+    except Exception:
         ratio = 1.0
         T1 = np.float32([[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]])
         ret = T1

--- a/ppocr/data/latexocr_dataset.py
+++ b/ppocr/data/latexocr_dataset.py
@@ -151,7 +151,7 @@ class LaTeXOCRDataSet(Dataset):
                 return self.__getitem__(rnd_idx)
             return (images_transform, labels, attention_mask)
 
-        except:
+        except Exception:
 
             self.logger.error(
                 "When parsing line {}, error happened with msg: {}".format(

--- a/ppocr/data/lmdb_dataset.py
+++ b/ppocr/data/lmdb_dataset.py
@@ -254,7 +254,7 @@ class LMDBDataSetTableMaster(LMDBDataSet):
 
         try:
             data = pickle.loads(txn.get(str(index).encode("utf8")))
-        except:
+        except Exception:
             return None
 
         # img_name, img, info_lines

--- a/ppocr/data/pgnet_dataset.py
+++ b/ppocr/data/pgnet_dataset.py
@@ -83,7 +83,7 @@ class PGDataSet(Dataset):
             if self.mode.lower() == "eval":
                 try:
                     img_id = int(data_line.split(".")[0][7:])
-                except:
+                except Exception:
                     img_id = 0
             data = {"img_path": img_path, "label": label, "img_id": img_id}
             if not os.path.exists(img_path):

--- a/ppocr/data/pubtab_dataset.py
+++ b/ppocr/data/pubtab_dataset.py
@@ -115,7 +115,7 @@ class PubTabDataSet(Dataset):
                 img = f.read()
                 data["image"] = img
             outs = transform(data, self.ops)
-        except:
+        except Exception:
             import traceback
 
             err = traceback.format_exc()

--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -79,7 +79,7 @@ class SimpleDataSet(Dataset):
             try:
                 info = json.loads(file_name)
                 file_name = random.choice(info)
-            except:
+            except Exception:
                 pass
         return file_name
 
@@ -136,7 +136,7 @@ class SimpleDataSet(Dataset):
             data["ext_data"] = self.get_ext_data()
             data["filename"] = data["img_path"]
             outs = transform(data, self.ops)
-        except:
+        except Exception:
             self.logger.error(
                 "When parsing line {}, error happened with msg: {}".format(
                     data_line, traceback.format_exc()
@@ -242,7 +242,7 @@ class MultiScaleDataSet(SimpleDataSet):
             if outs is not None:
                 outs = self.resize_norm_img(outs, img_width, img_height)
                 outs = transform(outs, self.ops[-1:])
-        except:
+        except Exception:
             self.logger.error(
                 "When parsing line {}, error happened with msg: {}".format(
                     data_line, traceback.format_exc()

--- a/ppocr/modeling/heads/rec_cppd_head.py
+++ b/ppocr/modeling/heads/rec_cppd_head.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 try:
     from collections import Callable
-except:
+except Exception:
     from collections.abc import Callable
 
 import numpy as np

--- a/ppocr/postprocess/east_postprocess.py
+++ b/ppocr/postprocess/east_postprocess.py
@@ -77,7 +77,7 @@ class EASTPostProcess(object):
             import lanms
 
             boxes = lanms.merge_quadrangle_n9(boxes, nms_thresh)
-        except:
+        except Exception:
             print(
                 "You should install lanms by pip3 install lanms-nova to speed up nms_locality"
             )

--- a/ppocr/postprocess/rec_postprocess.py
+++ b/ppocr/postprocess/rec_postprocess.py
@@ -973,7 +973,7 @@ class NRTRLabelDecode(BaseRecLabelDecode):
             for idx in range(len(text_index[batch_idx])):
                 try:
                     char_idx = self.character[int(text_index[batch_idx][idx])]
-                except:
+                except Exception:
                     continue
                 if char_idx == "</s>":  # end
                     break

--- a/ppocr/utils/e2e_metric/Deteval.py
+++ b/ppocr/utils/e2e_metric/Deteval.py
@@ -351,7 +351,7 @@ def get_score_C(gt_label, text, pred_bboxes):
 
                     try:
                         det_gt_iou = get_intersection(det_p, gt_p) / det_p.area()
-                    except:
+                    except Exception:
                         print(det_x, det_y, gt_p)
                     if det_gt_iou > threshold:
                         detections[det_id] = []

--- a/ppstructure/table/table_master_match.py
+++ b/ppstructure/table/table_master_match.py
@@ -528,7 +528,7 @@ def merge_span_token(master_token_list):
             else:
                 new_master_token_list.append(master_token_list[pointer])
                 pointer += 1
-        except:
+        except Exception:
             print("Break in merge...")
             break
     new_master_token_list.append("</tbody>")

--- a/ppstructure/table/tablepyxl/style.py
+++ b/ppstructure/table/tablepyxl/style.py
@@ -15,7 +15,7 @@ try:
     from openpyxl.styles.fills import FILL_SOLID
     from openpyxl.styles.numbers import FORMAT_CURRENCY_USD_SIMPLE, FORMAT_PERCENTAGE
     from openpyxl.styles.colors import BLACK
-except:
+except Exception:
     import warnings
 
     warnings.warn(

--- a/test_tipc/compare_results.py
+++ b/test_tipc/compare_results.py
@@ -49,7 +49,7 @@ def parser_results_from_log_by_name(log_path, names_list):
         result = outs.split("{}".format(name))[-1]
         try:
             result = json.loads(result)
-        except:
+        except Exception:
             result = np.array([int(r) for r in result.split()]).reshape(-1, 4)
         parser_results[name] = result
     return parser_results
@@ -67,7 +67,7 @@ def load_gt_from_file(gt_file):
         image_name = image_name.split("/")[-1]
         try:
             result = json.loads(result)
-        except:
+        except Exception:
             result = np.array([int(r) for r in result.split()]).reshape(-1, 4)
         parser_gt[image_name] = result
     return parser_gt

--- a/test_tipc/supplementary/load_cifar.py
+++ b/test_tipc/supplementary/load_cifar.py
@@ -12,7 +12,7 @@ def load_CIFAR_batch(filename):
         Y = datadict[b"fine_labels"]
         try:
             X = X.reshape(10000, 3, 32, 32)
-        except:
+        except Exception:
             X = X.reshape(50000, 3, 32, 32)
         Y = np.array(Y)
         print(Y.shape)

--- a/tools/end2end/convert_ppocr_label.py
+++ b/tools/end2end/convert_ppocr_label.py
@@ -39,7 +39,7 @@ def convert_label(label_dir, mode="gt", save_dir="./save_results/"):
         try:
             tmp = line.split("\t")
             assert len(tmp) == 2, ""
-        except:
+        except Exception:
             tmp = line.strip().split("    ")
 
         gt_lists = []

--- a/tools/program.py
+++ b/tools/program.py
@@ -293,7 +293,7 @@ def train(
         extra_input = config["Architecture"]["algorithm"] in extra_input_models
     try:
         model_type = config["Architecture"]["model_type"]
-    except:
+    except Exception:
         model_type = None
 
     algorithm = config["Architecture"]["algorithm"]

--- a/tools/train.py
+++ b/tools/train.py
@@ -180,7 +180,7 @@ def main(config, device, logger, vdl_writer, seed):
             os.remove(
                 os.path.join(config["Global"]["save_model_dir"], "train_result.json")
             )
-        except:
+        except Exception:
             pass
     if use_amp:
         AMP_RELATED_FLAGS_SETTING = {}


### PR DESCRIPTION
## What
Replace 44 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.