### PR TITLE
Fix docs anchor links

### DIFF
--- a/docs/version3.x/inference_deployment/serving/paddleocr_official_api/cli.md
+++ b/docs/version3.x/inference_deployment/serving/paddleocr_official_api/cli.md
@@ -8,7 +8,7 @@ comments: true
 
 ## 安装与认证
 
-先按 [安装 `paddleocr`](../../../installation.md#11-安装-paddleocr) 安装 Python 包。安装 `paddleocr` 本体后即可使用此功能，无需安装额外依赖组。
+先按 [安装 `paddleocr`](../../../installation.md#install-paddleocr) 安装 Python 包。安装 `paddleocr` 本体后即可使用此功能，无需安装额外依赖组。
 
 请先在 [AI Studio Access Token 页面](https://aistudio.baidu.com/account/accessToken) 获取访问令牌。
 

--- a/docs/version3.x/inference_deployment/serving/paddleocr_official_api/python.md
+++ b/docs/version3.x/inference_deployment/serving/paddleocr_official_api/python.md
@@ -8,7 +8,7 @@ Python SDK 通过 `paddleocr` 包中的 `PaddleOCRClient` 和 `AsyncPaddleOCRCli
 
 ## 安装与认证
 
-先按 [安装 `paddleocr`](../../../installation.md#11-安装-paddleocr) 安装 Python 包。安装 `paddleocr` 本体后即可使用此功能，无需安装额外依赖组。
+先按 [安装 `paddleocr`](../../../installation.md#install-paddleocr) 安装 Python 包。安装 `paddleocr` 本体后即可使用此功能，无需安装额外依赖组。
 
 请先在 [AI Studio Access Token 页面](https://aistudio.baidu.com/account/accessToken) 获取访问令牌。
 

--- a/docs/version3.x/installation.md
+++ b/docs/version3.x/installation.md
@@ -10,7 +10,7 @@ comments: true
 
 **Python 版本要求**：`paddleocr` 本体与 `doc2md` 依赖组支持 Python 3.8 及以上；其他可选依赖组（`doc-parser`、`ie`、`trans`、`all`）受上游依赖限制，需要 Python 3.9 及以上。
 
-### 1.1 安装 `paddleocr`
+### 1.1 安装 `paddleocr` {#install-paddleocr}
 
 从 PyPI 安装最新版本的 `paddleocr`：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.en.md
@@ -80,7 +80,7 @@ If you wish to use PaddleOCR-VL in an offline environment, replace `ccr-2vdh3abv
 
 If Docker is not an option, you can manually install the inference engine and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 
-This guide provides PaddlePaddle installation steps. To use Transformers or other inference engines, see [Section 1.2 of the main tutorial](./PaddleOCR-VL.en.md#12).
+This guide provides PaddlePaddle installation steps. To use Transformers or other inference engines, see [Section 1.2 of the main tutorial](./PaddleOCR-VL.en.md#manual-install-inference-engine-and-paddleocr).
 
 **We strongly recommend installing PaddleOCR-VL in a virtual environment to avoid dependency conflicts.** For example, create a virtual environment using Python's standard venv library:
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL-NVIDIA-Blackwell.md
@@ -79,7 +79,7 @@ docker run \
 
 如果您无法使用 Docker，也可以手动安装推理引擎和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 
-本教程提供 PaddlePaddle 安装步骤；若需使用 Transformers 等其他推理引擎，请参考 [主教程第 1.2 节](./PaddleOCR-VL.md#12)。
+本教程提供 PaddlePaddle 安装步骤；若需使用 Transformers 等其他推理引擎，请参考 [主教程第 1.2 节](./PaddleOCR-VL.md#manual-install-inference-engine-and-paddleocr)。
 
 **我们强烈推荐您在虚拟环境中安装 PaddleOCR-VL，以避免发生依赖冲突。** 例如，使用 Python venv 标准库创建虚拟环境：
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL.en.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL.en.md
@@ -309,7 +309,7 @@ The image comes preinstalled with the PaddlePaddle framework and does not includ
 > `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-vl:paddleocr3.3-nvidia-gpu-offline`
 
 
-### 1.2 Method 2: Manually Install the Inference Engine and PaddleOCR
+### 1.2 Method 2: Manually Install the Inference Engine and PaddleOCR {#manual-install-inference-engine-and-paddleocr}
 
 If you cannot use Docker, you can manually install the inference engine and PaddleOCR. This guide documents Python 3.9–3.13 as the verified range.
 

--- a/docs/version3.x/pipeline_usage/PaddleOCR-VL.md
+++ b/docs/version3.x/pipeline_usage/PaddleOCR-VL.md
@@ -149,7 +149,7 @@ docker load -i paddleocr-vl-latest-nvidia-gpu-offline.tar
 > 例如：
 > `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleocr-vl:paddleocr3.3-nvidia-gpu-offline`
 
-### 1.2 方法二：手动安装推理引擎和 PaddleOCR
+### 1.2 方法二：手动安装推理引擎和 PaddleOCR {#manual-install-inference-engine-and-paddleocr}
 
 如果您无法使用 Docker，也可以手动安装推理引擎和 PaddleOCR。本文档验证过的 Python 版本范围为 3.9–3.13。
 


### PR DESCRIPTION
## Summary
- Add stable anchors for PaddleOCR-VL manual install and PaddleOCR package installation sections.
- Update docs links that used stale generated anchors so strict MkDocs anchor validation passes.

## Test plan
- `ENABLE_GIT_PLUGINS=false ./.venv/bin/python -m mkdocs build -f mkdocs-ci.yml --site-dir /tmp/paddleocr-doc-anchor-fix --clean`


Made with [Cursor](https://cursor.com)