### PR TITLE
Add developer onboarding documentation

### DIFF
--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,0 +1,67 @@
+# PaddleOCR Developer Onboarding
+
+Welcome! This documentation is designed for software engineers who are new to
+OCR (Optical Character Recognition) and PaddleOCR. It covers everything you
+need to understand the project architecture and start contributing.
+
+## Reading Order
+
+Start from the top and work your way down. Each document builds on the previous.
+
+1. **[OCR Fundamentals](ocr-fundamentals.md)** — What OCR is, how detection
+   and recognition work, key algorithms and metrics. Start here if you have
+   zero OCR background.
+2. **[Architecture Deep Dive](architecture.md)** — PaddleOCR's two-layer
+   design: the high-level pipeline API (`paddleocr/`) and the core ML
+   framework (`ppocr/`). Covers the config system, data pipeline, and model
+   composition.
+3. **[Codebase Map](codebase-map.md)** — Quick-reference directory guide.
+   Skim once, return often.
+4. **[Adding Models](adding-models.md)** — Step-by-step guide for adding a
+   new backbone, head, neck, loss, or complete model configuration.
+5. **[Training & Evaluation](training-evaluation.md)** — How to train models,
+   prepare data, run evaluation, and interpret metrics.
+6. **[Deployment & Export](deployment-export.md)** — Exporting trained models,
+   high-performance inference, ONNX, serving, mobile, and Docker deployment.
+7. **[Testing & Debugging](testing-debugging.md)** — Running the test suite,
+   test patterns, debugging common training and inference issues.
+
+## Quick Links
+
+| I want to...                        | Go to                                          |
+|-------------------------------------|-------------------------------------------------|
+| Understand what OCR is              | [OCR Fundamentals](ocr-fundamentals.md)         |
+| Learn how the code is structured    | [Architecture](architecture.md)                 |
+| Find where a specific file lives    | [Codebase Map](codebase-map.md)                 |
+| Add a new backbone or head          | [Adding Models](adding-models.md)               |
+| Train or fine-tune a model          | [Training & Evaluation](training-evaluation.md) |
+| Deploy a model to production        | [Deployment & Export](deployment-export.md)      |
+| Run tests or debug an issue         | [Testing & Debugging](testing-debugging.md)      |
+
+## Prerequisites
+
+- **Python** 3.8 - 3.13
+- **PaddlePaddle** 3.x (GPU version recommended for training)
+- **Git** for version control
+- A basic understanding of deep learning concepts (CNNs, loss functions,
+  gradient descent) is helpful but not required — the OCR Fundamentals
+  doc covers OCR-specific concepts from scratch.
+
+Install PaddlePaddle:
+
+```bash
+# GPU (CUDA 12.6)
+python -m pip install paddlepaddle-gpu==3.2.1
+
+# CPU only
+python -m pip install paddlepaddle==3.2.1
+```
+
+Install PaddleOCR:
+
+```bash
+python -m pip install paddleocr
+
+# With document parsing (VLM) support
+python -m pip install "paddleocr[doc-parser]"
+```

--- a/docs/onboarding/adding-models.md
+++ b/docs/onboarding/adding-models.md
@@ -1,0 +1,327 @@
+# Adding Models
+
+Step-by-step guide for adding new components to PaddleOCR's Layer 2 core ML
+framework. Read [Architecture](architecture.md) first to understand the
+four-component model pattern and the dynamic instantiation system.
+
+## Overview
+
+"Adding a model" in PaddleOCR means adding one or more of these components:
+
+| Component       | Directory                         | Registry file              |
+|-----------------|-----------------------------------|----------------------------|
+| Backbone        | `ppocr/modeling/backbones/`       | `backbones/__init__.py`    |
+| Neck            | `ppocr/modeling/necks/`           | `necks/__init__.py`        |
+| Head            | `ppocr/modeling/heads/`           | `heads/__init__.py`        |
+| Loss            | `ppocr/losses/`                   | `losses/__init__.py`       |
+| Post-processor  | `ppocr/postprocess/`              | `postprocess/__init__.py`  |
+| Metric          | `ppocr/metrics/`                  | `metrics/__init__.py`      |
+
+All components follow the same registration pattern. Once registered, they
+are selected by name in YAML config files.
+
+---
+
+## The Registration Pattern
+
+Every component type uses the same pattern for dynamic instantiation:
+
+```
+YAML config                    __init__.py                    Python class
+───────────                    ───────────                    ────────────
+
+Backbone:            ──>    build_backbone(config, model_type)
+  name: MobileNetV3              │
+  scale: 0.5                     ├── 1. Pop "name" from config
+                                 ├── 2. Assert name in support_dict
+                                 ├── 3. eval("MobileNetV3")(scale=0.5)
+                                 │
+                                 v
+                            MobileNetV3 instance
+                            with self.out_channels set
+```
+
+This means:
+1. Your class name in Python must **exactly match** the `name` field in YAML
+2. Your class must be **imported** in the `__init__.py` where `eval()` runs
+3. Your class name must be **listed** in the `support_dict` list
+4. All remaining config keys (after `name` is popped) are passed as
+   `**kwargs` to your constructor
+
+---
+
+## Adding a New Backbone
+
+### Step 1: Create the Implementation File
+
+Create a file in `ppocr/modeling/backbones/`. Follow the naming convention:
+`{task}_{name}.py` (e.g., `det_my_backbone.py` or `rec_my_backbone.py`).
+
+Your backbone must:
+- Inherit from `paddle.nn.Layer`
+- Accept `in_channels` as a constructor parameter
+- Set `self.out_channels` (critical for the in_channels threading chain)
+
+```python
+# ppocr/modeling/backbones/det_my_backbone.py
+
+import paddle
+import paddle.nn as nn
+
+class MyBackbone(nn.Layer):
+    def __init__(self, in_channels, num_features=256, **kwargs):
+        super().__init__()
+        self.out_channels = num_features  # REQUIRED: next component reads this
+        # ... build your layers ...
+
+    def forward(self, x):
+        # x shape: (batch, in_channels, H, W)
+        # return: feature maps or dict of feature maps
+        return x
+```
+
+### Step 2: Register in `__init__.py`
+
+Edit `ppocr/modeling/backbones/__init__.py`. You must:
+1. Add an import in the correct `model_type` branch
+2. Add the class name to the `support_dict` list
+
+```python
+def build_backbone(config, model_type):
+    if model_type == "det" or model_type == "table":
+        from .det_mobilenet_v3 import MobileNetV3
+        from .det_my_backbone import MyBackbone    # <-- ADD IMPORT
+        # ...
+        support_dict = [
+            "MobileNetV3",
+            "MyBackbone",    # <-- ADD TO LIST
+            # ...
+        ]
+```
+
+**Important: model_type gating.** The backbone is only available for the
+model_type branch where you register it. If you register under `det`, it
+will NOT be available when `model_type` is `rec`. Register in multiple
+branches if needed.
+
+### Step 3: Create a Config File
+
+Create a YAML config in `configs/det/` (or the appropriate task directory):
+
+```yaml
+Architecture:
+  model_type: det
+  algorithm: DB
+  Backbone:
+    name: MyBackbone           # Must match class name exactly
+    num_features: 256          # Passed as kwargs to constructor
+  Neck:
+    name: DBFPN
+    out_channels: 256
+  Head:
+    name: DBHead
+    k: 50
+# ... Loss, Optimizer, PostProcess, Metric, Train, Eval sections ...
+```
+
+### Step 4: Smoke Test
+
+```bash
+# Quick training test (will fail on data if you don't have ICDAR, but
+# verifies the model builds correctly)
+python tools/train.py -c configs/det/my_config.yml \
+    -o Global.epoch_num=1 \
+    -o Global.save_model_dir=./output/test/
+```
+
+---
+
+## Adding a New Head
+
+Same pattern as backbones, but in `ppocr/modeling/heads/`:
+
+1. Create `ppocr/modeling/heads/det_my_head.py` (or `rec_my_head.py`)
+2. Must accept `in_channels` as constructor parameter
+3. Import and add to `support_dict` in `ppocr/modeling/heads/__init__.py`
+
+```python
+# ppocr/modeling/heads/det_my_head.py
+class MyDetHead(nn.Layer):
+    def __init__(self, in_channels, **kwargs):
+        super().__init__()
+        # ... build layers using in_channels ...
+```
+
+Heads do NOT need `out_channels` since they are the last component in the
+chain.
+
+Note: `build_head` does NOT use model_type gating — all heads are available
+regardless of task type. But by convention, detection heads start with `det_`
+and recognition heads with `rec_`.
+
+---
+
+## Adding a New Neck
+
+Same pattern in `ppocr/modeling/necks/`:
+
+1. Create `ppocr/modeling/necks/my_neck.py`
+2. Must accept `in_channels` and set `self.out_channels`
+3. Import and add to `support_dict` in `ppocr/modeling/necks/__init__.py`
+
+---
+
+## Adding a New Loss Function
+
+In `ppocr/losses/`:
+
+1. Create `ppocr/losses/my_loss.py`
+2. Inherit from `paddle.nn.Layer`
+3. Implement `forward(self, predicts, batch)` returning a dict with a
+   `"loss"` key
+4. Import and add to `support_dict` in `ppocr/losses/__init__.py`
+
+```python
+# ppocr/losses/my_loss.py
+class MyLoss(nn.Layer):
+    def __init__(self, alpha=1.0, **kwargs):
+        super().__init__()
+        self.alpha = alpha
+
+    def forward(self, predicts, batch):
+        # predicts: model output (dict or tensor)
+        # batch: ground truth data from dataloader
+        loss = ...
+        return {"loss": loss}
+```
+
+Config:
+```yaml
+Loss:
+  name: MyLoss
+  alpha: 2.0
+```
+
+---
+
+## Adding a New Post-Processor
+
+In `ppocr/postprocess/`:
+
+1. Create or add to a file in `ppocr/postprocess/`
+2. Implement `__call__(self, preds, label=None, *args, **kwargs)`
+3. Import and add to `support_dict` in `ppocr/postprocess/__init__.py`
+
+Post-processors convert raw model output (logits, probability maps) into
+human-readable results (text strings, polygon coordinates).
+
+---
+
+## Adding a New Metric
+
+In `ppocr/metrics/`:
+
+1. Create `ppocr/metrics/my_metric.py`
+2. Implement `__call__(self, preds, batch)` that accumulates results
+3. Implement `get_metric(self)` that returns the final metric dict
+4. Import and add to `support_dict` in `ppocr/metrics/__init__.py`
+
+The metric dict must include the key specified by `main_indicator` in the
+config (e.g., `hmean` for detection, `acc` for recognition).
+
+---
+
+## Creating a Complete Model Configuration
+
+To create a full config from scratch, use an existing config as a template.
+`configs/det/det_mv3_db.yml` is the simplest complete detection config.
+
+Checklist for a new config:
+
+- [ ] `Architecture.model_type` matches where your backbone is registered
+- [ ] `Architecture.algorithm` is set (used for algorithm-specific logic in
+      the training loop)
+- [ ] All component `name` fields exactly match Python class names
+- [ ] `Loss.name` matches a registered loss class
+- [ ] `PostProcess.name` matches a registered post-processor
+- [ ] `Metric.name` and `main_indicator` are set correctly
+- [ ] `Train.dataset` and `Eval.dataset` point to valid data
+- [ ] Transform pipeline is appropriate for your task
+
+---
+
+## The `extra_input_models` List (Critical Gotcha)
+
+The training loop in `tools/program.py` has a hardcoded list called
+`extra_input_models` (around line 267). Algorithms in this list pass extra
+data to the model during the forward pass:
+
+```python
+extra_input_models = [
+    "SRN", "NRTR", "SAR", "SEED", "SVTR", "SVTR_LCNet", "VisionLAN",
+    "RobustScanner", "SPIN", "ABINet", "CPPD", "SATRN", "ParseQ",
+    # ...
+]
+```
+
+If your new algorithm needs `data=batch[1:]` in the forward pass (i.e., it
+uses ground-truth labels during training beyond just the image), you **must**
+add your algorithm name to this list. Otherwise, only the image tensor will be
+passed to your model.
+
+Similarly, the training and evaluation functions have algorithm-specific
+branches for loss computation and metric evaluation. Check if your algorithm
+needs special handling.
+
+---
+
+## In-Channels Threading
+
+The four-component chain threads `in_channels` through each component:
+
+```
+in_channels = 3 (RGB input)
+       │
+       v
+[Transform]  reads in_channels=3,  sets out_channels=3
+       │
+       v
+[Backbone]   reads in_channels=3,  sets out_channels=256
+       │
+       v
+[Neck]       reads in_channels=256, sets out_channels=128
+       │
+       v
+[Head]       reads in_channels=128
+```
+
+If any component sets `out_channels` incorrectly, the next component
+receives the wrong `in_channels` and you get a shape mismatch error during
+the forward pass. Always verify `out_channels` is correct.
+
+For backbones that produce multi-scale features (common in detection),
+`out_channels` is typically a list (e.g., `[64, 128, 256, 512]`). The neck
+must handle this list format.
+
+---
+
+## Common Pitfalls
+
+1. **Class name mismatch**: `name: MyBackBone` in YAML but class is
+   `MyBackbone` in Python — the `eval()` call will fail.
+
+2. **Missing model_type registration**: You add a backbone for detection but
+   try to use it in a recognition config. Register in the correct branch of
+   `build_backbone`.
+
+3. **Missing out_channels**: Your backbone or neck does not set
+   `self.out_channels`. The next component in the chain gets `in_channels`
+   from the previous component's attribute.
+
+4. **Missing from extra_input_models**: Your model needs ground-truth data
+   during training but isn't listed in `tools/program.py:extra_input_models`.
+   Only the image tensor gets passed.
+
+5. **Config key naming**: After `name` is popped, all remaining keys are
+   passed as `**kwargs`. If your constructor parameter is `num_features` but
+   you write `features` in YAML, you get an unexpected keyword argument error.

