### PR TITLE
docs: fix broken relative links in distillation and model list docs

### DIFF
--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
@@ -210,7 +210,7 @@ Architecture:
 
 When the model is finally trained, it contains 3 sub-networks: `Teacher`, `Student`, `Student2`.
 
-The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](../../ppocr/modeling/architectures/distillation_model.py).
+The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py).
 The final model output is a dictionary, the key is the name of all the sub-networks, for example, here are `Student` and `Teacher`, and the value is the output of the corresponding sub-network,
 which can be `Tensor` (only the last layer of the network is returned) and `dict` (also returns the characteristic information in the middle).
 In the recognition task, in order to add more loss functions and ensure the scalability of the distillation method, the output of each sub-network is saved as a `dict`, which contains the sub-module output.

--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
@@ -201,7 +201,7 @@ Architecture:
 
 最终该模型训练时，包含3个子网络：`Teacher`, `Student`, `Student2`。
 
-蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../ppocr/modeling/architectures/distillation_model.py)。
+蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py)。
 
 最终模型`forward`输出为一个字典，key为所有的子网络名称，例如这里为`Student`与`Teacher`，value为对应子网络的输出，可以为`Tensor`（只返回该网络的最后一层）和`dict`（也返回了中间的特征信息）。
 

--- a/docs/version2.x/ppocr/model_list.md
+++ b/docs/version2.x/ppocr/model_list.md
@@ -109,7 +109,7 @@ PaddleOCR提供的可下载模型包括`推理模型`、`训练模型`、`预训
 | 模型名称                      | 模型简介 | 配置文件 | 推理模型大小 | 下载地址  |
 | ---------- | ------------- | ------------- | ------------ | -- |
 | ch_ppocr_mobile_slim_v2.0_cls | slim量化版模型，对检测到的文本行文字角度分类 | [cls_mv3.yml](../../../configs/cls/cls_mv3.yml) | 2.1M         | [推理模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_cls_slim_infer.tar) / [训练模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_rec_slim_infer.tar) / [nb模型](https://paddleocr.bj.bcebos.com/PP-OCRv2/lite/ch_ppocr_mobile_v2.0_cls_infer_opt.nb) |
-| ch_ppocr_mobile_v2.0_cls      | 原始分类器模型，对检测到的文本行文字角度分类 | [cls_mv3.yml](../../../../configs/cls/cls_mv3.yml) | 1.38M        | [推理模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_cls_infer.tar) / [训练模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_cls_train.tar)             |
+| ch_ppocr_mobile_v2.0_cls      | 原始分类器模型，对检测到的文本行文字角度分类 | [cls_mv3.yml](../../../configs/cls/cls_mv3.yml) | 1.38M        | [推理模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_cls_infer.tar) / [训练模型](https://paddleocr.bj.bcebos.com/dygraph_v2.0/ch/ch_ppocr_mobile_v2.0_cls_train.tar)             |
 
 ## 4. Paddle-Lite 模型
 


### PR DESCRIPTION
## Summary

Fixes three relative markdown links that fail the repo link checker (reported in #18103). Each file already had a correct sibling link for the same target; this PR aligns the broken references with those paths.

## Problem

From `docs/version2.x/ppocr/model_compress/knowledge_distillation.{md,en.md}`, the first `distillation_model.py` link used `../../ppocr/...`, which resolves to `docs/version2.x/ppocr/modeling/...` (non-existent). The same pages link the file correctly later with `../../../../ppocr/modeling/architectures/distillation_model.py`.

In `docs/version2.x/ppocr/model_list.md`, the `ch_ppocr_mobile_v2.0_cls` config link used `../../../../configs/cls/cls_mv3.yml` (one `../` too many, resolving outside the repo). The slim variant on the preceding row already uses `../../../configs/cls/cls_mv3.yml`.

## Solution

- `knowledge_distillation.md` / `.en.md`: change the early `distillation_model.py` link to `../../../../ppocr/modeling/architectures/distillation_model.py`.
- `model_list.md`: change the `ch_ppocr_mobile_v2.0_cls` config link to `../../../configs/cls/cls_mv3.yml`.

## Out of scope

- External 404s (BOS model tarballs, PaddleSlim anchors, etc.) from the same link-check report.
- Other `../../../../configs/...` links under `model_train/` subdirs — those paths are depth-correct for their directory.

## Test plan

- [x] `realpath` from each doc directory confirms all three links resolve to `ppocr/modeling/architectures/distillation_model.py` and `configs/cls/cls_mv3.yml`.
- [ ] CI link checker on the next scheduled run.

## Related

- #18103 — automated link checker report listing these broken file paths

Made with [Cursor](https://cursor.com)