### PR TITLE
Make doc preprocessing options configurable in MCP server

### DIFF
--- a/docs/version3.x/deployment/mcp_server.en.md
+++ b/docs/version3.x/deployment/mcp_server.en.md
@@ -84,8 +84,9 @@ Convert images containing formulas and tables to editable csv/Excel format:
     - [2.3 Working Modes Explained](#23-working-modes-explained)
     - [2.4 Using `uvx`](#24-using-uvx)
 - [3. Running the Server](#3-running-the-server)
-- [4. Parameter Reference](#4-parameter-reference)
-- [5. Known Limitations](#5-known-limitations)
+- [4. Tool Parameter Reference](#4-tool-parameter-reference)
+- [5. Server Parameter Reference](#5-server-parameter-reference)
+- [6. Known Limitations](#6-known-limitations)
 
 ## 1. Installation
 
@@ -163,7 +164,7 @@ This section explains how to use the PaddleOCR MCP server within Claude for Desk
 
     **Notes**:
 
-    - `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 4 for more details.
+    - `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 5 for more details.
     - `PADDLEOCR_MCP_PIPELINE_CONFIG` is optional; if not set, the default pipeline configuration will be used. If you need to adjust the configuration, such as changing the model, please refer to the [PaddleOCR documentation](../paddleocr_and_paddlex.md) to export the pipeline configuration file, and set `PADDLEOCR_MCP_PIPELINE_CONFIG` to the absolute path of this configuration file.
 
     - **Inference Performance Tips**:
@@ -215,8 +216,8 @@ This section explains how to use the PaddleOCR MCP server within Claude for Desk
 In the configuration file for Claude for Desktop, you need to define how the MCP server is started. The key fields are as follows:
 
 - `command`: `paddleocr_mcp` (if the executable can be found in the `PATH`) or the absolute path.
-- `args`: Configurable command-line arguments, such as `["--verbose"]`. See [4. Parameter Reference](#4-parameter-reference) for details.
-- `env`: Configurable environment variables. See [4. Parameter Reference](#4-parameter-reference) for details.
+- `args`: Configurable command-line arguments, such as `["--verbose"]`. See [5. Server Parameter Reference](#5-server-parameter-reference) for details.
+- `env`: Configurable environment variables. See [5. Server Parameter Reference](#5-server-parameter-reference) for details.
 
 ### 2.3 Working Modes Explained
 
@@ -257,7 +258,7 @@ Configuration example:
 
 **Notes**:
 
-- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 4 for more details.
+- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 5 for more details.
 - Replace `<your-server-url>` with your service base URL.
 - Replace `<your-access-token>` with your access token.
 
@@ -293,7 +294,7 @@ Configuration example:
 
 **Note**:
 
-- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 4 for more details. The Qianfan platform service currently only supports PP-StructureV3 and PaddleOCR-VL.
+- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 5 for more details. The Qianfan platform service currently only supports PP-StructureV3 and PaddleOCR-VL.
 
 #### Mode 4: Self-hosted Service
 
@@ -322,7 +323,7 @@ Configuration example:
 
 **Note**:
 
-- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 4 for more details.
+- `PADDLEOCR_MCP_PIPELINE` should be set to the pipeline name. See Section 5 for more details.
 - Replace `<your-server-url>` with your service’s base URL (e.g., `http://127.0.0.1:8000`).
 
 ### 2.4 Using `uvx`
@@ -402,9 +403,22 @@ paddleocr_mcp --pipeline PP-StructureV3 --ppocr_source local
 paddleocr_mcp --pipeline OCR --ppocr_source self_hosted --server_url http://127.0.0.1:8080 --http
 ```
 
-You can find all the supported parameters of the PaddleOCR MCP server in [4. Parameter Reference](#4-parameter-reference).
+You can find all the supported parameters of the PaddleOCR MCP server in [5. Server Parameter Reference](#5-server-parameter-reference).
 
-## 4. Parameter Reference
+## 4. Tool Parameter Reference
+
+In addition to server startup parameters, MCP tools support per-call parameters so that MCP hosts or agents can adjust processing behavior based on the current input.
+
+The `ocr`, `pp_structurev3`, and `paddleocr_vl` tools all support the following document preprocessing parameters:
+
+| Tool Parameter | Type | Default | Description |
+| -------------- | ---- | ------- | ----------- |
+| `use_doc_unwarping` | `bool` | `False` | Whether to enable document unwarping for this request. This can help with photographed, warped, or low-quality scanned documents. |
+| `use_doc_orientation_classify` | `bool` | `False` | Whether to enable document orientation classification for this request. This can help with documents whose orientation is unknown or rotated. |
+
+Both options default to `False` to preserve the existing behavior. Agents can decide whether to enable these preprocessing capabilities for each tool call instead of fixing them at MCP server startup.
+
+## 5. Server Parameter Reference
 
 You can control the MCP server via environment variables or CLI arguments.
 
@@ -422,7 +436,7 @@ You can control the MCP server via environment variables or CLI arguments.
 | -                                     | `--port`                  | `int`  | Port for the Streamable HTTP mode.                                                   | -                                        | `8000`        |
 | -                                     | `--verbose`               | `bool` | Enable verbose logging for debugging.                                               | -                                        | `False`       |
 
-## 5. Known Limitations
+## 6. Known Limitations
 
 - In the local Python library mode, the current tools cannot process PDF document inputs that are Base64 encoded.
 - In the local Python library mode, the current tools do not infer the file type based on the model's `file_type` prompt, and may fail to process some complex URLs.

--- a/docs/version3.x/deployment/mcp_server.md
+++ b/docs/version3.x/deployment/mcp_server.md
@@ -83,8 +83,9 @@ PaddleOCR 提供轻量级的 [Model Context Protocol（MCP）](https://modelcont
     - [2.3 工作模式说明](#23)
     - [2.4 使用 `uvx`](#24-uvx)
 - [3. 运行服务器](#3)
-- [4. 参数说明](#4)
-- [5. 已知局限性](#5)
+- [4. 工具参数说明](#4)
+- [5. 参数说明](#5)
+- [6. 已知局限性](#6)
 
 ## 1. 安装
 
@@ -183,8 +184,8 @@ paddleocr_mcp --help
 在 Claude for Desktop 的配置文件中，您需要定义 MCP 服务器的启动方式。关键字段如下：
 
 - `command`：`paddleocr_mcp`（如果可执行文件可在 `PATH` 中找到）或绝对路径。
-- `args`：可配置命令行参数，如 `["--verbose"]`。详见 [4. 参数说明](#4)。
-- `env`：可配置环境变量。详见 [4. 参数说明](#4)。
+- `args`：可配置命令行参数，如 `["--verbose"]`。详见 [5. 参数说明](#5)。
+- `env`：可配置环境变量。详见 [5. 参数说明](#5)。
 
 ### 2.3 工作模式说明
 
@@ -215,7 +216,7 @@ paddleocr_mcp --help
 
 **说明**：
 
-- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 4 节。
+- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 5 节。
 - `PADDLEOCR_MCP_PIPELINE_CONFIG` 为可选项，不设置时使用产线默认配置。如需调整配置，例如更换模型，请参考 [PaddleOCR 文档](../paddleocr_and_paddlex.md) 导出产线配置文件，并将 `PADDLEOCR_MCP_PIPELINE_CONFIG` 设置为配置文件的绝对路径。
 - **推理性能提示**：
 
@@ -256,7 +257,7 @@ paddleocr_mcp --help
 
 请参考 [2.1 快速开始](#21)。
 
-对于文字识别以外的任务，请在 PaddleOCR 官网获取任务对应的服务基础 URL，并正确设置 `PADDLEOCR_MCP_PIPELINE` 与 `PADDLEOCR_MCP_SERVER_URL`（参数说明详见第 4 节）。
+对于文字识别以外的任务，请在 PaddleOCR 官网获取任务对应的服务基础 URL，并正确设置 `PADDLEOCR_MCP_PIPELINE` 与 `PADDLEOCR_MCP_SERVER_URL`（参数说明详见第 5 节）。
 
 #### 模式三：千帆平台服务
 
@@ -286,7 +287,7 @@ paddleocr_mcp --help
 
 **说明**：
 
-- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 4 节。千帆平台服务目前仅支持 PP-StructureV3 和 PaddleOCR-VL。
+- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 5 节。千帆平台服务目前仅支持 PP-StructureV3 和 PaddleOCR-VL。
 
 #### 模式四：自托管服务
 
@@ -315,7 +316,7 @@ paddleocr_mcp --help
 
 **说明**：
 
-- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 4 节。
+- `PADDLEOCR_MCP_PIPELINE` 需要被设置为产线名称。详见第 5 节。
 - 将 `<your-server-url>` 替换为底层服务的基础 URL（如：`http://127.0.0.1:8000`）。
 
 ### 2.4 使用 `uvx`
@@ -395,9 +396,22 @@ paddleocr_mcp --pipeline PP-StructureV3 --ppocr_source local
 paddleocr_mcp --pipeline OCR --ppocr_source self_hosted --server_url http://127.0.0.1:8080 --http
 ```
 
-在 [4. 参数说明](#4) 中可以了解 PaddleOCR MCP 服务器支持的全部参数。
+在 [5. 参数说明](#5) 中可以了解 PaddleOCR MCP 服务器支持的全部参数。
 
-## 4. 参数说明
+## 4. 工具参数说明
+
+除服务器启动参数外，MCP 工具还支持在每次调用时传入参数，以便 MCP 主机或智能体根据当前输入动态调整处理方式。
+
+`ocr`、`pp_structurev3` 和 `paddleocr_vl` 工具均支持以下文档预处理参数：
+
+| 工具参数 | 类型 | 默认值 | 描述 |
+|:---------|:-----|:-------|:-----|
+| `use_doc_unwarping` | `bool` | `False` | 是否在本次调用中启用文档图像矫正。对于拍照、弯曲或质量较差的扫描文档可能有帮助。 |
+| `use_doc_orientation_classify` | `bool` | `False` | 是否在本次调用中启用文档方向分类。对于方向不确定或发生旋转的文档可能有帮助。 |
+
+这两个参数默认均为 `False`，以保持原有行为不变。智能体可以根据具体文档情况决定是否在某次工具调用中开启这些预处理能力，而无需在 MCP 服务器启动时固定配置。
+
+## 5. 参数说明
 
 您可以通过环境变量或命令行参数来控制 MCP 服务器的行为。
 
@@ -415,7 +429,7 @@ paddleocr_mcp --pipeline OCR --ppocr_source self_hosted --server_url http://127.
 | - | `--port` | `int` | Streamable HTTP 模式的端口。 | - | `8000` |
 | - | `--verbose` | `bool` | 启用详细日志记录，便于调试。 | - | `False` |
 
-## 5. 已知局限性
+## 6. 已知局限性
 
 - 在本地 Python 库模式下，当前提供的工具无法处理 Base64 编码的 PDF 文档输入。
 - 在本地 Python 库模式下，当前提供的工具不会根据模型提示的 `file_type` 推断文件类型，对于一些复杂 URL 可能处理失败。

--- a/mcp_server/paddleocr_mcp/__main__.py
+++ b/mcp_server/paddleocr_mcp/__main__.py
@@ -97,21 +97,6 @@ def _parse_args() -> argparse.Namespace:
         help="HTTP read timeout in seconds for API requests to the underlying server.",
     )
 
-    # Document preprocessing options
-    parser.add_argument(
-        "--use_doc_orientation_classify",
-        action="store_true",
-        default=os.getenv("PADDLEOCR_MCP_USE_DOC_ORIENTATION_CLASSIFY", "").lower()
-        == "true",
-        help="Enable document orientation classification.",
-    )
-    parser.add_argument(
-        "--use_doc_unwarping",
-        action="store_true",
-        default=os.getenv("PADDLEOCR_MCP_USE_DOC_UNWARPING", "").lower() == "true",
-        help="Enable document unwarping.",
-    )
-
     args = parser.parse_args()
     return args
 
@@ -176,8 +161,6 @@ async def async_main() -> None:
             aistudio_access_token=args.aistudio_access_token,
             qianfan_api_key=args.qianfan_api_key,
             timeout=args.timeout,
-            use_doc_orientation_classify=args.use_doc_orientation_classify,
-            use_doc_unwarping=args.use_doc_unwarping,
         )
     except Exception as e:
         print(f"Failed to create the pipeline handler: {e}", file=sys.stderr)

--- a/mcp_server/paddleocr_mcp/__main__.py
+++ b/mcp_server/paddleocr_mcp/__main__.py
@@ -97,6 +97,21 @@ def _parse_args() -> argparse.Namespace:
         help="HTTP read timeout in seconds for API requests to the underlying server.",
     )
 
+    # Document preprocessing options
+    parser.add_argument(
+        "--use_doc_orientation_classify",
+        action="store_true",
+        default=os.getenv("PADDLEOCR_MCP_USE_DOC_ORIENTATION_CLASSIFY", "").lower()
+        == "true",
+        help="Enable document orientation classification.",
+    )
+    parser.add_argument(
+        "--use_doc_unwarping",
+        action="store_true",
+        default=os.getenv("PADDLEOCR_MCP_USE_DOC_UNWARPING", "").lower() == "true",
+        help="Enable document unwarping.",
+    )
+
     args = parser.parse_args()
     return args
 
@@ -161,6 +176,8 @@ async def async_main() -> None:
             aistudio_access_token=args.aistudio_access_token,
             qianfan_api_key=args.qianfan_api_key,
             timeout=args.timeout,
+            use_doc_orientation_classify=args.use_doc_orientation_classify,
+            use_doc_unwarping=args.use_doc_unwarping,
         )
     except Exception as e:
         print(f"Failed to create the pipeline handler: {e}", file=sys.stderr)

--- a/mcp_server/paddleocr_mcp/pipelines.py
+++ b/mcp_server/paddleocr_mcp/pipelines.py
@@ -140,8 +140,6 @@ class PipelineHandler(abc.ABC):
         aistudio_access_token: Optional[str],
         qianfan_api_key: Optional[str],
         timeout: Optional[int],
-        use_doc_orientation_classify: bool = False,
-        use_doc_unwarping: bool = False,
     ) -> None:
         """Initialize the pipeline handler.
 
@@ -154,8 +152,6 @@ class PipelineHandler(abc.ABC):
             aistudio_access_token: AI Studio access token.
             qianfan_api_key: Qianfan API key.
             timeout: Read timeout in seconds for HTTP requests.
-            use_doc_orientation_classify: Enable document orientation classification.
-            use_doc_unwarping: Enable document unwarping.
         """
         self._pipeline = pipeline
         if ppocr_source == "local":
@@ -171,8 +167,6 @@ class PipelineHandler(abc.ABC):
         self._aistudio_access_token = aistudio_access_token
         self._qianfan_api_key = qianfan_api_key
         self._timeout = timeout or 60
-        self._use_doc_orientation_classify = use_doc_orientation_classify
-        self._use_doc_unwarping = use_doc_unwarping
 
         if self._mode == "local":
             if not LOCAL_OCR_AVAILABLE:
@@ -534,6 +528,8 @@ class OCRHandler(SimpleInferencePipelineHandler):
             input_data: str,
             output_mode: OutputMode = "simple",
             file_type: Optional[str] = None,
+            use_doc_unwarping: bool = False,
+            use_doc_orientation_classify: bool = False,
             *,
             ctx: Context,
         ) -> Union[str, List[Union[TextContent, ImageContent]]]:
@@ -548,11 +544,22 @@ class OCRHandler(SimpleInferencePipelineHandler):
                     - "image": For image files
                     - "pdf": For PDF documents
                     - None: For unknown file types
+                use_doc_unwarping: Whether to enable document unwarping for this request. Useful for photographed, warped, or low-quality scanned documents.
+                use_doc_orientation_classify: Whether to enable document orientation classification for this request. Useful for rotated documents.
             """
             await ctx.info(
                 f"--- OCR tool received `input_data`: {get_str_with_max_len(input_data, 50)} ---"
             )
-            return await self.process(input_data, output_mode, ctx, file_type)
+            return await self.process(
+                input_data,
+                output_mode,
+                ctx,
+                file_type,
+                infer_kwargs={
+                    "use_doc_unwarping": use_doc_unwarping,
+                    "use_doc_orientation_classify": use_doc_orientation_classify,
+                },
+            )
 
     def _create_local_engine(self) -> Any:
         return PaddleOCR(
@@ -565,14 +572,18 @@ class OCRHandler(SimpleInferencePipelineHandler):
 
     def _transform_local_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "use_doc_unwarping": self._use_doc_unwarping,
-            "use_doc_orientation_classify": self._use_doc_orientation_classify,
+            "use_doc_unwarping": kwargs.get("use_doc_unwarping", False),
+            "use_doc_orientation_classify": kwargs.get(
+                "use_doc_orientation_classify", False
+            ),
         }
 
     def _transform_service_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "useDocUnwarping": self._use_doc_unwarping,
-            "useDocOrientationClassify": self._use_doc_orientation_classify,
+            "useDocUnwarping": kwargs.get("use_doc_unwarping", False),
+            "useDocOrientationClassify": kwargs.get(
+                "use_doc_orientation_classify", False
+            ),
         }
 
     async def _parse_local_result(self, local_result: Dict, ctx: Context) -> Dict:
@@ -674,14 +685,18 @@ class _LayoutParsingHandler(SimpleInferencePipelineHandler):
 
     def _transform_local_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "use_doc_unwarping": self._use_doc_unwarping,
-            "use_doc_orientation_classify": self._use_doc_orientation_classify,
+            "use_doc_unwarping": kwargs.get("use_doc_unwarping", False),
+            "use_doc_orientation_classify": kwargs.get(
+                "use_doc_orientation_classify", False
+            ),
         }
 
     def _transform_service_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "useDocUnwarping": self._use_doc_unwarping,
-            "useDocOrientationClassify": self._use_doc_orientation_classify,
+            "useDocUnwarping": kwargs.get("use_doc_unwarping", False),
+            "useDocOrientationClassify": kwargs.get(
+                "use_doc_orientation_classify", False
+            ),
         }
 
     async def _parse_local_result(self, local_result: Dict, ctx: Context) -> Dict:
@@ -854,6 +869,8 @@ class PPStructureV3Handler(_LayoutParsingHandler):
             output_mode: OutputMode = "simple",
             file_type: Optional[str] = None,
             return_images: bool = True,
+            use_doc_unwarping: bool = False,
+            use_doc_orientation_classify: bool = False,
             *,
             ctx: Context,
         ) -> Union[str, List[Union[TextContent, ImageContent]]]:
@@ -869,12 +886,18 @@ class PPStructureV3Handler(_LayoutParsingHandler):
                     - "pdf": For PDF documents
                     - None: For unknown file types
                 return_images: Whether to return the images extracted from the document.
+                use_doc_unwarping: Whether to enable document unwarping for this request. Useful for photographed, warped, or low-quality scanned documents.
+                use_doc_orientation_classify: Whether to enable document orientation classification for this request. Useful for rotated documents.
             """
             return await self.process(
                 input_data,
                 output_mode,
                 ctx,
                 file_type,
+                infer_kwargs={
+                    "use_doc_unwarping": use_doc_unwarping,
+                    "use_doc_orientation_classify": use_doc_orientation_classify,
+                },
                 format_kwargs={"return_images": return_images},
             )
 
@@ -899,6 +922,8 @@ class PaddleOCRVLHandler(_LayoutParsingHandler):
             output_mode: OutputMode = "simple",
             file_type: Optional[str] = None,
             return_images: bool = True,
+            use_doc_unwarping: bool = False,
+            use_doc_orientation_classify: bool = False,
             *,
             ctx: Context,
         ) -> Union[str, List[Union[TextContent, ImageContent]]]:
@@ -914,12 +939,18 @@ class PaddleOCRVLHandler(_LayoutParsingHandler):
                     - "pdf": For PDF documents
                     - None: For unknown file types
                 return_images: Whether to return the images extracted from the document.
+                use_doc_unwarping: Whether to enable document unwarping for this request. Useful for photographed, warped, or low-quality scanned documents.
+                use_doc_orientation_classify: Whether to enable document orientation classification for this request. Useful for rotated documents.
             """
             return await self.process(
                 input_data,
                 output_mode,
                 ctx,
                 file_type,
+                infer_kwargs={
+                    "use_doc_unwarping": use_doc_unwarping,
+                    "use_doc_orientation_classify": use_doc_orientation_classify,
+                },
                 format_kwargs={"return_images": return_images},
             )
 

--- a/mcp_server/paddleocr_mcp/pipelines.py
+++ b/mcp_server/paddleocr_mcp/pipelines.py
@@ -140,6 +140,8 @@ class PipelineHandler(abc.ABC):
         aistudio_access_token: Optional[str],
         qianfan_api_key: Optional[str],
         timeout: Optional[int],
+        use_doc_orientation_classify: bool = False,
+        use_doc_unwarping: bool = False,
     ) -> None:
         """Initialize the pipeline handler.
 
@@ -152,6 +154,8 @@ class PipelineHandler(abc.ABC):
             aistudio_access_token: AI Studio access token.
             qianfan_api_key: Qianfan API key.
             timeout: Read timeout in seconds for HTTP requests.
+            use_doc_orientation_classify: Enable document orientation classification.
+            use_doc_unwarping: Enable document unwarping.
         """
         self._pipeline = pipeline
         if ppocr_source == "local":
@@ -167,6 +171,8 @@ class PipelineHandler(abc.ABC):
         self._aistudio_access_token = aistudio_access_token
         self._qianfan_api_key = qianfan_api_key
         self._timeout = timeout or 60
+        self._use_doc_orientation_classify = use_doc_orientation_classify
+        self._use_doc_unwarping = use_doc_unwarping
 
         if self._mode == "local":
             if not LOCAL_OCR_AVAILABLE:
@@ -559,14 +565,14 @@ class OCRHandler(SimpleInferencePipelineHandler):
 
     def _transform_local_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "use_doc_unwarping": False,
-            "use_doc_orientation_classify": False,
+            "use_doc_unwarping": self._use_doc_unwarping,
+            "use_doc_orientation_classify": self._use_doc_orientation_classify,
         }
 
     def _transform_service_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "useDocUnwarping": False,
-            "useDocOrientationClassify": False,
+            "useDocUnwarping": self._use_doc_unwarping,
+            "useDocOrientationClassify": self._use_doc_orientation_classify,
         }
 
     async def _parse_local_result(self, local_result: Dict, ctx: Context) -> Dict:
@@ -668,14 +674,14 @@ class _LayoutParsingHandler(SimpleInferencePipelineHandler):
 
     def _transform_local_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "use_doc_unwarping": False,
-            "use_doc_orientation_classify": False,
+            "use_doc_unwarping": self._use_doc_unwarping,
+            "use_doc_orientation_classify": self._use_doc_orientation_classify,
         }
 
     def _transform_service_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "useDocUnwarping": False,
-            "useDocOrientationClassify": False,
+            "useDocUnwarping": self._use_doc_unwarping,
+            "useDocOrientationClassify": self._use_doc_orientation_classify,
         }
 
     async def _parse_local_result(self, local_result: Dict, ctx: Context) -> Dict:

--- a/mcp_server/tests/test_doc_preprocessing_options.py
+++ b/mcp_server/tests/test_doc_preprocessing_options.py
@@ -1,0 +1,65 @@
+from paddleocr_mcp.pipelines import OCRHandler, PPStructureV3Handler
+
+
+def test_ocr_transforms_doc_preprocessing_options_per_call():
+    handler = object.__new__(OCRHandler)
+
+    local_kwargs = handler._transform_local_kwargs(
+        {
+            "use_doc_unwarping": True,
+            "use_doc_orientation_classify": True,
+        }
+    )
+    service_kwargs = handler._transform_service_kwargs(
+        {
+            "use_doc_unwarping": True,
+            "use_doc_orientation_classify": True,
+        }
+    )
+
+    assert local_kwargs == {
+        "use_doc_unwarping": True,
+        "use_doc_orientation_classify": True,
+    }
+    assert service_kwargs == {
+        "useDocUnwarping": True,
+        "useDocOrientationClassify": True,
+    }
+
+
+def test_layout_parsing_transforms_doc_preprocessing_options_per_call():
+    handler = object.__new__(PPStructureV3Handler)
+    handler._ppocr_source = "self_hosted"
+
+    local_kwargs = handler._transform_local_kwargs(
+        {
+            "use_doc_unwarping": True,
+            "use_doc_orientation_classify": False,
+        }
+    )
+    service_kwargs = handler._transform_service_kwargs(
+        {
+            "use_doc_unwarping": True,
+            "use_doc_orientation_classify": False,
+        }
+    )
+
+    assert local_kwargs == {
+        "use_doc_unwarping": True,
+        "use_doc_orientation_classify": False,
+    }
+    assert service_kwargs["useDocUnwarping"] is True
+    assert service_kwargs["useDocOrientationClassify"] is False
+
+
+def test_doc_preprocessing_options_default_to_false_per_call():
+    handler = object.__new__(OCRHandler)
+
+    assert handler._transform_local_kwargs({}) == {
+        "use_doc_unwarping": False,
+        "use_doc_orientation_classify": False,
+    }
+    assert handler._transform_service_kwargs({}) == {
+        "useDocUnwarping": False,
+        "useDocOrientationClassify": False,
+    }


### PR DESCRIPTION
## Summary

Add `--use_doc_orientation_classify` and `--use_doc_unwarping` CLI arguments (and corresponding `PADDLEOCR_MCP_USE_DOC_ORIENTATION_CLASSIFY` / `PADDLEOCR_MCP_USE_DOC_UNWARPING` environment variables) to the MCP server.

Previously these options were hardcoded to `False` with no way for users to override them. The default remains `False` to preserve backward compatibility.

## Problem

When processing scanned PDF documents via the MCP server in service mode (`aistudio`, `self_hosted`), layout detection can miss entire text blocks — lines are silently dropped from the output with no error or warning. Enabling `useDocUnwarping` and `useDocOrientationClassify` in the API request resolves the issue.

Since these options are hardcoded to `False` and not exposed as configuration, users have no way to work around this without patching the source code.

Related: #17164

## Usage

```bash
# Via environment variables
PADDLEOCR_MCP_USE_DOC_UNWARPING=true paddleocr_mcp ...

# Via CLI arguments
paddleocr_mcp --use_doc_unwarping --use_doc_orientation_classify ...
```

## Changes

- `mcp_server/paddleocr_mcp/__main__.py`: Add two new CLI arguments with env var fallbacks
- `mcp_server/paddleocr_mcp/pipelines.py`: Replace hardcoded `False` with configurable instance variables