--- a/docs/onboarding/architecture.md
+++ b/docs/onboarding/architecture.md
@@ -1,0 +1,590 @@
+# PaddleOCR Architecture
+
+This document explains the internal architecture of PaddleOCR. It covers
+the two-layer design, model composition, the configuration system, and the
+data pipeline.
+
+## Two-Layer Architecture Overview
+
+PaddleOCR has two distinct layers of code that serve different purposes:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Layer 1: Pipeline API  (paddleocr/)                               │
+│                                                                     │
+│  User-facing Python API and CLI. Clean 2025-era code using ABCs.   │
+│  Wraps PaddleX for model management and inference orchestration.   │
+│                                                                     │
+│  Entry: paddleocr/__init__.py                                       │
+│  Key:   PaddleOCR, PPStructureV3, PaddleOCRVL, CLI subcommands    │
+├─────────────────────────────────────────────────────────────────────┤
+│  PaddleX  (external dependency)                                     │
+│                                                                     │
+│  Model registry, download, inference engine, pipeline orchestration │
+│  Lives outside this repo — treat as a black box                     │
+├─────────────────────────────────────────────────────────────────────┤
+│  Layer 2: Core ML Framework  (ppocr/)                               │
+│                                                                     │
+│  Model definitions, training loop, losses, metrics, data pipeline.  │
+│  Original 2020-era code using eval()-based dynamic instantiation.   │
+│                                                                     │
+│  Entry: tools/train.py, tools/eval.py, tools/export_model.py       │
+│  Key:   BaseModel, build_backbone/neck/head, YAML configs          │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**When to use which layer:**
+
+| Task                           | Layer   | Entry point                      |
+|--------------------------------|---------|----------------------------------|
+| Run inference on an image      | Layer 1 | `PaddleOCR().predict("img.jpg")` |
+| Deploy to production           | Layer 1 | `paddleocr ocr --input img.jpg`  |
+| Train a model                  | Layer 2 | `python tools/train.py -c ...`   |
+| Add a new model component      | Layer 2 | Edit `ppocr/modeling/`           |
+| Evaluate a checkpoint          | Layer 2 | `python tools/eval.py -c ...`    |
+| Export for deployment           | Layer 2 | `python tools/export_model.py`   |
+
+---
+
+## Layer 1: Pipeline API (`paddleocr/`)
+
+### Entry Point
+
+`paddleocr/__init__.py` exports everything users interact with:
+
+**13 model classes** (each wraps a single PaddleX predictor):
+
+| Class                              | Task                             |
+|------------------------------------|----------------------------------|
+| `TextDetection`                    | Locate text regions              |
+| `TextRecognition`                  | Read text from cropped regions   |
+| `TextLineOrientationClassification`| Classify text line rotation      |
+| `DocImgOrientationClassification`  | Classify document page rotation  |
+| `TextImageUnwarping`               | Correct perspective distortion   |
+| `LayoutDetection`                  | Detect document layout regions   |
+| `TableStructureRecognition`        | Parse table structure            |
+| `TableCellsDetection`             | Detect table cell boundaries     |
+| `TableClassification`             | Classify table type (wired/wireless) |
+| `FormulaRecognition`              | Convert formula images to LaTeX  |
+| `SealTextDetection`               | Detect text in seal stamps       |
+| `ChartParsing`                    | Parse chart images               |
+| `DocVLM`                          | Vision-Language document parsing |
+
+**10 pipeline classes** (each orchestrates multiple models):
+
+| Class                       | Pipeline                                 |
+|-----------------------------|------------------------------------------|
+| `PaddleOCR`                 | General OCR (detection + recognition)    |
+| `PPStructureV3`             | Document structure analysis              |
+| `PaddleOCRVL`              | Vision-Language document parsing         |
+| `PPChatOCRv4Doc`           | Chat-based document QA                   |
+| `PPDocTranslation`         | Document translation                     |
+| `DocPreprocessor`          | Image preprocessing (orientation, unwarp)|
+| `DocUnderstanding`         | Document comprehension                   |
+| `FormulaRecognitionPipeline`| Formula OCR pipeline                    |
+| `SealRecognition`          | Seal stamp text extraction               |
+| `TableRecognitionPipelineV2`| Advanced table recognition              |
+
+### Base Classes
+
+All models inherit from `PaddleXPredictorWrapper`
+(`paddleocr/_models/base.py:30`):
+
+```python
+class PaddleXPredictorWrapper(metaclass=abc.ABCMeta):
+    def __init__(self, *, model_name=None, model_dir=None, **common_args):
+        self._model_name = model_name or self.default_model_name
+        self.paddlex_predictor = self._create_paddlex_predictor()
+
+    def _create_paddlex_predictor(self):
+        return create_predictor(model_name=self._model_name, ...)
+
+    def predict(self, *args, **kwargs):
+        return list(self.predict_iter(*args, **kwargs))
+```
+
+All pipelines inherit from `PaddleXPipelineWrapper`
+(`paddleocr/_pipelines/base.py:54`):
+
+```python
+class PaddleXPipelineWrapper(metaclass=abc.ABCMeta):
+    def __init__(self, *, paddlex_config=None, **common_args):
+        self._merged_paddlex_config = self._get_merged_paddlex_config()
+        self.paddlex_pipeline = self._create_paddlex_pipeline()
+
+    def _create_paddlex_pipeline(self):
+        return create_pipeline(config=self._merged_paddlex_config, ...)
+```
+
+The pattern is the same: take user parameters, merge into a PaddleX
+configuration, and delegate to PaddleX's `create_predictor` or
+`create_pipeline`.
+
+### CLI System
+
+`paddleocr/_cli.py` registers every model and pipeline as a CLI subcommand:
+
+```bash
+paddleocr ocr --input image.jpg              # PaddleOCR pipeline
+paddleocr pp_structurev3 --input doc.pdf      # PPStructureV3 pipeline
+paddleocr doc_parser --input page.png         # PaddleOCRVL pipeline
+paddleocr text_detection --input image.jpg    # Single model inference
+```
+
+### PaddleOCR-VL (Vision-Language Model)
+
+PaddleOCR-VL is a fundamentally different approach from the traditional
+pipeline. Instead of separate detection and recognition models, it uses a
+single 0.9B-parameter Vision-Language Model:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  PaddleOCR-VL-1.5  (0.9B parameters)                      │
+│                                                            │
+│  ┌───────────────┐    ┌──────────────────────────────┐    │
+│  │ NaViT-style   │    │  ERNIE-4.5-0.3B              │    │
+│  │ Visual Encoder │──>│  Language Model               │──> │ Markdown
+│  │ (dynamic res) │    │  (text generation)            │    │ Output
+│  └───────────────┘    └──────────────────────────────┘    │
+│                                                            │
+│  Handles: text, tables, formulas, charts, seals            │
+│  Languages: 109                                            │
+│  Accuracy: 94.5% on OmniDocBench v1.5                     │
+└────────────────────────────────────────────────────────────┘
+```
+
+Use PaddleOCR-VL when you need end-to-end document parsing. Use the
+traditional OCR pipeline when you need fine-grained control over individual
+detection/recognition stages.
+
+### How a Prediction Flows Through Layer 1
+
+```
+User code:
+  ocr = PaddleOCR(lang="en")
+  result = ocr.predict("image.jpg")
+         │
+         v
+PaddleOCR.__init__()                   [paddleocr/_pipelines/ocr.py:55]
+  │  Resolves model names from lang/version
+  │  Builds config overrides dict
+  │  Calls super().__init__()
+  v
+PaddleXPipelineWrapper.__init__()      [paddleocr/_pipelines/base.py:54]
+  │  Loads PaddleX pipeline config
+  │  Merges user overrides
+  │  Calls create_pipeline(config=...)
+  v
+PaddleX (external)
+  │  Downloads models if needed
+  │  Initializes sub-models (det, rec, cls)
+  │  Returns pipeline object
+  v
+ocr.predict("image.jpg")
+  │  Delegates to paddlex_pipeline.predict()
+  v
+PaddleX pipeline orchestration:
+  │  1. [Optional] Doc orientation classification
+  │  2. [Optional] Text image unwarping
+  │  3. Text detection (finds text regions)
+  │  4. [Optional] Text line orientation classification
+  │  5. Text recognition (reads text in each region)
+  v
+Result: list of dicts with rec_texts, rec_scores, dt_polys, etc.
+```
+
+---
+
+## Layer 2: Core ML Framework (`ppocr/`)
+
+This is where model architectures are defined, training happens, and new
+algorithms are implemented.
+
+### The Four-Component Model Architecture
+
+Every model in Layer 2 is built from up to four components chained together.
+This is defined in `ppocr/modeling/architectures/base_model.py:27-117`:
+
+```
+                  in_channels = 3 (RGB)
+                        │
+                        v
+              ┌──────────────────┐
+              │    Transform     │  Optional. TPS (Thin Plate Spline)
+              │                  │  for text rectification (rec only).
+              │  out_channels ───│──> in_channels for next component
+              └──────────────────┘
+                        │
+                        v
+              ┌──────────────────┐
+              │    Backbone      │  Feature extractor.
+              │                  │  MobileNetV3, ResNet, SVTRNet, etc.
+              │  out_channels ───│──> in_channels for next component
+              └──────────────────┘
+                        │
+                        v
+              ┌──────────────────┐
+              │    Neck          │  Feature fusion / sequence encoding.
+              │                  │  DBFPN, SequenceEncoder, RNN, etc.
+              │  out_channels ───│──> in_channels for next component
+              └──────────────────┘
+                        │
+                        v
+              ┌──────────────────┐
+              │    Head          │  Task-specific output layer.
+              │                  │  DBHead, CTCHead, ClsHead, etc.
+              └──────────────────┘
+                        │
+                        v
+                  Predictions
+            (logits, probability maps, etc.)
+```
+
+**Critical: in_channels threading.** Each component reads `in_channels` from
+its config, and must set `self.out_channels` so the next component in the
+chain receives the correct value. If `out_channels` is wrong or missing, you
+get a shape mismatch error.
+
+Here is the actual code (simplified):
+
+```python
+class BaseModel(nn.Layer):
+    def __init__(self, config):
+        in_channels = config.get("in_channels", 3)
+        model_type = config["model_type"]
+
+        # Each component: set in_channels, build, read out_channels
+        if config.get("Transform"):
+            config["Transform"]["in_channels"] = in_channels
+            self.transform = build_transform(config["Transform"])
+            in_channels = self.transform.out_channels
+
+        config["Backbone"]["in_channels"] = in_channels
+        self.backbone = build_backbone(config["Backbone"], model_type)
+        in_channels = self.backbone.out_channels
+
+        if config.get("Neck"):
+            config["Neck"]["in_channels"] = in_channels
+            self.neck = build_neck(config["Neck"])
+            in_channels = self.neck.out_channels
+
+        config["Head"]["in_channels"] = in_channels
+        self.head = build_head(config["Head"])
+```
+
+### Dynamic Instantiation Pattern
+
+All `build_*` functions follow the same pattern — they pop the `"name"` key
+from the config dict and use `eval()` to instantiate the class:
+
+```python
+# ppocr/modeling/backbones/__init__.py:145-152
+def build_backbone(config, model_type):
+    # ... imports gated by model_type ...
+    module_name = config.pop("name")
+    assert module_name in support_dict
+    module_class = eval(module_name)(**config)
+    return module_class
+```
+
+This pattern is used by `build_backbone`, `build_neck`, `build_head`,
+`build_loss`, `build_post_process`, and `build_metric`. It means:
+
+1. **Class names in YAML must exactly match Python class names.** `"DBHead"`
+   works. `"Dbhead"` or `"DB_Head"` does not.
+2. **The class must be imported** in the `__init__.py` file where `eval()` runs.
+
+### model_type Gating (Backbones Only)
+
+`build_backbone` is unique — it uses `model_type` to control which backbones
+are available:
+
+```python
+def build_backbone(config, model_type):
+    if model_type == "det" or model_type == "table":
+        from .det_mobilenet_v3 import MobileNetV3
+        # ... detection backbones ...
+        support_dict = ["MobileNetV3", "ResNet", "ResNet_vd", ...]
+    elif model_type == "rec" or model_type == "cls":
+        from .rec_mobilenet_v3 import MobileNetV3
+        # ... recognition backbones ...
+        support_dict = ["MobileNetV1Enhance", "MobileNetV3", ...]
+    elif model_type == "kie":
+        # ... KIE backbones ...
+    # ...
+```
+
+A backbone registered under `det` is **invisible** when `model_type` is `rec`.
+Some class names (like `MobileNetV3`) appear in multiple branches but are
+imported from different files with different implementations.
+
+### Component Inventory
+
+**Backbones** (`ppocr/modeling/backbones/`):
+- Detection: MobileNetV3, ResNet, ResNet_vd, PPLCNet, PPLCNetV3, PPHGNet,
+  RepSVTR_det (12 classes across det/table)
+- Recognition: MobileNetV3, ResNet, SVTRNet, SVTRv2, PPLCNetV3, DenseNet,
+  ViTSTR, DonutSwinModel, PPHGNetV2_B4, and more (28 classes across rec/cls)
+- KIE: Kie_backbone, LayoutLMForSer, LayoutXLMForSer, etc. (6 classes)
+
+**Necks** (`ppocr/modeling/necks/`):
+- Detection: DBFPN, EASTFPN, SASTFPN, FCEFPN, CSPPAN, RSEFPN
+- Recognition: SequenceEncoder (wraps RNN/BiLSTM), SVTR
+- Table: TableFPN
+
+**Heads** (`ppocr/modeling/heads/`):
+- Detection: DBHead, EASTHead, SASTHead, PSEHead, FCEHead, CT_Head, DRRGHead
+- Recognition: CTCHead, AttentionHead, SARHead, MultiHead, ParseQHead,
+  ABINetHead, and many more (20+ recognition heads)
+- Classification: ClsHead
+- Table: TableAttentionHead, SLAHead, TableMasterHead
+- KIE: SDMGRHead
+
+**Transforms** (`ppocr/modeling/transforms/`):
+- TPS (Thin Plate Spline) — geometric text rectification, recognition only
+
+### DistillationModel
+
+`ppocr/modeling/architectures/distillation_model.py` defines a
+teacher-student setup for knowledge distillation. It wraps multiple
+BaseModel instances and routes data through teacher and student models
+during training.
+
+---
+
+## The Configuration System
+
+PaddleOCR is config-driven. YAML files in `configs/` define every aspect of
+a model: architecture, loss, optimizer, data, and evaluation.
+
+### Config File Structure
+
+Here is a complete config annotated section by section, using
+`configs/det/det_mv3_db.yml` as the example:
+
+```yaml
+# ── Global training parameters ──────────────────────────────────
+Global:
+  use_gpu: true
+  epoch_num: 1200
+  log_smooth_window: 20
+  print_batch_step: 10
+  save_model_dir: ./output/db_mv3/
+  save_epoch_step: 1200
+  eval_batch_step: [0, 2000]     # evaluate every 2000 iterations
+  cal_metric_during_train: false
+  pretrained_model: ./pretrain_models/MobileNetV3_large_x0_5_pretrained
+  checkpoints:                    # resume training from checkpoint
+  save_inference_dir:             # where to save exported model
+
+# ── Model architecture ──────────────────────────────────────────
+Architecture:
+  model_type: det                 # det | rec | cls | kie | table | e2e
+  algorithm: DB                   # used for algorithm-specific logic
+  Transform:                      # null for detection
+  Backbone:
+    name: MobileNetV3             # must match Python class name exactly
+    scale: 0.5
+    model_name: large
+  Neck:
+    name: DBFPN
+    out_channels: 256
+  Head:
+    name: DBHead
+    k: 50                         # DB binarization parameter
+
+# ── Loss function ───────────────────────────────────────────────
+Loss:
+  name: DBLoss
+  balance_loss: true
+  main_loss_type: DiceLoss
+  alpha: 5
+  beta: 10
+  ohem_ratio: 3
+
+# ── Optimizer ───────────────────────────────────────────────────
+Optimizer:
+  name: Adam
+  beta1: 0.9
+  beta2: 0.999
+  lr:
+    learning_rate: 0.001
+  regularizer:
+    name: L2
+    factor: 0
+
+# ── Post-processing (decoding model output) ─────────────────────
+PostProcess:
+  name: DBPostProcess
+  thresh: 0.3
+  box_thresh: 0.6
+  max_candidates: 1000
+  unclip_ratio: 1.5
+
+# ── Evaluation metric ──────────────────────────────────────────
+Metric:
+  name: DetMetric
+  main_indicator: hmean           # metric for best checkpoint selection
+
+# ── Training data ──────────────────────────────────────────────
+Train:
+  dataset:
+    name: SimpleDataSet
+    data_dir: ./train_data/icdar2015/text_localization/
+    label_file_list:
+      - ./train_data/icdar2015/text_localization/train_icdar2015_label.txt
+    transforms:
+      - DecodeImage:
+          img_mode: BGR
+          channel_first: false
+      - DetLabelEncode:
+      - IaaAugment: ...           # data augmentation
+      - MakeBorderMap: ...        # generate DB target maps
+      - MakeShrinkMap: ...
+      - NormalizeImage: ...
+      - ToCHWImage:
+      - KeepKeys:
+          keep_keys: [image, threshold_map, threshold_mask, ...]
+  loader:
+    shuffle: true
+    batch_size_per_card: 16
+    num_workers: 8
+
+# ── Evaluation data ────────────────────────────────────────────
+Eval:
+  dataset:
+    name: SimpleDataSet
+    data_dir: ./train_data/icdar2015/text_localization/
+    label_file_list:
+      - ./train_data/icdar2015/text_localization/test_icdar2015_label.txt
+    transforms:
+      - DecodeImage: ...
+      - DetLabelEncode:
+      - DetResizeForTest:
+          image_shape: [736, 1280]
+      - NormalizeImage: ...
+      - ToCHWImage:
+      - KeepKeys:
+          keep_keys: [image, shape, polys, ignore_tags]
+  loader:
+    shuffle: false
+    batch_size_per_card: 1
+```
+
+### Config Loading and CLI Overrides
+
+Configs are loaded and merged in `tools/program.py`:
+
+```python
+# Load from YAML file
+config = load_config(file_path)         # program.py:75
+
+# Merge CLI overrides: -o key=value
+merge_config(config, opts)              # program.py:88
+
+# CLI: python tools/train.py -c config.yml -o Global.use_gpu=false
+```
+
+The `-o` flag uses dot notation for nested keys:
+`-o Architecture.Backbone.name=ResNet_vd`
+
+### How Config Maps to Code
+
+```
+YAML Config                          Python Code
+────────────────                     ──────────────────
+
+Architecture:
+  model_type: det       ──────────>  build_model(config["Architecture"])
+  algorithm: DB                            │
+  Backbone:                                v
+    name: MobileNetV3   ──────────>  build_backbone(config, "det")
+    scale: 0.5                         eval("MobileNetV3")(scale=0.5)
+  Neck:                                    │
+    name: DBFPN         ──────────>  build_neck(config)
+    out_channels: 256                  eval("DBFPN")(out_channels=256)
+  Head:                                    │
+    name: DBHead        ──────────>  build_head(config)
+    k: 50                              eval("DBHead")(k=50)
+
+Loss:
+  name: DBLoss          ──────────>  build_loss(config["Loss"])
+                                       eval("DBLoss")(**params)
+
+PostProcess:
+  name: DBPostProcess   ──────────>  build_post_process(config["PostProcess"])
+                                       eval("DBPostProcess")(**params)
+
+Metric:
+  name: DetMetric       ──────────>  build_metric(config["Metric"])
+                                       eval("DetMetric")(**params)
+```
+
+---
+
+## The Data Pipeline
+
+### Dataset Classes
+
+All datasets live in `ppocr/data/`:
+
+| Class              | Format                    | Use case                 |
+|--------------------|---------------------------|--------------------------|
+| `SimpleDataSet`    | Image files + label txt   | Most common              |
+| `LMDBDataSet`      | LMDB key-value store      | Large-scale training     |
+| `MultiScaleDataSet`| Multi-resolution images   | Multi-scale training     |
+| `PubTabDataSet`    | Table structure data      | Table recognition        |
+
+**SimpleDataSet label format** — one line per image:
+
+```
+image_path\t[{"transcription": "text", "points": [[x1,y1], ...]}]
+```
+
+### Transform Chain
+
+Data augmentation is configured as a list of operators in the YAML config
+under `Train.dataset.transforms`. Each operator is a class in
+`ppocr/data/imaug/`:
+
+```yaml
+transforms:
+  - DecodeImage:         # Load image from path
+      img_mode: BGR
+  - DetLabelEncode:      # Parse label annotations
+  - IaaAugment:          # Random augmentation (flip, rotate, resize)
+  - MakeBorderMap:       # Generate DB border regression target
+  - MakeShrinkMap:       # Generate DB shrink map target
+  - NormalizeImage:      # Scale to [0,1], apply mean/std
+  - ToCHWImage:          # Convert HWC to CHW format
+  - KeepKeys:            # Select which fields to pass to the model
+```
+
+Operators are instantiated by `create_operators()` in
+`ppocr/data/imaug/__init__.py` using the same `eval()` pattern.
+
+### DataLoader Construction
+
+`ppocr/data/__init__.py:build_dataloader` builds a PaddlePaddle DataLoader
+from the config:
+
+```
+YAML Train/Eval section
+         │
+         v
+build_dataloader(config, "Train", device, logger, seed)
+         │
+         ├── Instantiates dataset class (SimpleDataSet, etc.)
+         ├── Creates transform pipeline from config
+         ├── Sets up batch sampler
+         └── Returns paddle.io.DataLoader
+```
+
+---
+
+## What's Next?
+
+- **[Codebase Map](codebase-map.md)** — Quick reference for where things
+  live in the repo
+- **[Adding Models](adding-models.md)** — Step-by-step guide for adding
+  new components

--- a/docs/onboarding/codebase-map.md
+++ b/docs/onboarding/codebase-map.md
@@ -1,0 +1,234 @@
+# Codebase Map
+
+Quick-reference guide to the PaddleOCR repository. Skim this once to build
+spatial awareness, then return when you need to find something specific.
+
+## Top-Level Directory Structure
+
+```
+PADDLEOCR/
+├── paddleocr/          # Layer 1: Pipeline API (user-facing)
+├── ppocr/              # Layer 2: Core ML framework (model training)
+├── ppstructure/        # Legacy PP-Structure (superseded by PPStructureV3)
+├── configs/            # YAML training configurations
+├── tools/              # Training, eval, export scripts
+├── deploy/             # Deployment: C++, ONNX, mobile, Docker, serving
+├── tests/              # Pytest test suite
+├── docs/               # User-facing documentation (MkDocs, multilingual)
+├── doc/                # Font files for text rendering
+├── benchmark/          # Performance benchmarking scripts
+├── mcp_server/         # Claude MCP server integration
+├── langchain-paddleocr/# LangChain integration wrapper
+├── skills/             # Claude Code skills
+├── test_tipc/          # Training & Inference Precision Comparison tests
+├── applications/       # Application examples
+├── readme/             # Multilingual README files
+├── .github/            # CI/CD workflows, issue templates
+├── pyproject.toml      # Python package metadata
+├── setup.py            # Setuptools entry (delegates to pyproject.toml)
+├── requirements.txt    # Core dependencies
+└── mkdocs.yml          # Documentation site configuration
+```
+
+## paddleocr/ — Pipeline API (Layer 1)
+
+```
+paddleocr/
+├── __init__.py          # Exports: 13 models + 10 pipelines + logger
+├── __main__.py          # python -m paddleocr entry point
+├── _cli.py              # CLI: registers subcommands for all models/pipelines
+├── _common_args.py      # Shared CLI argument definitions
+├── _abstract.py         # CLISubcommandExecutor ABC
+├── _version.py          # Package version
+├── _models/             # Model wrappers (one file per model)
+│   ├── base.py          # PaddleXPredictorWrapper ABC
+│   ├── text_detection.py
+│   ├── text_recognition.py
+│   ├── layout_detection.py
+│   ├── table_structure_recognition.py
+│   ├── formula_recognition.py
+│   ├── doc_vlm.py
+│   └── ...              # 13 model classes total
+├── _pipelines/          # Pipeline orchestrators (one file per pipeline)
+│   ├── base.py          # PaddleXPipelineWrapper ABC
+│   ├── ocr.py           # PaddleOCR (general OCR pipeline)
+│   ├── pp_structurev3.py# PPStructureV3 (document structure)
+│   ├── paddleocr_vl.py  # PaddleOCRVL (Vision-Language)
+│   ├── pp_chatocrv4.py  # PPChatOCRv4Doc
+│   └── ...              # 10 pipeline classes total
+└── _utils/              # Utilities: logging, CLI helpers, deprecation
+```
+
+## ppocr/ — Core ML Framework (Layer 2)
+
+```
+ppocr/
+├── modeling/
+│   ├── architectures/
+│   │   ├── __init__.py          # build_model()
+│   │   ├── base_model.py        # BaseModel: Transform→Backbone→Neck→Head
+│   │   └── distillation_model.py# DistillationModel: teacher-student
+│   ├── backbones/
+│   │   ├── __init__.py          # build_backbone(config, model_type)
+│   │   ├── det_mobilenet_v3.py  # Detection MobileNetV3
+│   │   ├── rec_mobilenet_v3.py  # Recognition MobileNetV3
+│   │   ├── rec_svtrnet.py       # SVTRNet backbone
+│   │   └── ...                  # 30+ backbone implementations
+│   ├── necks/
+│   │   ├── __init__.py          # build_neck(config)
+│   │   ├── db_fpn.py            # DBFPN for detection
+│   │   ├── rnn.py               # SequenceEncoder for recognition
+│   │   └── ...                  # 15+ neck implementations
+│   ├── heads/
+│   │   ├── __init__.py          # build_head(config)
+│   │   ├── det_db_head.py       # DBHead for DB detection
+│   │   ├── rec_ctc_head.py      # CTCHead for CTC recognition
+│   │   ├── rec_multi_head.py    # MultiHead (CTC + attention combined)
+│   │   ├── cls_head.py          # ClsHead for classification
+│   │   └── ...                  # 30+ head implementations
+│   └── transforms/
+│       ├── __init__.py          # build_transform(config)
+│       └── tps.py               # Thin Plate Spline (rec text rectification)
+├── data/
+│   ├── __init__.py              # build_dataloader()
+│   ├── simple_dataset.py        # SimpleDataSet (file-based)
+│   ├── lmdb_dataset.py          # LMDBDataSet (LMDB format)
+│   └── imaug/
+│       ├── __init__.py          # create_operators(), transform()
+│       ├── operators.py         # DecodeImage, NormalizeImage, ToCHWImage
+│       ├── label_ops.py         # DetLabelEncode, CTCLabelEncode
+│       ├── iaa_augment.py       # IaaAugment, RandAugment
+│       ├── make_border_map.py   # DB border map target generation
+│       ├── make_shrink_map.py   # DB shrink map target generation
+│       └── ...                  # 20+ augmentation operators
+├── losses/
+│   ├── __init__.py              # build_loss(): 37 loss classes
+│   ├── det_db_loss.py           # DBLoss
+│   ├── rec_ctc_loss.py          # CTCLoss
+│   ├── combined_loss.py         # CombinedLoss (weighted sum)
+│   └── ...                      # 35+ loss implementations
+├── postprocess/
+│   ├── __init__.py              # build_post_process(): 30+ decoders
+│   ├── db_postprocess.py        # DBPostProcess (binary→contour→polygon)
+│   ├── rec_postprocess.py       # CTCLabelDecode, AttnLabelDecode, etc.
+│   ├── cls_postprocess.py       # ClsPostProcess
+│   └── ...
+├── metrics/
+│   ├── __init__.py              # build_metric(): 15 metric classes
+│   ├── det_metric.py            # DetMetric (precision, recall, hmean)
+│   ├── rec_metric.py            # RecMetric (accuracy)
+│   ├── cls_metric.py            # ClsMetric
+│   └── ...
+├── optimizer/
+│   ├── __init__.py              # build_optimizer()
+│   ├── optimizer.py             # Optimizer wrappers
+│   ├── learning_rate.py         # 15+ LR schedulers (Cosine, Poly, Step)
+│   └── regularizer.py           # L1/L2 regularization
+└── utils/
+    ├── save_load.py             # Checkpoint save/load
+    ├── logging.py               # Logger configuration
+    ├── utility.py               # Common utilities
+    ├── export_model.py          # Dynamic→static graph export
+    └── ...
+```
+
+## configs/ — Training Configurations
+
+```
+configs/
+├── det/                         # Text detection configs
+│   ├── PP-OCRv5/                # PP-OCRv5 detection (latest)
+│   ├── PP-OCRv4/
+│   ├── PP-OCRv3/
+│   └── det_mv3_db.yml           # Classic MobileNetV3 + DB example
+├── rec/                         # Text recognition configs
+│   ├── PP-OCRv5/
+│   │   ├── PP-OCRv5_mobile_rec.yml
+│   │   ├── PP-OCRv5_server_rec.yml
+│   │   └── multi_language/      # Per-language configs
+│   ├── SVTRv2/
+│   └── PP-FormulaNet/           # Formula recognition configs
+├── cls/                         # Text angle classification configs
+├── table/                       # Table recognition configs
+├── kie/                         # Key Information Extraction configs
+├── e2e/                         # End-to-end detection+recognition
+└── sr/                          # Super-resolution configs
+```
+
+**Config naming convention**: `{algorithm}_{backbone}_{extras}.yml`
+(e.g., `det_mv3_db.yml` = detection, MobileNetV3, DB algorithm)
+
+## tools/ — Training & Inference Scripts
+
+| File                | Purpose                                    |
+|---------------------|--------------------------------------------|
+| `train.py`          | Main training entry point                  |
+| `eval.py`           | Model evaluation                           |
+| `export_model.py`   | Export to static graph for deployment      |
+| `program.py`        | Config loading, training loop, eval loop   |
+| `infer_det.py`      | Detection inference (Layer 2 style)        |
+| `infer_rec.py`      | Recognition inference                      |
+| `infer_cls.py`      | Classification inference                   |
+| `infer_kie.py`      | KIE inference                              |
+| `infer/predict_system.py` | Full det+rec pipeline inference      |
+
+## deploy/ — Deployment Targets
+
+| Directory          | Target                                       |
+|--------------------|----------------------------------------------|
+| `cpp_infer/`       | C++ native inference (Linux/Windows)         |
+| `paddle2onnx/`     | ONNX model conversion                       |
+| `lite/`            | PaddleLite (mobile optimization)             |
+| `android_demo/`    | Android app demo                             |
+| `ios_demo/`        | iOS app demo                                 |
+| `hubserving/`      | PaddleHub Serving (REST API)                 |
+| `docker/`          | Docker images for serving                    |
+| `paddleocr_vl_docker/` | Docker for VL model deployment           |
+| `avh/`             | ARM Virtual Hardware (edge MCU)              |
+| `slim/`            | Model compression (quantization, pruning)    |
+
+## tests/ — Test Suite
+
+```
+tests/
+├── testing_utils.py             # Test helpers: TEST_DATA_DIR, assertions
+├── test_files/                  # Sample images for testing
+├── models/                      # Per-model unit tests (13 files)
+│   ├── test_text_detection.py
+│   ├── test_text_recognition.py
+│   ├── test_layout_detection.py
+│   └── ...
+└── pipelines/                   # Per-pipeline integration tests (10 files)
+    ├── test_ocr.py
+    ├── test_pp_structurev3.py
+    └── ...
+```
+
+## ppstructure/ — Legacy (Being Superseded)
+
+The `ppstructure/` directory contains the original PP-Structure
+implementation for table recognition, layout analysis, and KIE. This is
+being replaced by the `PPStructureV3` pipeline in `paddleocr/_pipelines/`.
+**Do not build new features on ppstructure/.**
+
+## Quick Reference Table
+
+| I want to...                        | Look at                                                   |
+|-------------------------------------|-----------------------------------------------------------|
+| Add a new backbone                  | `ppocr/modeling/backbones/__init__.py`                     |
+| Add a new head                      | `ppocr/modeling/heads/__init__.py`                         |
+| Add a new neck                      | `ppocr/modeling/necks/__init__.py`                         |
+| Add a new loss function             | `ppocr/losses/__init__.py`                                 |
+| Add a new post-processor            | `ppocr/postprocess/__init__.py`                            |
+| Add a new metric                    | `ppocr/metrics/__init__.py`                                |
+| Add a new data augmentation         | `ppocr/data/imaug/`                                       |
+| Create a training config            | `configs/det/det_mv3_db.yml` (as template)                 |
+| Understand the model composition    | `ppocr/modeling/architectures/base_model.py`               |
+| Understand the training loop        | `tools/program.py` train() function                        |
+| Understand config loading           | `tools/program.py` load_config(), merge_config()           |
+| See how the OCR pipeline works      | `paddleocr/_pipelines/ocr.py`                              |
+| See how the VL pipeline works       | `paddleocr/_pipelines/paddleocr_vl.py`                     |
+| See all exported classes            | `paddleocr/__init__.py`                                    |
+| Run CLI inference                   | `paddleocr/_cli.py`                                        |
+| Export a model                      | `tools/export_model.py` + `ppocr/utils/export_model.py`   |
+| Find character dictionaries         | `ppocr/utils/dict/`                                        |

--- a/docs/onboarding/deployment-export.md
+++ b/docs/onboarding/deployment-export.md
@@ -1,0 +1,328 @@
+# Deployment and Export
+
+Guide for exporting trained models and deploying PaddleOCR to production.
+Covers Layer 1 (pipeline API) deployment, model export, high-performance
+inference, ONNX, serving, and mobile/edge deployment.
+
+## Export Overview
+
+Before deployment, trained models (dynamic graph) must be exported to static
+graph format for inference optimization:
+
+```
+Trained Model                      Static Model                Deploy Targets
+(dynamic graph)                    (inference-ready)
+                                                               ┌─────────────┐
+┌─────────────┐  export_model.py   ┌─────────────────┐       │ Python API  │
+│ .pdparams   │─────────────────>  │ inference.pdmodel│──────>│ (Layer 1)   │
+│ .pdopt      │                    │ inference.pdiparams      ├─────────────┤
+│ .states     │                    │ inference.yml    │──────>│ CLI         │
+└─────────────┘                    └─────────────────┘       ├─────────────┤
+                                          │                   │ C++ Infer   │
+                                          │    Paddle2ONNX    ├─────────────┤
+                                          ├──────────────────>│ ONNX Runtime│
+                                          │                   ├─────────────┤
+                                          │                   │ TensorRT    │
+                                          │                   ├─────────────┤
+                                          │                   │ REST API    │
+                                          │                   ├─────────────┤
+                                          └──────────────────>│ Mobile/Edge │
+                                                              └─────────────┘
+```
+
+## Exporting a Trained Model
+
+### Using tools/export_model.py
+
+```bash
+python tools/export_model.py \
+    -c configs/det/det_mv3_db.yml \
+    -o Global.checkpoints=./output/db_mv3/best_accuracy \
+    -o Global.save_inference_dir=./inference/det_db/
+```
+
+This produces three files:
+- `inference.pdmodel` — network structure
+- `inference.pdiparams` — model weights
+- `inference.yml` — configuration metadata (input shape, preprocessing)
+
+The export process (`ppocr/utils/export_model.py`) converts the dynamic
+PaddlePaddle graph to a static graph using `paddle.jit.to_static` with
+algorithm-specific `InputSpec` configurations.
+
+---
+
+## Layer 1 Deployment (Pipeline API)
+
+For most production use cases, Layer 1 is the recommended path. It handles
+model downloading, pipeline orchestration, and result formatting.
+
+### Python API
+
+```python
+from paddleocr import PaddleOCR
+
+# General OCR (PP-OCRv5 by default)
+ocr = PaddleOCR(lang="en")
+result = ocr.predict("image.jpg")
+
+for res in result:
+    res.print()                        # Print results
+    res.save_to_json("output/")        # Save as JSON
+    res.save_to_img("output/")         # Save visualization
+
+# Access structured data
+for res in result:
+    texts = res.json["rec_texts"]      # Recognized text strings
+    scores = res.json["rec_scores"]    # Confidence scores
+    polys = res.json["dt_polys"]       # Detection polygons
+```
+
+```python
+from paddleocr import PPStructureV3
+
+# Document structure analysis
+structure = PPStructureV3()
+result = structure.predict("document.pdf")
+for res in result:
+    res.save_to_markdown("output/")    # Markdown output
+```
+
+```python
+from paddleocr import PaddleOCRVL
+
+# Vision-Language document parsing
+vl = PaddleOCRVL()
+result = vl.predict("complex_doc.png")
+for res in result:
+    res.save_to_markdown("output/")
+```
+
+### Using Custom Model Directories
+
+Point to your own exported models:
+
+```python
+ocr = PaddleOCR(
+    text_detection_model_dir="./inference/my_det_model/",
+    text_recognition_model_dir="./inference/my_rec_model/",
+)
+```
+
+### CLI
+
+```bash
+# OCR pipeline
+paddleocr ocr --input image.jpg --device gpu:0
+
+# Document structure
+paddleocr pp_structurev3 --input document.pdf
+
+# Vision-Language parsing
+paddleocr doc_parser --input page.png
+
+# Single model inference
+paddleocr text_detection --input image.jpg
+paddleocr text_recognition --input cropped_text.jpg
+```
+
+### When to Use Layer 1 vs Layer 2
+
+```
+Use Layer 1 (paddleocr/)              Use Layer 2 (ppocr/ + tools/)
+─────────────────────────              ──────────────────────────────
+
+Production inference                   Training new models
+REST API serving                       Evaluating checkpoints
+Quick prototyping                      Adding new architectures
+Custom model directories               Debugging model internals
+CLI batch processing                   Exporting models
+                                       Research experiments
+```
+
+---
+
+## High-Performance Inference (HPI)
+
+HPI automatically selects the best inference backend and applies
+optimizations (TensorRT, ONNX Runtime, OpenVINO) based on your hardware.
+
+### Installation
+
+```bash
+# CPU systems
+paddleocr install_hpi_deps cpu
+
+# GPU systems (requires CUDA 11.8 + cuDNN 8.9, or CUDA 12.6 + cuDNN 9.5)
+paddleocr install_hpi_deps gpu
+```
+
+### Usage
+
+```python
+from paddleocr import PaddleOCR
+
+ocr = PaddleOCR(enable_hpi=True)
+result = ocr.predict("image.jpg")
+```
+
+```bash
+paddleocr ocr --input image.jpg --enable_hpi true
+```
+
+**Supported backends**: Paddle Inference (with TensorRT), ONNX Runtime,
+OpenVINO. HPI selects the optimal backend automatically.
+
+**Note**: The first run builds the inference engine (slow). Subsequent runs
+reuse the cached engine.
+
+---
+
+## ONNX Export
+
+Convert PaddlePaddle models to ONNX format for cross-platform inference:
+
+```bash
+# Install the conversion tool
+paddlex --install paddle2onnx
+
+# Convert
+paddlex \
+    --paddle2onnx \
+    --paddle_model_dir ./inference/det_db/ \
+    --onnx_model_dir ./onnx_models/det_db/ \
+    --opset_version 14
+```
+
+The converter handles operator mapping automatically. If conversion fails at
+the specified opset version, it retries with higher versions.
+
+---
+
+## Serving Deployment
+
+### Basic Serving (PaddleX)
+
+```bash
+# Install serving plugin
+paddlex --install serving
+
+# Start server
+paddlex --serve --pipeline OCR --host 0.0.0.0 --port 8080
+```
+
+The server exposes REST API endpoints at `http://0.0.0.0:8080`. Send
+images via HTTP POST and receive JSON results. Client code can be in any
+language.
+
+Parameters:
+
+| Flag          | Purpose                  | Default     |
+|---------------|--------------------------|-------------|
+| `--pipeline`  | Pipeline name or config  | Required    |
+| `--device`    | GPU/CPU selection        | Auto-detect |
+| `--host`      | Bind address             | 0.0.0.0     |
+| `--port`      | Listen port              | 8080        |
+| `--use_hpip`  | Enable HPI               | false       |
+
+### Production Serving (Triton)
+
+For high-stability production environments, PaddleOCR supports deployment on
+NVIDIA Triton Inference Server. See the PaddleX Serving Guide for details.
+
+---
+
+## PaddleOCR-VL Deployment
+
+PaddleOCR-VL (the Vision-Language model) has specialized deployment options
+due to its LLM component:
+
+| Backend                 | Hardware              | Use case                |
+|-------------------------|-----------------------|-------------------------|
+| PaddlePaddle only       | All supported GPUs    | Default, broadest compat|
+| PaddlePaddle + vLLM     | NVIDIA (CC >= 8.0)    | High-throughput GPU     |
+| PaddlePaddle + SGLang   | NVIDIA                | Optimized serving       |
+| PaddlePaddle + FastDeploy| Multi-backend        | Flexible acceleration   |
+| MLX-VLM                 | Apple Silicon          | macOS native            |
+| llama.cpp               | CPU (x64)             | CPU-optimized           |
+
+**Docker is strongly recommended** for VL deployment to avoid environment
+issues:
+
+```bash
+# Start vLLM-backed server
+docker run --rm --gpus all --network host \
+    <paddleocr-vl-image>:latest \
+    paddleocr genai_server \
+        --model_name PaddleOCR-VL-1.5-0.9B \
+        --host 0.0.0.0 --port 8080 \
+        --backend vllm
+
+# Use with CLI
+paddleocr doc_parser \
+    --input image.png \
+    --vl_rec_backend vllm-server \
+    --vl_rec_server_url http://127.0.0.1:8080/v1
+```
+
+---
+
+## C++ Inference
+
+For native performance without Python overhead:
+
+- Source: `deploy/cpp_infer/`
+- Supports Linux and Windows
+- Uses Paddle Inference C++ API
+- Provides command-line tool for detection, recognition, classification
+
+Build with CMake. See `deploy/cpp_infer/readme.md` for platform-specific
+instructions.
+
+---
+
+## Mobile and Edge Deployment
+
+### PaddleLite (Mobile)
+
+`deploy/lite/` contains PaddleLite optimization configs for mobile devices.
+PaddleLite provides model quantization and hardware-specific optimization.
+
+### Android and iOS Demos
+
+- `deploy/android_demo/` — Android OCR demo app
+- `deploy/ios_demo/` — iOS OCR demo app
+
+### ARM Virtual Hardware (Edge MCU)
+
+`deploy/avh/` provides deployment to ARM Cortex-M/A targets for embedded
+systems.
+
+---
+
+## Docker Deployment
+
+Containerized deployment for serving:
+
+```
+deploy/docker/              # General-purpose Docker images
+deploy/paddleocr_vl_docker/ # VL model Docker images
+```
+
+Docker images include all dependencies and provide ready-to-use serving
+endpoints.
+
+---
+
+## Model Compression
+
+`deploy/slim/` provides tools for reducing model size:
+
+- **Quantization** — INT8 inference for smaller models and faster execution
+- **Knowledge Distillation** — Train smaller models from larger teachers
+- **Pruning** — Remove unnecessary model parameters
+
+## What's Next?
+
+- **[Testing & Debugging](testing-debugging.md)** — Running tests and
+  debugging common issues

