### PR TITLE
Isolate pip cache mount by architecture for multi-arch NPU build

### DIFF
--- a/deploy/paddleocr_vl_docker/accelerators/huawei-npu/pipeline.Dockerfile
+++ b/deploy/paddleocr_vl_docker/accelerators/huawei-npu/pipeline.Dockerfile
@@ -17,6 +17,8 @@ ENV LD_LIBRARY_PATH=${ASCEND_TOOLKIT_HOME}/lib64:${ASCEND_TOOLKIT_HOME}/lib64/pl
 
 FROM base-${TARGETARCH} AS base
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV PYTHONUNBUFFERED=1
@@ -33,16 +35,16 @@ RUN apt-get update \
     && fc-cache -fv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,id=pip-${TARGETARCH},target=/root/.cache/pip \
     python -m pip install paddlepaddle==3.2.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/ \
     && python -m pip install paddle-custom-npu==3.2.0 -i https://www.paddlepaddle.org.cn/packages/stable/npu/
 
 ARG PADDLEOCR_VERSION=">=3.4.0,<3.5"
 ARG PADDLEX_VERSION=">=3.4.0,<3.5"
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,id=pip-${TARGETARCH},target=/root/.cache/pip \
     python -m pip install "paddleocr[doc-parser]${PADDLEOCR_VERSION}" "paddlex[serving]${PADDLEX_VERSION}"
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,id=pip-${TARGETARCH},target=/root/.cache/pip \
     python -m pip install numpy==1.26.4 opencv-contrib-python==4.11.0.86
 
 RUN groupadd -g 1001 paddleocr \
@@ -53,7 +55,7 @@ WORKDIR /home/paddleocr
 USER paddleocr
 
 ENV LD_LIBRARY_PATH=${ASCEND_TOOLKIT_HOME}/tools/aml/lib64:${ASCEND_TOOLKIT_HOME}/tools/aml/lib64/plugin:$LD_LIBRARY_PATH
-ENV PYTHONPATH=${ASCEND_TOOLKIT_HOME}/python/site-packages:${ASCEND_TOOLKIT_HOME}/opp/built-in/op_impl/ai_core/tbe:$PYTHONPATH
+ENV PYTHONPATH=${ASCEND_TOOLKIT_HOME}/python/site-packages:${ASCEND_TOOLKIT_HOME}/opp/built-in/op_impl/ai_core/tbe
 ENV PATH=${ASCEND_TOOLKIT_HOME}/bin:${ASCEND_TOOLKIT_HOME}/compiler/ccec_compiler/bin:${ASCEND_TOOLKIT_HOME}/tools/ccec_compiler/bin:$PATH
 ENV ASCEND_AICPU_PATH=${ASCEND_TOOLKIT_HOME}
 ENV ASCEND_OPP_PATH=${ASCEND_TOOLKIT_HOME}/opp


### PR DESCRIPTION
## Summary

- Add `id=pip-${TARGETARCH}` to all `--mount=type=cache` directives in `huawei-npu/pipeline.Dockerfile`, so that multi-arch builds (amd64 + arm64) get isolated pip cache volumes per architecture instead of sharing a single cache. This avoids arm64 builds scanning incompatible amd64 wheels and vice versa.
- Fix BuildKit lint warning `UndefinedVar: Usage of undefined variable '$PYTHONPATH'` by removing the trailing `:$PYTHONPATH` append from the `PYTHONPATH` ENV line, since no prior stage defines this variable.

## Background

The `huawei-npu/pipeline.Dockerfile` is the only multi-architecture Dockerfile in the accelerators directory (supports both `linux/amd64` and `linux/arm64`). Without an explicit `id` on the cache mount, BuildKit defaults the `id` to the `target` path, causing both architectures to share the same pip cache volume during multi-platform builds.

## Test plan

- [ ] Build for `linux/amd64` and verify pip install works as before
- [ ] Build for `linux/arm64` and verify pip install works as before
- [ ] Build with `--platform linux/amd64,linux/arm64` and verify both architectures get separate cache volumes
- [ ] Verify the BuildKit `UndefinedVar` warning is gone in `--progress=plain` output

Made with [Cursor](https://cursor.com)