### PR TITLE
skills: add Client-Platform header for official skills

### DIFF
--- a/skills/paddleocr-doc-parsing/scripts/lib.py
+++ b/skills/paddleocr-doc-parsing/scripts/lib.py
@@ -164,6 +164,7 @@ def _make_api_request(api_url: str, token: str, params: dict) -> dict:
     headers = {
         "Authorization": f"token {token}",
         "Content-Type": "application/json",
+        "Client-Platform": "official-skill",
     }
 
     timeout = float(os.getenv("PADDLEOCR_DOC_PARSING_TIMEOUT", str(DEFAULT_TIMEOUT)))

--- a/skills/paddleocr-text-recognition/scripts/lib.py
+++ b/skills/paddleocr-text-recognition/scripts/lib.py
@@ -153,6 +153,7 @@ def _make_api_request(api_url: str, token: str, params: dict) -> dict:
     headers = {
         "Authorization": f"token {token}",
         "Content-Type": "application/json",
+        "Client-Platform": "official-skill",
     }
 
     timeout = float(os.getenv("PADDLEOCR_TIMEOUT", str(DEFAULT_TIMEOUT)))


### PR DESCRIPTION
## Summary
Add Client-Platform: official-skill request header in official skills runtime API calls for traffic source attribution.

## Changes
- skills/paddleocr-text-recognition/scripts/lib.py
  - Add header Client-Platform: official-skill in _make_api_request
- skills/paddleocr-doc-parsing/scripts/lib.py
  - Add header Client-Platform: official-skill in _make_api_request

## Notes
- No changes to configure.py probe/config requests.
- No function signatures or request payload logic changed.

Follow-up context: this continues the skills work from #17690.