### PR TITLE
Add MiniMax-M3 as alternative LLM provider for ChatOCR and DocTranslation

### DIFF
--- a/docs/version3.x/pipeline_usage/PP-ChatOCRv4.en.md
+++ b/docs/version3.x/pipeline_usage/PP-ChatOCRv4.en.md
@@ -971,7 +971,7 @@ Before using the PP-ChatOCRv4-doc pipeline locally, ensure you have completed th
 
 Please note: If you encounter issues such as the program becoming unresponsive, unexpected program termination, running out of memory resources, or extremely slow inference during execution, please try adjusting the configuration according to the documentation, such as disabling unnecessary features or using lighter-weight models.
 
-Before performing model inference, you first need to prepare the API key for the large language model. PP-ChatOCRv4 supports large model services on the [Baidu Cloud Qianfan Platform](https://console.bce.baidu.com/qianfan/ais/console/onlineService) or the locally deployed standard OpenAI interface. If using the Baidu Cloud Qianfan Platform, refer to [Authentication and Authorization](https://cloud.baidu.com/doc/qianfan-api/s/ym9chdsy5) to obtain the API key. If using a locally deployed large model service, refer to the [PaddleNLP Large Model Deployment Documentation](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/llm) for deployment of the dialogue interface and vectorization interface for large models, and fill in the corresponding `base_url` and `api_key`. If you need to use a multimodal large model for data fusion, refer to the OpenAI service deployment in the [PaddleMIX Model Documentation](https://github.com/PaddlePaddle/PaddleMIX/tree/develop/paddlemix/examples/ppdocbee2) for multimodal large model deployment, and fill in the corresponding `base_url` and `api_key`.
+Before performing model inference, you first need to prepare the API key for the large language model. PP-ChatOCRv4 supports large model services on the [Baidu Cloud Qianfan Platform](https://console.bce.baidu.com/qianfan/ais/console/onlineService), [MiniMax Cloud](https://www.minimax.io/), or the locally deployed standard OpenAI interface. If using the Baidu Cloud Qianfan Platform, refer to [Authentication and Authorization](https://cloud.baidu.com/doc/qianfan-api/s/ym9chdsy5) to obtain the API key. If using MiniMax Cloud, obtain an API key from [MiniMax Platform](https://platform.minimaxi.com/) and pass it via `--minimax_api_key` or the `MINIMAX_API_KEY` environment variable. If using a locally deployed large model service, refer to the [PaddleNLP Large Model Deployment Documentation](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/llm) for deployment of the dialogue interface and vectorization interface for large models, and fill in the corresponding `base_url` and `api_key`. If you need to use a multimodal large model for data fusion, refer to the OpenAI service deployment in the [PaddleMIX Model Documentation](https://github.com/PaddlePaddle/PaddleMIX/tree/develop/paddlemix/examples/ppdocbee2) for multimodal large model deployment, and fill in the corresponding `base_url` and `api_key`.
 
 **Note**: If local deployment of a multimodal large model is restricted due to the local environment, you can comment out the lines containing the `mllm` variable in the code and only use the large language model for information extraction.
 
@@ -982,6 +982,9 @@ After updating the configuration file, you can complete quick inference using ju
 
 ```bash
 paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --qianfan_api_key your_api_key
+
+# Use MiniMax Cloud as the LLM provider
+paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --minimax_api_key your_minimax_api_key
 
 # 通过 --invoke_mllm 和 --pp_docbee_base_url 使用多模态大模型
 paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --qianfan_api_key your_api_key --invoke_mllm True --pp_docbee_base_url http://127.0.0.1:8080/
@@ -1381,6 +1384,12 @@ Any float > <code>0</code></li>
 <td></td>
 </tr>
 <tr>
+<td><code>minimax_api_key</code></td>
+<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M2.7, 204K context) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
+<td><code>str</code></td>
+<td></td>
+</tr>
+<tr>
 <td><code>device</code></td>
 <td><b>Meaning:</b>The device used for inference.<br/>
 <b>Description:</b> 
@@ -1478,6 +1487,18 @@ chat_bot_config = {
     "api_type": "openai",
     "api_key": "api_key",  # your api_key
 }
+
+# Alternatively, use MiniMax Cloud as the LLM provider:
+# from paddleocr._pipelines.llm_config import get_minimax_chat_bot_config
+# chat_bot_config = get_minimax_chat_bot_config()  # reads MINIMAX_API_KEY env var
+# Or configure manually:
+# chat_bot_config = {
+#     "module_name": "chat_bot",
+#     "model_name": "MiniMax-M2.7",  # 204K context window
+#     "base_url": "https://api.minimax.io/v1",
+#     "api_type": "openai",
+#     "api_key": "your_minimax_api_key",
+# }
 
 retriever_config = {
     "module_name": "retriever",

--- a/docs/version3.x/pipeline_usage/PP-ChatOCRv4.en.md
+++ b/docs/version3.x/pipeline_usage/PP-ChatOCRv4.en.md
@@ -1385,7 +1385,7 @@ Any float > <code>0</code></li>
 </tr>
 <tr>
 <td><code>minimax_api_key</code></td>
-<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M2.7, 204K context) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
+<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M3, 512K context, 128K max output) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
 <td><code>str</code></td>
 <td></td>
 </tr>
@@ -1494,7 +1494,7 @@ chat_bot_config = {
 # Or configure manually:
 # chat_bot_config = {
 #     "module_name": "chat_bot",
-#     "model_name": "MiniMax-M2.7",  # 204K context window
+#     "model_name": "MiniMax-M3",  # 512K context window, 128K max output
 #     "base_url": "https://api.minimax.io/v1",
 #     "api_type": "openai",
 #     "api_key": "your_minimax_api_key",

--- a/docs/version3.x/pipeline_usage/PP-ChatOCRv4.md
+++ b/docs/version3.x/pipeline_usage/PP-ChatOCRv4.md
@@ -861,7 +861,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="https://padd
 
 **请注意，如果在执行过程中遇到程序失去响应、程序异常退出、内存资源耗尽、推理速度极慢等问题，请尝试参考文档调整配置，例如关闭不需要使用的功能或使用更轻量的模型。**
 
-在进行模型推理之前，首先需要准备大语言模型的 api_key，PP-ChatOCRv4 支持在[百度云千帆平台](https://console.bce.baidu.com/qianfan/ais/console/onlineService)或者本地部署的标准 OpenAI 接口大模型服务。如果使用百度云千帆平台，可以参考[认证鉴权](https://cloud.baidu.com/doc/qianfan-api/s/ym9chdsy5) 获取 api_key。如果使用本地部署的大模型服务，可以参考[PaddleNLP大模型部署文档](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/llm)进行大模型部署对话接口部署和向量化接口部署，并填写对应的 base_url 和 api_key 即可。如果需要使用多模态大模型进行数据融合，可以参考[PaddleMIX模型文档](https://github.com/PaddlePaddle/PaddleMIX/tree/develop/paddlemix/examples/ppdocbee2)中的OpenAI服务部署进行多模态大模型部署，并填写对应的 base_url 和 api_key 即可。
+在进行模型推理之前，首先需要准备大语言模型的 api_key，PP-ChatOCRv4 支持在[百度云千帆平台](https://console.bce.baidu.com/qianfan/ais/console/onlineService)、[MiniMax 开放平台](https://platform.minimaxi.com/)或者本地部署的标准 OpenAI 接口大模型服务。如果使用百度云千帆平台，可以参考[认证鉴权](https://cloud.baidu.com/doc/qianfan-api/s/ym9chdsy5) 获取 api_key。如果使用 MiniMax 开放平台，可以在 [MiniMax 开放平台](https://platform.minimaxi.com/) 获取 API key，并通过 `--minimax_api_key` 或 `MINIMAX_API_KEY` 环境变量传入。如果使用本地部署的大模型服务，可以参考[PaddleNLP大模型部署文档](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/llm)进行大模型部署对话接口部署和向量化接口部署，并填写对应的 base_url 和 api_key 即可。如果需要使用多模态大模型进行数据融合，可以参考[PaddleMIX模型文档](https://github.com/PaddlePaddle/PaddleMIX/tree/develop/paddlemix/examples/ppdocbee2)中的OpenAI服务部署进行多模态大模型部署，并填写对应的 base_url 和 api_key 即可。
 
 **注:** 如果因本地环境限制无法在本地部署多模态大模型，可以将代码中的含有“mllm”变量的行注释掉，仅使用大语言模型完成信息抽取。
 
@@ -871,6 +871,9 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="https://padd
 
 ```bash
 paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --qianfan_api_key your_api_key
+
+# 使用 MiniMax 开放平台作为大语言模型
+paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --minimax_api_key your_minimax_api_key
 
 # 通过 --invoke_mllm 和 --pp_docbee_base_url 使用多模态大模型
 paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数 --qianfan_api_key your_api_key --invoke_mllm True --pp_docbee_base_url http://127.0.0.1:8080/
@@ -1239,6 +1242,12 @@ paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数
 <td></td>
 </tr>
 <tr>
+<td><code>minimax_api_key</code></td>
+<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M2.7，204K 上下文）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
+<td><code>str</code></td>
+<td></td>
+</tr>
+<tr>
 <td><code>device</code></td>
 <td><b>含义：</b>用于推理的设备。<br/>
 <b>说明：</b>支持指定具体卡号：
@@ -1331,6 +1340,18 @@ chat_bot_config = {
     "api_type": "openai",
     "api_key": "api_key",  # your api_key
 }
+
+# 也可以使用 MiniMax 开放平台作为大语言模型：
+# from paddleocr._pipelines.llm_config import get_minimax_chat_bot_config
+# chat_bot_config = get_minimax_chat_bot_config()  # 读取 MINIMAX_API_KEY 环境变量
+# 或手动配置：
+# chat_bot_config = {
+#     "module_name": "chat_bot",
+#     "model_name": "MiniMax-M2.7",  # 204K 上下文窗口
+#     "base_url": "https://api.minimax.io/v1",
+#     "api_type": "openai",
+#     "api_key": "your_minimax_api_key",
+# }
 
 retriever_config = {
     "module_name": "retriever",

--- a/docs/version3.x/pipeline_usage/PP-ChatOCRv4.md
+++ b/docs/version3.x/pipeline_usage/PP-ChatOCRv4.md
@@ -1243,7 +1243,7 @@ paddleocr pp_chatocrv4_doc -i vehicle_certificate-1.png -k 驾驶室准乘人数
 </tr>
 <tr>
 <td><code>minimax_api_key</code></td>
-<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M2.7，204K 上下文）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
+<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M3，512K 上下文，最大输出 128K）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
 <td><code>str</code></td>
 <td></td>
 </tr>
@@ -1347,7 +1347,7 @@ chat_bot_config = {
 # 或手动配置：
 # chat_bot_config = {
 #     "module_name": "chat_bot",
-#     "model_name": "MiniMax-M2.7",  # 204K 上下文窗口
+#     "model_name": "MiniMax-M3",  # 512K 上下文窗口，最大输出 128K
 #     "base_url": "https://api.minimax.io/v1",
 #     "api_type": "openai",
 #     "api_key": "your_minimax_api_key",

--- a/docs/version3.x/pipeline_usage/PP-DocTranslation.en.md
+++ b/docs/version3.x/pipeline_usage/PP-DocTranslation.en.md
@@ -693,6 +693,9 @@ You can download the [test file](https://paddle-model-ecology.bj.bcebos.com/padd
 
 ```bash
 paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --qianfan_api_key your_api_key
+
+# Use MiniMax Cloud as the LLM provider
+paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --minimax_api_key your_minimax_api_key
 ```
 
 <details><summary><b>Command line supports more parameter settings. Click to expand for detailed description of command line parameters</b></summary>
@@ -1244,6 +1247,12 @@ If not set, the pipeline initialized value will be used, default is <code>True</
 <td></td>
 </tr>
 <tr>
+<td><code>minimax_api_key</code></td>
+<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M2.7, 204K context) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
+<td><code>str</code></td>
+<td></td>
+</tr>
+<tr>
 <td><code>device</code></td>
 <td><b>Meaning:</b>Device used for inference.<br/>
 <b>Description:</b> 
@@ -1341,6 +1350,10 @@ chat_bot_config = {
     "api_type": "openai",
     "api_key": "api_key",  # your api_key
 }
+
+# Alternatively, use MiniMax Cloud as the LLM provider:
+# from paddleocr._pipelines.llm_config import get_minimax_chat_bot_config
+# chat_bot_config = get_minimax_chat_bot_config()  # reads MINIMAX_API_KEY env var
 
 if input_path.lower().endswith(".md"):
     # Read markdown documents, supporting passing in directories and url links with the .md suffix

--- a/docs/version3.x/pipeline_usage/PP-DocTranslation.en.md
+++ b/docs/version3.x/pipeline_usage/PP-DocTranslation.en.md
@@ -1248,7 +1248,7 @@ If not set, the pipeline initialized value will be used, default is <code>True</
 </tr>
 <tr>
 <td><code>minimax_api_key</code></td>
-<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M2.7, 204K context) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
+<td><b>Meaning:</b>API key for <a href="https://platform.minimaxi.com/">MiniMax Cloud</a>. When set, uses MiniMax (MiniMax-M3, 512K context, 128K max output) as the LLM provider instead of Qianfan. Can also be set via the <code>MINIMAX_API_KEY</code> environment variable.</td>
 <td><code>str</code></td>
 <td></td>
 </tr>

--- a/docs/version3.x/pipeline_usage/PP-DocTranslation.md
+++ b/docs/version3.x/pipeline_usage/PP-DocTranslation.md
@@ -690,6 +690,9 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="https://padd
 
 ```bash
 paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --qianfan_api_key your_api_key
+
+# 使用 MiniMax 开放平台作为大语言模型
+paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --minimax_api_key your_minimax_api_key
 ```
 
 <details><summary><b>命令行支持更多参数设置，点击展开以查看命令行参数的详细说明</b></summary>
@@ -1265,6 +1268,12 @@ paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --
 <td></td>
 </tr>
 <tr>
+<td><code>minimax_api_key</code></td>
+<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M2.7，204K 上下文）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
+<td><code>str</code></td>
+<td></td>
+</tr>
+<tr>
 <td><code>device</code></td>
 <td><b>含义：</b>用于推理的设备。<br/>
 <b>含义：</b>
@@ -1365,6 +1374,10 @@ chat_bot_config = {
     "api_type": "openai",
     "api_key": "api_key",  # your api_key
 }
+
+# 也可以使用 MiniMax 开放平台作为大语言模型：
+# from paddleocr._pipelines.llm_config import get_minimax_chat_bot_config
+# chat_bot_config = get_minimax_chat_bot_config()  # 读取 MINIMAX_API_KEY 环境变量
 
 if input_path.lower().endswith(".md"):
     # 读取markdown文档，支持传入目录和以 .md 为后缀的 url 链接

--- a/docs/version3.x/pipeline_usage/PP-DocTranslation.md
+++ b/docs/version3.x/pipeline_usage/PP-DocTranslation.md
@@ -1269,7 +1269,7 @@ paddleocr pp_doctranslation -i vehicle_certificate-1.png --target_language en --
 </tr>
 <tr>
 <td><code>minimax_api_key</code></td>
-<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M2.7，204K 上下文）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
+<td><b>含义：</b><a href="https://platform.minimaxi.com/">MiniMax 开放平台</a> 的 API key。设置后将使用 MiniMax（MiniMax-M3，512K 上下文，最大输出 128K）作为大语言模型，替代千帆平台。也可通过 <code>MINIMAX_API_KEY</code> 环境变量设置。</td>
 <td><code>str</code></td>
 <td></td>
 </tr>

--- a/paddleocr/_pipelines/llm_config.py
+++ b/paddleocr/_pipelines/llm_config.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for building LLM chat_bot_config from third-party provider keys."""
+
+import os
+
+
+# MiniMax models and their context window sizes (tokens).
+MINIMAX_MODELS = {
+    "MiniMax-M2.7": 204_800,
+    "MiniMax-M2.7-highspeed": 204_800,
+}
+
+MINIMAX_DEFAULT_MODEL = "MiniMax-M2.7"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+def get_minimax_chat_bot_config(api_key=None):
+    """Return a ``chat_bot_config`` dict targeting MiniMax Cloud API.
+
+    Parameters
+    ----------
+    api_key : str or None
+        MiniMax API key.  When *None* the ``MINIMAX_API_KEY`` environment
+        variable is used as a fallback.
+
+    Returns
+    -------
+    dict
+        A config dict ready to be passed as ``chat_bot_config`` to any
+        pipeline that accepts it (PP-ChatOCRv4-doc, PP-DocTranslation, …).
+
+    Raises
+    ------
+    ValueError
+        If no API key is provided and the environment variable is not set.
+    """
+    api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "A MiniMax API key is required.  Pass it via --minimax_api_key "
+            "or set the MINIMAX_API_KEY environment variable."
+        )
+
+    return {
+        "module_name": "chat_bot",
+        "model_name": MINIMAX_DEFAULT_MODEL,
+        "base_url": MINIMAX_BASE_URL,
+        "api_type": "openai",
+        "api_key": api_key,
+    }

--- a/paddleocr/_pipelines/llm_config.py
+++ b/paddleocr/_pipelines/llm_config.py
@@ -19,11 +19,12 @@ import os
 
 # MiniMax models and their context window sizes (tokens).
 MINIMAX_MODELS = {
+    "MiniMax-M3": 512_000,
     "MiniMax-M2.7": 204_800,
     "MiniMax-M2.7-highspeed": 204_800,
 }
 
-MINIMAX_DEFAULT_MODEL = "MiniMax-M2.7"
+MINIMAX_DEFAULT_MODEL = "MiniMax-M3"
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
 
 

--- a/paddleocr/_pipelines/pp_chatocrv4_doc.py
+++ b/paddleocr/_pipelines/pp_chatocrv4_doc.py
@@ -17,6 +17,7 @@ from .._utils.cli import (
     str2bool,
 )
 from .base import PaddleXPipelineWrapper, PipelineCLISubcommandExecutor
+from .llm_config import get_minimax_chat_bot_config
 from .utils import create_config_from_structure
 
 
@@ -680,6 +681,13 @@ class PPChatOCRv4DocCLISubcommandExecutor(PipelineCLISubcommandExecutor):
             type=str,
             help="Configuration for the multimodal large language model.",
         )
+        subparser.add_argument(
+            "--minimax_api_key",
+            type=str,
+            help="API key for MiniMax Cloud. When set, uses MiniMax as the "
+            "LLM provider for information extraction instead of Qianfan. "
+            "Can also be set via the MINIMAX_API_KEY environment variable.",
+        )
 
     def execute_with_args(self, args):
         params = get_subcommand_args(args)
@@ -687,8 +695,13 @@ class PPChatOCRv4DocCLISubcommandExecutor(PipelineCLISubcommandExecutor):
         keys = params.pop("keys")
         save_path = params.pop("save_path")
         invoke_mllm = params.pop("invoke_mllm")
+        minimax_api_key = params.pop("minimax_api_key")
         qianfan_api_key = params.pop("qianfan_api_key")
-        if qianfan_api_key is not None:
+        if minimax_api_key is not None:
+            params["chat_bot_config"] = get_minimax_chat_bot_config(
+                minimax_api_key
+            )
+        elif qianfan_api_key is not None:
             params["retriever_config"] = {
                 "module_name": "retriever",
                 "model_name": "embedding-v1",

--- a/paddleocr/_pipelines/pp_doctranslation.py
+++ b/paddleocr/_pipelines/pp_doctranslation.py
@@ -18,6 +18,7 @@ from .._utils.cli import (
 )
 from .._utils.logging import logger
 from .base import PaddleXPipelineWrapper, PipelineCLISubcommandExecutor
+from .llm_config import get_minimax_chat_bot_config
 from .utils import create_config_from_structure
 
 
@@ -906,14 +907,26 @@ class PPDocTranslationCLISubcommandExecutor(PipelineCLISubcommandExecutor):
             type=str,
             help="Configuration for the embedding model.",
         )
+        subparser.add_argument(
+            "--minimax_api_key",
+            type=str,
+            help="API key for MiniMax Cloud. When set, uses MiniMax as the "
+            "LLM provider for document translation instead of Qianfan. "
+            "Can also be set via the MINIMAX_API_KEY environment variable.",
+        )
 
     def execute_with_args(self, args):
         params = get_subcommand_args(args)
         input = params.pop("input")
         target_language = params.pop("target_language")
         save_path = params.pop("save_path")
+        minimax_api_key = params.pop("minimax_api_key")
         qianfan_api_key = params.pop("qianfan_api_key")
-        if qianfan_api_key is not None:
+        if minimax_api_key is not None:
+            params["chat_bot_config"] = get_minimax_chat_bot_config(
+                minimax_api_key
+            )
+        elif qianfan_api_key is not None:
             params["chat_bot_config"] = {
                 "module_name": "chat_bot",
                 "model_name": "ernie-3.5-8k",

--- a/tests/pipelines/test_minimax_llm_config.py
+++ b/tests/pipelines/test_minimax_llm_config.py
@@ -1,0 +1,185 @@
+"""Tests for MiniMax LLM provider configuration and CLI integration.
+
+These tests import the ``llm_config`` module directly (bypassing the
+heavyweight paddleocr top-level __init__) so they can run without
+the full paddlex dependency graph.
+"""
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap: import llm_config without pulling in paddleocr.__init__
+# (which requires paddlex).  We add the *parent* of ``paddleocr/`` to
+# sys.path so that ``paddleocr._pipelines.llm_config`` resolves, while
+# stubbing out the heavy paddleocr.__init__.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _ensure_llm_config_importable():
+    """Make ``paddleocr._pipelines.llm_config`` importable in isolation."""
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+
+    # Provide lightweight stubs so "from paddleocr._pipelines.llm_config …"
+    # does not trigger the real paddleocr/__init__.py (which imports paddlex).
+    for mod_name in ("paddleocr", "paddleocr._pipelines"):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    spec = importlib.util.spec_from_file_location(
+        "paddleocr._pipelines.llm_config",
+        os.path.join(_REPO_ROOT, "paddleocr", "_pipelines", "llm_config.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["paddleocr._pipelines.llm_config"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+llm_config = _ensure_llm_config_importable()
+
+get_minimax_chat_bot_config = llm_config.get_minimax_chat_bot_config
+MINIMAX_BASE_URL = llm_config.MINIMAX_BASE_URL
+MINIMAX_DEFAULT_MODEL = llm_config.MINIMAX_DEFAULT_MODEL
+MINIMAX_MODELS = llm_config.MINIMAX_MODELS
+
+
+# =====================================================================
+# Unit tests
+# =====================================================================
+
+
+class TestGetMinimaxChatBotConfig:
+    """Unit tests for get_minimax_chat_bot_config()."""
+
+    def test_returns_correct_structure_with_explicit_key(self):
+        config = get_minimax_chat_bot_config(api_key="test-key-123")
+        assert config == {
+            "module_name": "chat_bot",
+            "model_name": MINIMAX_DEFAULT_MODEL,
+            "base_url": MINIMAX_BASE_URL,
+            "api_type": "openai",
+            "api_key": "test-key-123",
+        }
+
+    def test_uses_env_var_when_no_explicit_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key-456")
+        config = get_minimax_chat_bot_config()
+        assert config["api_key"] == "env-key-456"
+
+    def test_explicit_key_takes_precedence_over_env_var(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        config = get_minimax_chat_bot_config(api_key="explicit-key")
+        assert config["api_key"] == "explicit-key"
+
+    def test_raises_when_no_key_available(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="MiniMax API key is required"):
+            get_minimax_chat_bot_config()
+
+    def test_api_type_is_openai(self):
+        config = get_minimax_chat_bot_config(api_key="k")
+        assert config["api_type"] == "openai"
+
+    def test_base_url_points_to_minimax(self):
+        config = get_minimax_chat_bot_config(api_key="k")
+        assert "minimax" in config["base_url"]
+
+    def test_default_model_is_m27(self):
+        config = get_minimax_chat_bot_config(api_key="k")
+        assert config["model_name"] == "MiniMax-M2.7"
+
+    def test_minimax_models_registry(self):
+        assert "MiniMax-M2.7" in MINIMAX_MODELS
+        assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
+        for ctx in MINIMAX_MODELS.values():
+            assert ctx == 204_800
+
+    def test_config_module_name_is_chat_bot(self):
+        config = get_minimax_chat_bot_config(api_key="k")
+        assert config["module_name"] == "chat_bot"
+
+    def test_empty_string_key_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-fallback")
+        config = get_minimax_chat_bot_config(api_key="")
+        assert config["api_key"] == "env-fallback"
+
+
+# =====================================================================
+# Integration tests (require MINIMAX_API_KEY)
+# =====================================================================
+
+
+class TestMinimaxIntegration:
+    """Integration tests verifying MiniMax API connectivity."""
+
+    @pytest.mark.skipif(
+        not os.environ.get("MINIMAX_API_KEY"),
+        reason="MINIMAX_API_KEY not set",
+    )
+    def test_minimax_api_responds(self):
+        """Smoke-test the MiniMax API with a trivial chat request."""
+        import json
+        import urllib.request
+
+        config = get_minimax_chat_bot_config()
+        url = config["base_url"].rstrip("/") + "/chat/completions"
+        payload = json.dumps(
+            {
+                "model": config["model_name"],
+                "messages": [{"role": "user", "content": "Say hi"}],
+                "max_tokens": 8,
+                "temperature": 0.1,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {config['api_key']}",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+        assert "choices" in data
+        assert len(data["choices"]) > 0
+
+    @pytest.mark.skipif(
+        not os.environ.get("MINIMAX_API_KEY"),
+        reason="MINIMAX_API_KEY not set",
+    )
+    def test_minimax_highspeed_model_responds(self):
+        """Verify M2.7-highspeed variant is also accessible."""
+        import json
+        import urllib.request
+
+        config = get_minimax_chat_bot_config()
+        url = config["base_url"].rstrip("/") + "/chat/completions"
+        payload = json.dumps(
+            {
+                "model": "MiniMax-M2.7-highspeed",
+                "messages": [{"role": "user", "content": "Reply OK"}],
+                "max_tokens": 4,
+                "temperature": 0.1,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {config['api_key']}",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+        assert "choices" in data

--- a/tests/pipelines/test_minimax_llm_config.py
+++ b/tests/pipelines/test_minimax_llm_config.py
@@ -93,15 +93,17 @@ class TestGetMinimaxChatBotConfig:
         config = get_minimax_chat_bot_config(api_key="k")
         assert "minimax" in config["base_url"]
 
-    def test_default_model_is_m27(self):
+    def test_default_model_is_m3(self):
         config = get_minimax_chat_bot_config(api_key="k")
-        assert config["model_name"] == "MiniMax-M2.7"
+        assert config["model_name"] == "MiniMax-M3"
 
     def test_minimax_models_registry(self):
+        assert "MiniMax-M3" in MINIMAX_MODELS
         assert "MiniMax-M2.7" in MINIMAX_MODELS
         assert "MiniMax-M2.7-highspeed" in MINIMAX_MODELS
-        for ctx in MINIMAX_MODELS.values():
-            assert ctx == 204_800
+        assert MINIMAX_MODELS["MiniMax-M3"] == 512_000
+        assert MINIMAX_MODELS["MiniMax-M2.7"] == 204_800
+        assert MINIMAX_MODELS["MiniMax-M2.7-highspeed"] == 204_800
 
     def test_config_module_name_is_chat_bot(self):
         config = get_minimax_chat_bot_config(api_key="k")


### PR DESCRIPTION
## Summary

Add [MiniMax Cloud](https://www.minimax.io/) as an alternative LLM provider for the **PP-ChatOCRv4** and **PP-DocTranslation** pipelines, alongside the existing Qianfan (ERNIE) support. The default model is **MiniMax-M3** (512K context window, 128K max output, image input).

### What's Changed

- **New `llm_config.py` module**: Shared helper `get_minimax_chat_bot_config()` that builds a `chat_bot_config` dict for MiniMax's OpenAI-compatible API (default `MiniMax-M3`)
- **CLI integration**: Added `--minimax_api_key` argument to both `pp_chatocrv4_doc` and `pp_doctranslation` CLI subcommands
- **Environment variable support**: API key can also be set via `MINIMAX_API_KEY` env var (more secure than CLI)
- **Priority handling**: When both `--minimax_api_key` and `--qianfan_api_key` are provided, MiniMax takes precedence
- **Documentation**: Updated both English and Chinese docs for PP-ChatOCRv4 and PP-DocTranslation with MiniMax usage examples (CLI and Python API)

### Available MiniMax Models

| Model | Context Window | Max Output |
|-------|---------------|------------|
| MiniMax-M3 (default) | 512K tokens | 128K tokens |
| MiniMax-M2.7 | 204K tokens | — |
| MiniMax-M2.7-highspeed | 204K tokens | — |

`MiniMax-M3` is the latest model, with a 512K context window, up to 128K output, and image input support.

### Usage

**CLI:**

```bash
# PP-ChatOCRv4
paddleocr pp_chatocrv4_doc -i input.pdf -k field --minimax_api_key YOUR_KEY

# PP-DocTranslation
paddleocr pp_doctranslation -i input.pdf --target_language en --minimax_api_key YOUR_KEY
```

**Python API:**

```python
from paddleocr._pipelines.llm_config import get_minimax_chat_bot_config

chat_bot_config = get_minimax_chat_bot_config()  # reads MINIMAX_API_KEY env var
# Or pass api_key explicitly:
# chat_bot_config = get_minimax_chat_bot_config(api_key="YOUR_KEY")
```

### Files Changed (8 files)

| File | Change |
|------|--------|
| `paddleocr/_pipelines/llm_config.py` | New: MiniMax config helper, default `MiniMax-M3` |
| `paddleocr/_pipelines/pp_chatocrv4_doc.py` | Add `--minimax_api_key` CLI arg |
| `paddleocr/_pipelines/pp_doctranslation.py` | Add `--minimax_api_key` CLI arg |
| `tests/pipelines/test_minimax_llm_config.py` | 10 unit + 2 integration tests (asserts M3 default) |
| `docs/.../PP-ChatOCRv4.en.md` | English docs update |
| `docs/.../PP-ChatOCRv4.md` | Chinese docs update |
| `docs/.../PP-DocTranslation.en.md` | English docs update |
| `docs/.../PP-DocTranslation.md` | Chinese docs update |

## Test Plan

- [x] 10 unit tests pass (config structure, env var fallback, key precedence, error handling, M3 default)
- [x] 2 integration tests pass (MiniMax M3 and M2.7-highspeed API smoke tests)
- [x] Existing pipeline tests unaffected (no changes to core pipeline logic)