### PR TITLE
fix(ppstructurev3): escape html-sensitive OCR text in table markdown output

### DIFF
--- a/paddleocr/_pipelines/_patch_table_markdown.py
+++ b/paddleocr/_pipelines/_patch_table_markdown.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patches for PP-StructureV3 table markdown escaping.
+
+Fixes HTML-sensitive OCR text being injected into table cells without escaping,
+which breaks `save_to_markdown()` output for content like `<recv .../>`.
+
+See: https://github.com/PaddlePaddle/PaddleOCR/issues/16096
+"""
+
+import html
+import logging
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+
+
+def _split_bold_wrapper(content):
+    """Return whether content is wrapped by a single outer `<b>...</b>` pair."""
+    if content.startswith("<b>") and content.endswith("</b>"):
+        return True, content[3:-4]
+    return False, content
+
+
+def _escape_cell_content(content):
+    """Escape OCR cell text while preserving a single outer bold wrapper."""
+    is_bold, inner_content = _split_bold_wrapper(content)
+    escaped_content = html.escape(inner_content, quote=True)
+    if is_bold:
+        return f"<b>{escaped_content}</b>"
+    return escaped_content
+
+
+def _fixed_get_html_result(matched_index, ocr_contents, pred_structures):
+    """Generate HTML table content with HTML-sensitive OCR text escaped."""
+    pred_html = []
+    td_index = 0
+    head_structure = pred_structures[0:3]
+    html_text = "".join(head_structure)
+    table_structure = pred_structures[3:-3]
+
+    for tag in table_structure:
+        if "</td>" not in tag:
+            pred_html.append(tag)
+            continue
+
+        if tag == "<td></td>":
+            pred_html.append("<td>")
+
+        if td_index in matched_index:
+            matched_cell_indexes = matched_index[td_index]
+            use_shared_bold_wrapper = (
+                len(matched_cell_indexes) > 1
+                and "<b>" in ocr_contents[matched_cell_indexes[0]]
+            )
+            if use_shared_bold_wrapper:
+                pred_html.append("<b>")
+
+            for content_index, ocr_index in enumerate(matched_cell_indexes):
+                content = ocr_contents[ocr_index]
+                if len(matched_cell_indexes) > 1:
+                    if len(content) == 0:
+                        continue
+                    if content[0] == " ":
+                        content = content[1:]
+                    if content.startswith("<b>"):
+                        content = content[3:]
+                    if content.endswith("</b>"):
+                        content = content[:-4]
+                    if len(content) == 0:
+                        continue
+                    if (
+                        content_index != len(matched_cell_indexes) - 1
+                        and content[-1] != " "
+                    ):
+                        content += " "
+                    pred_html.append(html.escape(content, quote=True))
+                else:
+                    pred_html.append(_escape_cell_content(content))
+
+            if use_shared_bold_wrapper:
+                pred_html.append("</b>")
+
+        if tag == "<td></td>":
+            pred_html.append("</td>")
+        else:
+            pred_html.append(tag)
+        td_index += 1
+
+    html_text += "".join(pred_html)
+    html_text += "".join(pred_structures[-3:])
+    return html_text
+
+
+def apply_patches():
+    """Monkey-patch PaddleX table post-processing helpers."""
+    global _patched
+    if _patched:
+        return
+
+    try:
+        import paddlex.inference.pipelines.table_recognition.table_recognition_post_processing as post_processing
+        import paddlex.inference.pipelines.table_recognition.table_recognition_post_processing_v2 as post_processing_v2
+    except ImportError:
+        logger.debug("paddlex table recognition modules not available; skipping patches")
+        return
+
+    post_processing.get_html_result = _fixed_get_html_result
+    post_processing_v2.get_html_result = _fixed_get_html_result
+
+    _patched = True
+    logger.debug("Applied table markdown escaping patches for issue #16096")

--- a/paddleocr/_pipelines/_patch_table_markdown.py
+++ b/paddleocr/_pipelines/_patch_table_markdown.py
@@ -115,7 +115,9 @@ def apply_patches():
         import paddlex.inference.pipelines.table_recognition.table_recognition_post_processing as post_processing
         import paddlex.inference.pipelines.table_recognition.table_recognition_post_processing_v2 as post_processing_v2
     except ImportError:
-        logger.debug("paddlex table recognition modules not available; skipping patches")
+        logger.debug(
+            "paddlex table recognition modules not available; skipping patches"
+        )
         return
 
     post_processing.get_html_result = _fixed_get_html_result

--- a/paddleocr/_pipelines/pp_structurev3.py
+++ b/paddleocr/_pipelines/pp_structurev3.py
@@ -22,8 +22,10 @@ from .._utils.cli import (
 from .base import PaddleXPipelineWrapper, PipelineCLISubcommandExecutor
 from .utils import create_config_from_structure
 from ._patch_layout_parsing import apply_patches as _apply_layout_parsing_patches
+from ._patch_table_markdown import apply_patches as _apply_table_markdown_patches
 
 _apply_layout_parsing_patches()
+_apply_table_markdown_patches()
 
 _SUPPORTED_OCR_VERSIONS = ["PP-OCRv3", "PP-OCRv4", "PP-OCRv5"]
 

--- a/tests/pipelines/test_patch_table_markdown.py
+++ b/tests/pipelines/test_patch_table_markdown.py
@@ -1,0 +1,183 @@
+"""Regression tests for table markdown escaping patches (issue #16096).
+
+These tests import the patch module directly so they can verify the patched
+HTML assembly logic without importing the full paddleocr package.
+"""
+
+import importlib.util
+import sys
+import types
+
+def _import_patch_module():
+    """Import _patch_table_markdown without triggering paddleocr.__init__."""
+    spec = importlib.util.spec_from_file_location(
+        "paddleocr._pipelines._patch_table_markdown",
+        "paddleocr/_pipelines/_patch_table_markdown.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_patch_mod = _import_patch_module()
+_fixed_get_html_result = _patch_mod._fixed_get_html_result
+
+
+def _minimal_table_structure():
+    return [
+        "<html>",
+        "<body>",
+        "<table>",
+        "<tr>",
+        "<td></td>",
+        "</tr>",
+        "</table>",
+        "</body>",
+        "</html>",
+    ]
+
+
+def _buggy_get_html_result(matched_index, ocr_contents, pred_structures):
+    """Current upstream behavior used to build fake paddlex modules."""
+    pred_html = []
+    td_index = 0
+    head_structure = pred_structures[0:3]
+    html = "".join(head_structure)
+    table_structure = pred_structures[3:-3]
+    for tag in table_structure:
+        if "</td>" in tag:
+            if "<td></td>" == tag:
+                pred_html.extend("<td>")
+            if td_index in matched_index.keys():
+                b_with = False
+                if (
+                    "<b>" in ocr_contents[matched_index[td_index][0]]
+                    and len(matched_index[td_index]) > 1
+                ):
+                    b_with = True
+                    pred_html.extend("<b>")
+                for i, td_index_index in enumerate(matched_index[td_index]):
+                    content = ocr_contents[td_index_index]
+                    if len(matched_index[td_index]) > 1:
+                        if len(content) == 0:
+                            continue
+                        if content[0] == " ":
+                            content = content[1:]
+                        if "<b>" in content:
+                            content = content[3:]
+                        if "</b>" in content:
+                            content = content[:-4]
+                        if len(content) == 0:
+                            continue
+                        if i != len(matched_index[td_index]) - 1 and " " != content[-1]:
+                            content += " "
+                    pred_html.extend(content)
+                if b_with:
+                    pred_html.extend("</b>")
+            if "<td></td>" == tag:
+                pred_html.append("</td>")
+            else:
+                pred_html.append(tag)
+            td_index += 1
+        else:
+            pred_html.append(tag)
+    html += "".join(pred_html)
+    html += "".join(pred_structures[-3:])
+    return html
+
+
+def _install_fake_paddlex_modules():
+    """Install a minimal paddlex module tree for apply_patches tests."""
+    module_names = [
+        "paddlex",
+        "paddlex.inference",
+        "paddlex.inference.pipelines",
+        "paddlex.inference.pipelines.table_recognition",
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing",
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing_v2",
+    ]
+    originals = {name: sys.modules.get(name) for name in module_names}
+
+    paddlex_mod = types.ModuleType("paddlex")
+    inference_mod = types.ModuleType("paddlex.inference")
+    pipelines_mod = types.ModuleType("paddlex.inference.pipelines")
+    table_rec_mod = types.ModuleType("paddlex.inference.pipelines.table_recognition")
+    post_mod = types.ModuleType(
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing"
+    )
+    post_v2_mod = types.ModuleType(
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing_v2"
+    )
+
+    post_mod.get_html_result = _buggy_get_html_result
+    post_v2_mod.get_html_result = _buggy_get_html_result
+
+    paddlex_mod.inference = inference_mod
+    inference_mod.pipelines = pipelines_mod
+    pipelines_mod.table_recognition = table_rec_mod
+    table_rec_mod.table_recognition_post_processing = post_mod
+    table_rec_mod.table_recognition_post_processing_v2 = post_v2_mod
+
+    sys.modules["paddlex"] = paddlex_mod
+    sys.modules["paddlex.inference"] = inference_mod
+    sys.modules["paddlex.inference.pipelines"] = pipelines_mod
+    sys.modules["paddlex.inference.pipelines.table_recognition"] = table_rec_mod
+    sys.modules[
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing"
+    ] = post_mod
+    sys.modules[
+        "paddlex.inference.pipelines.table_recognition.table_recognition_post_processing_v2"
+    ] = post_v2_mod
+
+    return originals, post_mod, post_v2_mod
+
+
+def _restore_modules(originals):
+    for name, module in originals.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+class TestFixedGetHtmlResult:
+    def test_escapes_html_sensitive_cell_text(self):
+        result = _fixed_get_html_result(
+            {0: [0]},
+            ['<recv response="200" response_txn="invite" />'],
+            _minimal_table_structure(),
+        )
+        assert (
+            "<td>&lt;recv response=&quot;200&quot; response_txn=&quot;invite&quot; /&gt;</td>"
+            in result
+        )
+        assert '<td><recv response="200" response_txn="invite" /></td>' not in result
+
+    def test_preserves_bold_markup_while_escaping_text(self):
+        result = _fixed_get_html_result(
+            {0: [0]},
+            ['<b><pause milliseconds="5000"/></b>'],
+            _minimal_table_structure(),
+        )
+        assert (
+            "<td><b>&lt;pause milliseconds=&quot;5000&quot;/&gt;</b></td>"
+            in result
+        )
+
+
+class TestApplyPatches:
+    def test_apply_patches_monkey_patches_both_post_processing_modules(self):
+        originals, post_mod, post_v2_mod = _install_fake_paddlex_modules()
+        try:
+            _patch_mod._patched = False
+            _patch_mod.apply_patches()
+
+            assert post_mod.get_html_result is _fixed_get_html_result
+            assert post_v2_mod.get_html_result is _fixed_get_html_result
+
+            _patch_mod.apply_patches()
+            assert post_mod.get_html_result is _fixed_get_html_result
+            assert post_v2_mod.get_html_result is _fixed_get_html_result
+        finally:
+            _patch_mod._patched = False
+            _restore_modules(originals)

--- a/tests/pipelines/test_patch_table_markdown.py
+++ b/tests/pipelines/test_patch_table_markdown.py
@@ -8,6 +8,7 @@ import importlib.util
 import sys
 import types
 
+
 def _import_patch_module():
     """Import _patch_table_markdown without triggering paddleocr.__init__."""
     spec = importlib.util.spec_from_file_location(
@@ -159,10 +160,7 @@ class TestFixedGetHtmlResult:
             ['<b><pause milliseconds="5000"/></b>'],
             _minimal_table_structure(),
         )
-        assert (
-            "<td><b>&lt;pause milliseconds=&quot;5000&quot;/&gt;</b></td>"
-            in result
-        )
+        assert "<td><b>&lt;pause milliseconds=&quot;5000&quot;/&gt;</b></td>" in result
 
 
 class TestApplyPatches:


### PR DESCRIPTION
Addresses #16096

## Summary

This PR fixes an HTML escaping issue in `PPStructureV3` table markdown export.

When OCR text inside table cells contains HTML-sensitive content such as `<recv .../>` or `<pause .../>`, the current table HTML assembly path may inject raw OCR text directly into `<td>` nodes. This makes the markdown output render incorrectly and can blur the boundary between original OCR content and generated HTML structure.

This PR narrows the fix to the `PPStructureV3` table export path only.

## Changes

- add a local PaddleOCR patch for PaddleX table post-processing
- escape HTML-sensitive table cell OCR text with `html.escape(..., quote=True)`
- preserve a single outer `<b>...</b>` wrapper so bold formatting is not lost
- apply the patch to both table post-processing modules
- add regression tests for:
  - raw HTML-sensitive OCR text such as `<recv .../>`
  - bold-wrapped content
  - patch application on both post-processing modules

## Scope

This PR does not change `PaddleOCRVL`.
It only fixes the `PPStructureV3` table markdown export path.

## Tests

```bash
pytest tests/pipelines/test_patch_layout_parsing.py tests/pipelines/test_patch_table_markdown.py -q
```