### PR TITLE
Fix type parsing for deprecated arguments

### DIFF
--- a/paddleocr/_pipelines/ocr.py
+++ b/paddleocr/_pipelines/ocr.py
@@ -672,7 +672,7 @@ class PaddleOCRCLISubcommandExecutor(PipelineCLISubcommandExecutor):
             subparser.add_argument(
                 "--" + name,
                 action=DeprecatedOptionAction,
-                type=str,
+                type=deprecated_arg_types[name],
                 help=f"[Deprecated] Please use `--{new_name}` instead.",
             )
 


### PR DESCRIPTION
Fixes #17831 by replacing the hardcoded type with the correct type out of `deprecated_arg_types` dictionary.