### PR TITLE
Fix PaddleOCR-VL HPS pipeline not using the vLLM server

### DIFF
--- a/deploy/paddleocr_vl_docker/hps/prepare.sh
+++ b/deploy/paddleocr_vl_docker/hps/prepare.sh
@@ -53,6 +53,19 @@ sed -i.bak \
     "${PIPELINE_CONFIG}"
 rm -f "${PIPELINE_CONFIG}.bak"
 
+# Some SDKs (e.g. PaddleOCR-VL-1.6) ship a pipeline config with
+# `backend: native`, which makes the pipeline run the VLM inside the Triton
+# container instead of calling the dedicated vLLM server, resulting in much
+# higher latency and GPU memory usage. Patch the config to use the vLLM
+# server.
+if grep -qE '^\s*backend: native\s*$' "${PIPELINE_CONFIG}"; then
+    sed -i.bak \
+        -e 's|^\( *\)batch_size: -1$|\1batch_size: 4096|' \
+        -e 's|^\( *\)backend: native$|\1backend: vllm-server\n\1server_url: http://paddleocr-vlm-server:8080/v1|' \
+        "${PIPELINE_CONFIG}"
+    rm -f "${PIPELINE_CONFIG}.bak"
+fi
+
 VLM_NAME="$(_extract_vlm_name "${PIPELINE_CONFIG}")"
 if [ -z "${VLM_NAME}" ]; then
     echo "Failed to read VLM name from ${PIPELINE_CONFIG}" >&2

--- a/deploy/paddleocr_vl_docker/hps/prepare.sh
+++ b/deploy/paddleocr_vl_docker/hps/prepare.sh
@@ -53,11 +53,6 @@ sed -i.bak \
     "${PIPELINE_CONFIG}"
 rm -f "${PIPELINE_CONFIG}.bak"
 
-# Some SDKs (e.g. PaddleOCR-VL-1.6) ship a pipeline config with
-# `backend: native`, which makes the pipeline run the VLM inside the Triton
-# container instead of calling the dedicated vLLM server, resulting in much
-# higher latency and GPU memory usage. Patch the config to use the vLLM
-# server.
 if grep -qE '^\s*backend: native\s*$' "${PIPELINE_CONFIG}"; then
     sed -i.bak \
         -e 's|^\( *\)batch_size: -1$|\1batch_size: 4096|' \


### PR DESCRIPTION
The PaddleOCR-VL-1.6 HPS SDK ships a pipeline_config.yaml with `genai_config.backend: native`, which makes the pipeline run the VLM inside the Triton container instead of calling the dedicated vLLM server deployed by compose.yaml. The vLLM server stays completely idle while inference runs unbatched in the pipeline container, causing much higher latency (~10x slower per image in our tests) and ~2 GiB of extra GPU memory for the duplicated model weights.

Patch the config in prepare.sh to use `backend: vllm-server` with the compose service URL, matching the configuration shipped with the 1.5 SDK. Also restore batch_size from -1 to 4096 as in 1.5.