### PR TITLE
Fix missing libglib2.0-0 in HPS gateway Dockerfile (#17833)

### DIFF
--- a/deploy/paddleocr_vl_docker/hps/gateway.Dockerfile
+++ b/deploy/paddleocr_vl_docker/hps/gateway.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl libgl1 \
+    && apt-get install -y --no-install-recommends curl libgl1 libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
#17833 

The gateway container fails with `ImportError: libgthread-2.0.so.0` because `paddlex[serving]` transitively imports `cv2`, which requires `libglib2.0-0`. Add it to the apt-get install line.