--- a/docs/onboarding/ocr-fundamentals.md
+++ b/docs/onboarding/ocr-fundamentals.md
@@ -1,0 +1,290 @@
+# OCR Fundamentals
+
+This document teaches OCR (Optical Character Recognition) from scratch. If you
+already understand text detection, text recognition, and CTC decoding, skip
+ahead to [Architecture](architecture.md).
+
+## What Is OCR?
+
+OCR converts images of text into machine-readable character sequences. It is
+the technology behind:
+
+- Digitizing scanned documents and books
+- Reading license plates, street signs, and receipts
+- Extracting data from invoices, forms, and ID cards
+- Making PDFs searchable and accessible
+
+OCR sounds simple — "just read the text" — but in practice it is hard because
+real-world images contain curved text, uneven lighting, blur, rotation,
+multiple languages, complex layouts (tables, formulas, seals), and overlapping
+elements.
+
+## The OCR Pipeline
+
+Modern OCR systems break the problem into stages. The most common pipeline has
+three core steps:
+
+```
+┌─────────────┐    ┌────────────────┐    ┌──────────────────┐
+│             │    │                │    │                  │
+│  Input      │───>│  Text          │───>│  Text            │───> Output
+│  Image      │    │  Detection     │    │  Recognition     │     Text
+│             │    │                │    │                  │
+└─────────────┘    └────────────────┘    └──────────────────┘
+                     Finds WHERE           Reads WHAT
+                     text is               text says
+
+                   ┌────────────────┐
+                   │  (Optional)    │
+                   │  Text Angle    │
+                   │  Classification│
+                   └────────────────┘
+                     Corrects rotation
+                     before recognition
+```
+
+1. **Text Detection** — Locates text regions in the image and outputs their
+   coordinates (bounding boxes or polygons).
+2. **Text Angle Classification** (optional) — Determines if a text line is
+   rotated (0, 90, 180, or 270 degrees) and corrects it.
+3. **Text Recognition** — Takes each cropped text region and produces the
+   character sequence.
+
+The detection model finds *where* text is. The recognition model reads *what*
+it says. Splitting the problem this way allows each model to specialize.
+
+## Text Detection
+
+### What It Does
+
+A text detection model takes an image and outputs a set of regions where text
+appears. Each region is described as either:
+
+- A **bounding box**: four coordinates (x_min, y_min, x_max, y_max)
+- A **polygon**: a sequence of points that tightly follows the text shape
+  (needed for curved or rotated text)
+
+### The DB Algorithm
+
+PaddleOCR's default detection algorithm is **DB (Differentiable
+Binarization)**. Here is how it works at a high level:
+
+```
+                    ┌───────────┐
+    Input           │           │     Feature
+    Image ─────────>│  Backbone │────> Maps
+    (H x W x 3)    │ (e.g.     │     (multi-scale)
+                    │ MobileNet)│
+                    └───────────┘
+                          │
+                          v
+                    ┌───────────┐
+                    │           │     Fused
+                    │   FPN     │────> Feature
+                    │  (Neck)   │      Map
+                    └───────────┘
+                          │
+                    ┌─────┴──────┐
+                    │            │
+                    v            v
+              ┌──────────┐ ┌──────────┐
+              │Probability│ │Threshold │
+              │   Map     │ │   Map    │
+              └──────────┘ └──────────┘
+                    │            │
+                    v            v
+              ┌──────────────────────┐
+              │  Differentiable      │
+              │  Binarization        │
+              │  P > T ? text : bg   │
+              └──────────────────────┘
+                         │
+                         v
+              ┌──────────────────────┐
+              │  Contour Extraction  │
+              │  + Polygon Fitting   │──────> Text Polygons
+              │  + Unclip Expansion  │
+              └──────────────────────┘
+```
+
+Key ideas:
+- The **backbone** (e.g., MobileNetV3, ResNet) extracts visual features at
+  multiple scales.
+- The **FPN (Feature Pyramid Network)** neck fuses features from different
+  scales so the model can detect both large and small text.
+- The model produces a **probability map** (where is text?) and a **threshold
+  map** (adaptive per-pixel threshold). The innovation of DB is that the
+  binarization step (probability > threshold) is made *differentiable*, so the
+  whole pipeline can be trained end-to-end.
+- Post-processing extracts contours from the binary map, fits polygons, and
+  expands them slightly (unclip) to recover the full text region.
+
+In PaddleOCR, this is implemented in:
+- Detection heads: `ppocr/modeling/heads/det_db_head.py`
+- Post-processing: `ppocr/postprocess/db_postprocess.py`
+
+Other detection algorithms in PaddleOCR include **EAST**, **SAST**, **PSE**,
+**FCE** (for irregular text), **CT**, and **DRRG**.
+
+## Text Recognition
+
+### What It Does
+
+A text recognition model takes a cropped image of a single text line and
+outputs a character sequence with a confidence score. For example:
+
+```
+Input:  [image of "Hello World"]
+Output: ("Hello World", 0.97)
+```
+
+### CTC vs Attention Decoding
+
+There are two main approaches to converting a model's output into text:
+
+```
+CTC (Connectionist Temporal Classification)     Attention-Based
+─────────────────────────────────────────        ─────────────────────────
+
+Image ──> Backbone ──> Sequence of             Image ──> Backbone ──> Encoder
+          features     frame predictions                              │
+                       [H, e, -, l, l, -, o]                          v
+                            │                                     Decoder
+                            v                                   (autoregressive)
+                       CTC Decode:                                    │
+                       collapse repeats,                              v
+                       remove blanks                            H ─> e ─> l ─> ...
+                            │                                   (one char at a time,
+                            v                                    attending to image)
+                       "Hello"                                        │
+                                                                      v
+                                                                 "Hello"
+
+Pros:                                          Pros:
+  - Fast (non-autoregressive)                    - Handles variable-length
+  - Simple training                                output well
+  - Good for regular text                        - Better for irregular text
+
+Cons:                                          Cons:
+  - Assumes monotonic alignment                  - Slower (sequential decoding)
+  - Struggles with very long text                - More complex to train
+```
+
+**CTC** works by predicting a character (or blank) at every position in the
+feature sequence, then collapsing repeated characters and removing blanks. It
+is fast because all positions are predicted in parallel.
+
+**Attention-based** decoders generate characters one at a time, using an
+attention mechanism to "look at" relevant parts of the image for each
+character. They handle irregular and variable-length text better but are
+slower.
+
+PaddleOCR supports both approaches:
+- CTC: `ppocr/modeling/heads/rec_ctc_head.py`, decoded by
+  `ppocr/postprocess/rec_postprocess.py:CTCLabelDecode`
+- Attention: `ppocr/modeling/heads/rec_att_head.py`, decoded by
+  `ppocr/postprocess/rec_postprocess.py:AttnLabelDecode`
+- And many more: SAR, NRTR, SVTR, ParseQ, ABINet, etc.
+
+### Character Dictionaries
+
+Recognition models output indices into a **character dictionary** — a file
+listing every character the model can recognize. PaddleOCR ships dictionaries
+for 80+ languages in `ppocr/utils/dict/`. The size of the dictionary
+determines the output dimension of the recognition head.
+
+## Text Angle Classification
+
+Some documents contain text that is rotated 90 or 180 degrees (e.g., text
+printed vertically on a spine, or an upside-down scan). The **text angle
+classifier** predicts the rotation angle (0, 90, 180, or 270 degrees) so the
+image can be corrected before recognition.
+
+This is an optional step in the pipeline — only needed when input images may
+contain rotated text.
+
+In PaddleOCR: `ppocr/modeling/heads/cls_head.py`
+
+## Beyond Basic OCR
+
+PaddleOCR goes well beyond simple text detection + recognition:
+
+### Table Structure Recognition
+
+Detects table boundaries, rows, columns, and cells, then extracts content into
+structured formats (HTML, JSON). Uses specialized models like **SLANet** and
+**TableMaster**.
+
+### Layout Analysis
+
+Identifies document regions: titles, paragraphs, images, tables, headers,
+footers, page numbers, formulas, and more. The **PP-StructureV3** pipeline
+combines layout detection with OCR, table recognition, formula recognition,
+and chart parsing to produce complete Markdown output from complex documents.
+
+### Formula Recognition
+
+Converts mathematical formula images to LaTeX markup. Uses **PP-FormulaNet**
+with specialized backbones and heads.
+
+### Key Information Extraction (KIE)
+
+Extracts structured key-value pairs from documents (e.g., "Name: John Smith"
+from a form). Uses models like **LayoutXLM** that combine visual, textual, and
+layout features.
+
+### Document Vision-Language Models (VLM)
+
+**PaddleOCR-VL** is a 0.9B-parameter Vision-Language Model that combines a
+NaViT-style visual encoder with ERNIE-4.5-0.3B language model. Unlike the
+traditional pipeline approach (separate detection + recognition), it performs
+end-to-end document parsing as a single model, handling text, tables, formulas,
+charts, and seals simultaneously. It supports 109 languages and achieves 94.5%
+accuracy on OmniDocBench v1.5.
+
+## Key Metrics
+
+Understanding evaluation metrics is essential for training and comparing
+models.
+
+### Detection Metrics
+
+| Metric        | What it measures                                               |
+|---------------|----------------------------------------------------------------|
+| **Precision** | Of all regions the model detected, what fraction are real text? |
+| **Recall**    | Of all real text regions, what fraction did the model find?    |
+| **H-mean**    | Harmonic mean of precision and recall (the primary metric)     |
+
+A detection is considered correct if its IoU (Intersection over Union) with a
+ground-truth region exceeds a threshold (typically 0.5).
+
+In PaddleOCR: `ppocr/metrics/det_metric.py:DetMetric` with
+`main_indicator: hmean`
+
+### Recognition Metrics
+
+| Metric        | What it measures                                               |
+|---------------|----------------------------------------------------------------|
+| **Accuracy**  | Fraction of text lines recognized exactly correctly            |
+| **NED**       | Normalized Edit Distance — how close the prediction is         |
+
+In PaddleOCR: `ppocr/metrics/rec_metric.py:RecMetric` with
+`main_indicator: acc`
+
+### The `main_indicator` Field
+
+In PaddleOCR config files, the `Metric` section specifies a `main_indicator`
+— the metric used to decide which checkpoint is "best" during training. For
+detection, this is `hmean`. For recognition, this is `acc`.
+
+```yaml
+Metric:
+  name: DetMetric
+  main_indicator: hmean
+```
+
+## What's Next?
+
+Now that you understand the core OCR concepts, proceed to
+[Architecture](architecture.md) to learn how PaddleOCR implements all of this
+in code.

