### PR TITLE
Clarify that PaddleOCR-VL manual-install docs describe the verified Python range

### DIFF
--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-AMD-GPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-AMD-GPU.en.md
@@ -48,7 +48,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-AMD-GPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-AMD-GPU.md
@@ -48,7 +48,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Huawei-Ascend-NPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Huawei-Ascend-NPU.en.md
@@ -51,7 +51,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Huawei-Ascend-NPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Huawei-Ascend-NPU.md
@@ -51,7 +51,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Hygon-DCU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Hygon-DCU.en.md
@@ -56,7 +56,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Hygon-DCU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Hygon-DCU.md
@@ -56,7 +56,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Iluvatar-GPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Iluvatar-GPU.en.md
@@ -53,7 +53,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Iluvatar-GPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Iluvatar-GPU.md
@@ -53,7 +53,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Intel-Arc-GPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Intel-Arc-GPU.en.md
@@ -48,7 +48,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Intel-Arc-GPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Intel-Arc-GPU.md
@@ -48,7 +48,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Kunlunxin-XPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Kunlunxin-XPU.en.md
@@ -49,7 +49,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. The required Python version is 3.9–3.13.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-Kunlunxin-XPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-Kunlunxin-XPU.md
@@ -49,7 +49,7 @@ docker run \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-MetaX-GPU.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-MetaX-GPU.en.md
@@ -50,7 +50,7 @@ If you wish to start the service in an environment without internet access, repl
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If you cannot use Docker, you can also manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-MetaX-GPU.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-MetaX-GPU.md
@@ -50,7 +50,7 @@ docker run -it \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.en.md
@@ -58,7 +58,7 @@ If you wish to use PaddleOCR-VL in an offline environment, replace `ccr-2vdh3abv
 
 ### 1.2 Method 2: Manually Install PaddlePaddle and PaddleOCR
 
-If Docker is not an option, you can manually install PaddlePaddle and PaddleOCR. Python version 3.9–3.13 is required.
+If Docker is not an option, you can manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, create a virtual environment using Python's standard venv library:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.md
@@ -58,7 +58,7 @@ docker run \
 
 ### 1.2 方法二：手动安装 PaddlePaddle 和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL.en.md
@@ -320,7 +320,7 @@ The image comes preinstalled with the PaddlePaddle framework and does not includ
 
 ### 1.2 Method 2: Manually Install the Inference Engine and PaddleOCR
 
-If you cannot use Docker, you can manually install PaddlePaddle and PaddleOCR. The required Python version is 3.9–3.13.
+If you cannot use Docker, you can manually install PaddlePaddle and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, use the Python venv standard library to create a virtual environment:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL.md
@@ -319,7 +319,7 @@ docker load -i paddleocr-vl-latest-nvidia-gpu-offline.tar
 
 ### 1.2 方法二：手动安装推理引擎和 PaddleOCR
 
-如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。要求 Python 版本为 3.9–3.13。
+如果您无法使用 Docker，也可以手动安装 PaddlePaddle 和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 


### PR DESCRIPTION
## Summary

Clarify the repeated PaddleOCR-VL manual-install wording so it describes the **documented verification range** instead of reading like a hard runtime prohibition.

## Why

The current sentence says Python 3.8–3.13 is required. That is easy to read as “newer Python versions will not work”, while the more conservative and accurate meaning appears to be that 3.8–3.13 is the range covered by the current docs/tests for these guides.

This PR keeps the docs conservative without expanding the official support promise.

## Changes

- update the repeated manual-install sentence in the PaddleOCR-VL main guide
- apply the same clarification to the hardware-specific PaddleOCR-VL guides
- keep scope docs-only

## Validation

- verified all repeated PaddleOCR-VL manual-install statements were updated consistently
- local package validation used for wording justification:
  - editable install/import of current `paddleocr` on Python 3.13 and 3.14 succeeded
  - editable install/import of current `langchain-paddleocr` on Python 3.14 succeeded
  - install/import of released `paddleocr==3.4.1` on Python 3.14 succeeded

Fixes #17935
