### PR TITLE
fix: restore global_step from .states when resuming training

### DIFF
--- a/ppocr/utils/save_load.py
+++ b/ppocr/utils/save_load.py
@@ -90,6 +90,8 @@ def load_model(config, model, optimizer=None, model_type="det"):
                 best_model_dict = states_dict.get("best_model_dict", {})
                 if "epoch" in states_dict:
                     best_model_dict["start_epoch"] = states_dict["epoch"] + 1
+                if "global_step" in states_dict:
+                    best_model_dict["global_step"] = states_dict["global_step"]
             logger.info("resume from {}".format(checkpoints))
 
             if optimizer is not None:
@@ -160,6 +162,8 @@ def load_model(config, model, optimizer=None, model_type="det"):
             best_model_dict["acc"] = 0.0
             if "epoch" in states_dict:
                 best_model_dict["start_epoch"] = states_dict["epoch"] + 1
+            if "global_step" in states_dict:
+                best_model_dict["global_step"] = states_dict["global_step"]
         logger.info("resume from {}".format(checkpoints))
     elif pretrained_model:
         is_float16 = load_pretrained_params(model, pretrained_model)


### PR DESCRIPTION
## Summary

Closes #18108

`load_model()` in `ppocr/utils/save_load.py` correctly restores `start_epoch` from the `.states` file, but silently drops `global_step`. Because `program.train()` initialises `global_step` from `pre_best_model_dict["global_step"]` (lines 232–234), the counter resets to 0 on every resume — corrupting log timestamps, eval scheduling, VisualDL step indices, and checkpoint metadata.

## Root cause

Both code paths inside `load_model()` read the `.states` file and populate `best_model_dict`, but neither included:

```python
if "global_step" in states_dict:
    best_model_dict["global_step"] = states_dict["global_step"]
```

## Fix

Add the two-line restore to both paths:
1. The KIE path (`metric.states` — line ~92)
2. The main path (`.states` — line ~162)

No other logic changed. `program.train()` already has the consumer code; this patch just feeds it the correct value.

## Test plan
- [ ] Resume a training run from a checkpoint saved at step N; verify logs show `global_step` starting at N+1 instead of 1
- [ ] Verify no regression for fresh-start training (no `.states` file present)
- [ ] Verify KIE model resume also restores `global_step` correctly