--- a/docs/onboarding/testing-debugging.md
+++ b/docs/onboarding/testing-debugging.md
@@ -1,0 +1,312 @@
+# Testing and Debugging
+
+Guide for running the PaddleOCR test suite, understanding test patterns, and
+debugging common training and inference issues.
+
+## Test Suite Overview
+
+PaddleOCR uses **pytest** with tests organized into two categories:
+
+```
+tests/
+├── testing_utils.py         # Shared test helpers
+├── test_files/              # Sample images used by tests
+├── models/                  # Unit tests for individual models (Layer 1)
+│   ├── test_text_detection.py
+│   ├── test_text_recognition.py
+│   ├── test_layout_detection.py
+│   ├── test_table_structure_recognition.py
+│   ├── test_table_cells_detection.py
+│   ├── test_table_classifcation.py
+│   ├── test_formula_recognition.py
+│   ├── test_seal_text_detection.py
+│   ├── test_doc_img_orientation_classifcation.py
+│   ├── test_textline_orientation_classifcation.py
+│   ├── test_text_image_unwarping.py
+│   ├── test_doc_vlm.py
+│   └── conftest.py
+└── pipelines/               # Integration tests for pipelines (Layer 1)
+    ├── test_ocr.py
+    ├── test_pp_structurev3.py
+    ├── test_seal_rec.py
+    ├── test_formula_recognition.py
+    ├── test_table_recognition_v2.py
+    ├── test_doc_preprocessor.py
+    ├── test_doc_understanding.py
+    ├── test_pp_chatocrv4_doc.py
+    ├── test_pp_doctranslation.py
+    ├── test_patch_layout_parsing.py
+    └── conftest.py
+```
+
+There are also additional unit tests at the top level of `tests/`:
+- `test_rec_postprocess.py` — Recognition post-processing
+- `test_cls_postprocess.py` — Classification post-processing
+- `test_formula_model.py` — Formula model specifics
+- `test_french_accents.py` — French accent handling
+- `test_iaa_augment.py` — Data augmentation
+
+## Running Tests
+
+### Full Suite
+
+```bash
+pytest tests/
+```
+
+### By Category
+
+```bash
+# Layer 1 model tests only
+pytest tests/models/
+
+# Layer 1 pipeline tests only
+pytest tests/pipelines/
+```
+
+### Individual Test Files
+
+```bash
+pytest tests/pipelines/test_ocr.py
+pytest tests/models/test_text_detection.py
+```
+
+### With Verbose Output
+
+```bash
+pytest tests/pipelines/test_ocr.py -v
+```
+
+## Test Patterns
+
+### Model Tests (tests/models/)
+
+Model tests verify that Layer 1 model wrappers produce valid results:
+
+```python
+# Typical model test pattern
+def test_text_detection(text_detection_model):
+    result = text_detection_model.predict(TEST_DATA_DIR / "sample.jpg")
+    check_simple_inference_result(result, expected_length=1)
+```
+
+- A **fixture** (in `conftest.py`) creates the model instance
+- The test calls `predict()` with a sample image from `test_files/`
+- `check_simple_inference_result()` verifies the result is a non-empty list
+  of dicts
+
+### Pipeline Tests (tests/pipelines/)
+
+Pipeline tests verify end-to-end behavior and parameter forwarding:
+
+```python
+# Inference test
+def test_ocr_predict(ocr_pipeline):
+    result = ocr_pipeline.predict(TEST_DATA_DIR / "sample.jpg")
+    check_simple_inference_result(result)
+
+# Parameter forwarding test
+def test_ocr_param_forwarding(monkeypatch, ocr_pipeline):
+    check_wrapper_simple_inference_param_forwarding(
+        monkeypatch,
+        ocr_pipeline,
+        "paddlex_pipeline",
+        TEST_DATA_DIR / "sample.jpg",
+        {"use_textline_orientation": True, "text_det_thresh": 0.5},
+    )
+```
+
+The parameter forwarding test uses `monkeypatch` to replace the underlying
+PaddleX pipeline's `predict` method with a dummy that captures arguments,
+then verifies all parameters are correctly forwarded.
+
+### Testing Utilities (tests/testing_utils.py)
+
+```python
+TEST_DATA_DIR = Path(__file__).parent / "test_files"
+
+def check_simple_inference_result(result, *, expected_length=1):
+    """Verify result is a non-empty list of dicts."""
+    assert isinstance(result, list)
+    assert len(result) == expected_length
+    for res in result:
+        assert isinstance(res, dict)
+
+def check_wrapper_simple_inference_param_forwarding(
+    monkeypatch, wrapper, wrapped_obj_attr_name, input, params
+):
+    """Verify all params are forwarded to the underlying predictor."""
+    # Patches predict, calls wrapper.predict, checks params arrived
+```
+
+---
+
+## Debugging Training Issues
+
+### Config Validation Errors
+
+**Symptom**: `AssertionError: backbone only support [...]`
+
+**Cause**: The `name` in your YAML config does not match any class in the
+`support_dict` for the given `model_type`.
+
+**Fix**:
+1. Check the class name matches exactly (case-sensitive)
+2. Check you registered in the correct `model_type` branch of
+   `build_backbone`
+3. Check the import is present in `__init__.py`
+
+---
+
+**Symptom**: `TypeError: __init__() got an unexpected keyword argument`
+
+**Cause**: A YAML config key does not match a constructor parameter. Remember
+that after `name` is popped from the config dict, all remaining keys are
+passed as `**kwargs`.
+
+**Fix**: Check the constructor signature of your component class and ensure
+YAML keys match parameter names exactly.
+
+### Data Pipeline Issues
+
+**Symptom**: Training hangs or crashes at the data loading step.
+
+**Debug**: Use the `test_reader` function in `tools/train.py` (line 248).
+Uncomment the call at the bottom of the file to test data loading without
+running training:
+
+```python
+# At bottom of tools/train.py, uncomment:
+test_reader(config, device, logger)
+```
+
+Or run directly:
+```bash
+python -c "
+import tools.program as program
+config, device, logger, _ = program.preprocess(is_train=True)
+from tools.train import test_reader
+test_reader(config, device, logger)
+"
+```
+
+**Common data issues**:
+- Wrong `data_dir` path (images not found)
+- Malformed label file (wrong delimiter, bad JSON)
+- Label file references images that don't exist
+- `num_workers` too high for your system
+
+### Loss NaN or Explosion
+
+**Symptom**: Loss becomes NaN or increases rapidly.
+
+**Common causes and fixes**:
+- **Learning rate too high**: Reduce `Optimizer.lr.learning_rate`
+- **AMP level too aggressive**: Try `amp_level: O1` instead of `O2`
+- **Missing gradient clipping**: Some algorithms require it
+- **Data issue**: Bad images or labels causing extreme values
+- **Batch size too small**: Increase `batch_size_per_card`
+
+### Checkpoint Loading Errors
+
+**Symptom**: `KeyError` or shape mismatch when loading a checkpoint.
+
+**Cause**: The model architecture in the config does not match the saved
+checkpoint. This happens when:
+- You changed the model architecture after training started
+- You are loading a pretrained model with a different head size
+- The character dictionary changed (different number of characters)
+
+**Fix**: Ensure the config matches the one used to create the checkpoint.
+For fine-tuning with a different character set, use `pretrained_model`
+(which ignores mismatched keys) instead of `checkpoints`.
+
+---
+
+## Debugging Inference Issues
+
+### Layer 1 Issues
+
+**Symptom**: `RuntimeError: A dependency error occurred during predictor creation`
+
+**Cause**: Missing PaddleX dependencies.
+
+**Fix**: Install required extras:
+```bash
+pip install "paddleocr[doc-parser]"   # For VLM features
+pip install "paddleocr[all]"          # All optional dependencies
+```
+
+---
+
+**Symptom**: Model download fails or times out.
+
+**Cause**: Network issues or disk space.
+
+**Fix**:
+- Check internet connectivity
+- Manually download the model and use `model_dir` parameter
+- Check available disk space
+
+### Layer 2 Issues
+
+**Symptom**: `InputSpec` error during model export.
+
+**Cause**: The export script (`ppocr/utils/export_model.py`) defines
+input shapes per algorithm. If your algorithm is not handled, export fails.
+
+**Fix**: Add an `InputSpec` branch for your algorithm in
+`ppocr/utils/export_model.py:dynamic_to_static()`.
+
+---
+
+**Symptom**: Shape mismatch during inference but training works.
+
+**Cause**: Dynamic shapes during training vs. fixed shapes during inference.
+Common with models that use different input sizes.
+
+**Fix**: Check the `InputSpec` used during export and ensure your inference
+input matches the expected shape.
+
+---
+
+## Logging
+
+### Layer 2 Logging (ppocr/utils/logging.py)
+
+The training scripts use PaddleOCR's custom logger:
+
+```python
+from ppocr.utils.logging import get_logger
+logger = get_logger()
+logger.info("Training started")
+```
+
+Log verbosity is controlled by `Global.log_smooth_window` and
+`Global.print_batch_step` in the config.
+
+### Layer 1 Logging (paddleocr/_utils/logging.py)
+
+The pipeline API uses a separate logger:
+
+```python
+from paddleocr import logger
+logger.setLevel("DEBUG")  # For verbose output
+```
+
+---
+
+## Common Errors Quick Reference
+
+| Error                                      | Likely cause                                     | Fix                                                    |
+|--------------------------------------------|--------------------------------------------------|--------------------------------------------------------|
+| `backbone only support [...]`              | Class name not in support_dict                   | Register in correct `__init__.py` branch               |
+| `head only support [...]`                  | Head class not registered                        | Add to `ppocr/modeling/heads/__init__.py`               |
+| `loss only support [...]`                  | Loss class not registered                        | Add to `ppocr/losses/__init__.py`                      |
+| `unexpected keyword argument 'xxx'`        | YAML key doesn't match constructor param         | Align YAML keys with `__init__` parameter names        |
+| Shape mismatch in forward pass             | `out_channels` wrong in backbone or neck         | Verify `self.out_channels` is set correctly             |
+| `No Images in train dataset`               | Empty dataset or wrong `data_dir`                | Check paths in config, verify images exist              |
+| Loss is NaN                                | LR too high, AMP issues, bad data                | Reduce LR, try `amp_level: O1`, check data             |
+| Checkpoint load `KeyError`                 | Architecture mismatch                            | Use matching config, or `pretrained_model` for fine-tune|
+| `DependencyError` in predictor creation    | Missing PaddleX extras                           | `pip install "paddleocr[all]"`                         |
+| Model only gets image tensor (no labels)   | Algorithm not in `extra_input_models`            | Add to list in `tools/program.py`                      |

--- a/docs/onboarding/training-evaluation.md
+++ b/docs/onboarding/training-evaluation.md
@@ -1,0 +1,368 @@
+# Training and Evaluation
+
+End-to-end guide for training PaddleOCR models and running evaluation. This
+covers the training pipeline, data preparation, evaluation, and checkpointing.
+
+## Training Overview
+
+```
+┌──────────────┐     ┌─────────────────┐     ┌───────────────────────┐
+│              │     │                 │     │                       │
+│  YAML Config │────>│  program.       │────>│  Build Components:    │
+│  (-c flag)   │     │  preprocess()   │     │  - DataLoader         │
+│              │     │                 │     │  - Model (BaseModel)  │
+└──────────────┘     └─────────────────┘     │  - Loss               │
+                                              │  - Optimizer + LR     │
+                                              │  - PostProcess        │
+┌──────────────┐     ┌─────────────────┐     │  - Metric             │
+│ CLI Override │────>│  merge_config() │────>│                       │
+│ (-o flag)    │     │                 │     └───────────┬───────────┘
+└──────────────┘     └─────────────────┘                 │
+                                                          v
+                                              ┌───────────────────────┐
+                                              │  program.train()      │
+                                              │                       │
+                                              │  For each epoch:      │
+                                              │    For each batch:    │
+                                              │      forward pass     │
+                                              │      compute loss     │
+                                              │      backward + step  │
+                                              │    Periodic eval      │
+                                              │    Save checkpoint    │
+                                              └───────────────────────┘
+```
+
+The entry point is `tools/train.py`. It calls `program.preprocess()` to
+load config and set up logging, then `main()` to build all components, and
+finally `program.train()` for the training loop.
+
+## Prerequisites
+
+- **PaddlePaddle** with GPU support (for training)
+- **Training data** in the expected format (see Data Preparation below)
+- **A config file** (start by copying an existing one from `configs/`)
+
+## Running Training
+
+### Single-GPU Training
+
+```bash
+python tools/train.py -c configs/det/det_mv3_db.yml
+```
+
+### Multi-GPU Training
+
+```bash
+python -m paddle.distributed.launch \
+    --gpus '0,1,2,3' \
+    tools/train.py \
+    -c configs/det/det_mv3_db.yml
+```
+
+### CLI Config Overrides
+
+Override any config value with `-o`:
+
+```bash
+python tools/train.py -c configs/det/det_mv3_db.yml \
+    -o Global.use_gpu=true \
+    -o Global.epoch_num=100 \
+    -o Train.loader.batch_size_per_card=8 \
+    -o Global.pretrained_model=./my_pretrain/model \
+    -o Architecture.Backbone.name=ResNet_vd
+```
+
+Dot notation navigates nested keys. This is implemented in
+`tools/program.py:merge_config()`.
+
+## The Training Loop in Detail
+
+### 1. `program.preprocess()` (tools/program.py)
+
+- Parses CLI args (`-c` config path, `-o` overrides, `-p` profiler)
+- Loads YAML config via `load_config()`
+- Merges CLI overrides via `merge_config()`
+- Sets up device (GPU/CPU), logging, and VisualDL writer
+- Returns `(config, device, logger, vdl_writer)`
+
+### 2. `train.py:main()` (tools/train.py:46)
+
+Builds all components in this order:
+
+```python
+# 1. Build data loaders
+train_dataloader = build_dataloader(config, "Train", device, logger, seed)
+valid_dataloader = build_dataloader(config, "Eval", device, logger, seed)
+
+# 2. Build post-processor (needed before model for character count)
+post_process_class = build_post_process(config["PostProcess"], global_config)
+
+# 3. Build model (may adjust head out_channels based on char count)
+model = build_model(config["Architecture"])
+
+# 4. Build loss
+loss_class = build_loss(config["Loss"])
+
+# 5. Build optimizer and LR scheduler
+optimizer, lr_scheduler = build_optimizer(config["Optimizer"], ...)
+
+# 6. Build metric
+eval_class = build_metric(config["Metric"])
+
+# 7. Load pretrained weights or resume from checkpoint
+pre_best_model_dict = load_model(config, model, optimizer, ...)
+
+# 8. Start training
+program.train(config, train_dataloader, valid_dataloader, device, model,
+              loss_class, optimizer, lr_scheduler, post_process_class,
+              eval_class, ...)
+```
+
+**Why is post-processing built before the model?** For recognition models,
+the post-processor loads the character dictionary, and the character count
+determines the output dimension of the recognition head. The training script
+reads `len(post_process_class.character)` and sets
+`config["Architecture"]["Head"]["out_channels"]` accordingly.
+
+### 3. `program.train()` (tools/program.py)
+
+The training loop:
+
+```
+For epoch in range(start_epoch, total_epochs):
+    For batch_idx, batch in enumerate(train_dataloader):
+        images = batch[0]
+
+        # Forward pass (with optional AMP)
+        if extra_input:
+            preds = model(images, data=batch[1:])
+        else:
+            preds = model(images)
+
+        # Compute loss
+        loss = loss_class(preds, batch)
+
+        # Backward pass
+        loss["loss"].backward()
+        optimizer.step()
+        optimizer.clear_grad()
+        lr_scheduler.step()
+
+        # Periodic evaluation
+        if global_step % eval_batch_step == 0:
+            metric = program.eval(model, valid_dataloader, ...)
+            if metric[main_indicator] > best:
+                save_model(model, "best_accuracy")
+```
+
+## Data Preparation
+
+### SimpleDataSet Format
+
+The most common format. You need:
+
+1. **Image files** in a directory
+2. **A label file** (text file, one line per image):
+
+**Detection labels:**
+```
+img_001.jpg\t[{"transcription": "HELLO", "points": [[100,50],[200,50],[200,80],[100,80]]}, ...]
+img_002.jpg\t[{"transcription": "WORLD", "points": [[50,100],[150,100],[150,130],[50,130]]}]
+```
+
+**Recognition labels:**
+```
+img_001.jpg\tHello World
+img_002.jpg\t你好世界
+```
+
+Fields are separated by `\t` (tab). The data directory and label file are
+specified in the config:
+
+```yaml
+Train:
+  dataset:
+    name: SimpleDataSet
+    data_dir: ./train_data/icdar2015/text_localization/
+    label_file_list:
+      - ./train_data/icdar2015/text_localization/train_label.txt
+```
+
+### LMDBDataSet Format
+
+For large-scale training. LMDB stores images and labels in a key-value
+database for fast sequential access. Use when your dataset has millions of
+samples.
+
+### Data Augmentation Pipeline
+
+The transform chain is configured in `Train.dataset.transforms`. Common
+operators:
+
+| Operator           | Purpose                                          |
+|--------------------|--------------------------------------------------|
+| `DecodeImage`      | Load image from path (BGR or RGB)                |
+| `DetLabelEncode`   | Parse detection label JSON into polygon arrays   |
+| `CTCLabelEncode`   | Encode text string to character indices           |
+| `IaaAugment`       | Random flip, rotation, resize                    |
+| `EastRandomCropData`| Random crop for detection training              |
+| `MakeBorderMap`    | Generate DB border regression target             |
+| `MakeShrinkMap`    | Generate DB shrink map target                    |
+| `RecResizeImg`     | Resize recognition images to fixed height        |
+| `NormalizeImage`   | Scale to [0,1], subtract mean, divide by std     |
+| `ToCHWImage`       | Convert from HWC to CHW tensor format            |
+| `KeepKeys`         | Select which data fields to pass to the model    |
+
+```
+Data Flow:
+
+Raw image file + label text
+         │
+         v
+    DecodeImage          → dict: {image: ndarray, label: str, ...}
+         │
+         v
+    DetLabelEncode       → dict: {image, polys, ignore_tags, ...}
+         │
+         v
+    IaaAugment           → dict: {image (augmented), polys, ...}
+         │
+         v
+    MakeBorderMap        → dict: {image, polys, threshold_map, ...}
+    MakeShrinkMap        → dict: {image, polys, shrink_map, ...}
+         │
+         v
+    NormalizeImage        → dict: {image (float32, normalized), ...}
+    ToCHWImage            → dict: {image (CHW format), ...}
+         │
+         v
+    KeepKeys             → tuple: (image, threshold_map, shrink_map, ...)
+         │
+         v
+    DataLoader batches   → tensor batch for model.forward()
+```
+
+## Checkpointing and Resuming
+
+### Saving Checkpoints
+
+Controlled by these Global config keys:
+
+```yaml
+Global:
+  save_model_dir: ./output/db_mv3/     # where to save
+  save_epoch_step: 100                   # save every N epochs
+```
+
+Checkpoints are saved as:
+- `{save_model_dir}/latest.pdparams` — latest model weights
+- `{save_model_dir}/latest.pdopt` — optimizer state
+- `{save_model_dir}/latest.states` — training state (epoch, best metric)
+- `{save_model_dir}/best_accuracy.pdparams` — best model by main_indicator
+
+### Resuming Training
+
+Set the `checkpoints` field to resume from a saved checkpoint:
+
+```yaml
+Global:
+  checkpoints: ./output/db_mv3/latest
+```
+
+Or via CLI:
+```bash
+python tools/train.py -c config.yml \
+    -o Global.checkpoints=./output/db_mv3/latest
+```
+
+### Loading a Pretrained Model (Fine-Tuning)
+
+Use `pretrained_model` to load weights without optimizer state:
+
+```yaml
+Global:
+  pretrained_model: ./pretrain_models/MobileNetV3_large_x0_5_pretrained
+```
+
+Difference: `checkpoints` loads both model + optimizer + training state
+(for resuming). `pretrained_model` loads only model weights (for
+fine-tuning).
+
+## Running Evaluation
+
+### Standalone Evaluation
+
+```bash
+python tools/eval.py -c configs/det/det_mv3_db.yml \
+    -o Global.checkpoints=./output/db_mv3/best_accuracy
+```
+
+### Evaluation During Training
+
+Controlled by `eval_batch_step`:
+
+```yaml
+Global:
+  eval_batch_step: [0, 2000]    # [start_step, interval]
+```
+
+This runs evaluation every 2000 training iterations, starting from iteration
+0. If the metric improves, the best checkpoint is saved.
+
+### Understanding Metric Output
+
+**Detection** (DetMetric):
+```
+precision: 0.8523   ← of detected boxes, % that are correct
+recall:    0.7891   ← of ground-truth boxes, % that were found
+hmean:     0.8195   ← harmonic mean (THE primary metric)
+```
+
+**Recognition** (RecMetric):
+```
+acc:       0.9234   ← % of text lines recognized exactly right
+norm_edit_dis: 0.0412  ← average normalized edit distance
+```
+
+The `main_indicator` field in the Metric config determines which value is
+used for "best checkpoint" selection.
+
+## Mixed Precision Training (AMP)
+
+Enable AMP for faster training on modern GPUs:
+
+```yaml
+Global:
+  use_amp: true
+  amp_level: O2          # O1 (conservative) or O2 (aggressive)
+  amp_dtype: float16      # float16 or bfloat16
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: false
+```
+
+Or via CLI:
+```bash
+python tools/train.py -c config.yml -o Global.use_amp=true
+```
+
+## Logging
+
+### Console Logging
+
+```yaml
+Global:
+  log_smooth_window: 20    # average loss over this many steps
+  print_batch_step: 10     # print every N steps
+```
+
+### WandB Integration
+
+PaddleOCR supports Weights & Biases logging via `ppocr/utils/loggers.py`.
+Configure in your training script or environment.
+
+## What's Next?
+
+- **[Deployment & Export](deployment-export.md)** — How to export your
+  trained model and deploy it to production
+- **[Testing & Debugging](testing-debugging.md)** — How to test and debug
+  common training issues


### PR DESCRIPTION
Create docs/onboarding/ with 8 standalone Markdown files covering OCR fundamentals, architecture deep dive, codebase navigation, and developer workflows (adding models, training, deployment, testing).

Targets software engineers new to OCR and PaddleOCR with zero prior OCR knowledge. Includes ASCII diagrams for key data flows and architecture patterns.