### PR TITLE
[BugFix] Fix root logger configuration being modified by PaddleOCR imports

### DIFF
--- a/paddleocr/__init__.py
+++ b/paddleocr/__init__.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging as _logging
+
+# Save root logger level before imports that may modify it
+_restore_root_level = _logging.getLogger().level
+_restore_root_handlers = list(_logging.getLogger().handlers)
+
 from paddlex.inference.utils.benchmark import benchmark
 
 from ._models import (
@@ -65,6 +71,16 @@ from ._api_client.models import (
 )
 from ._utils.logging import logger
 from ._version import version as __version__
+
+# Restore root logger state in case dependencies modified it
+_cur_handlers = list(_logging.getLogger().handlers)
+if len(_cur_handlers) != len(_restore_root_handlers) or any(
+    a is not b for a, b in zip(_cur_handlers, _restore_root_handlers)
+):
+    _logging.getLogger().handlers[:] = _restore_root_handlers
+_logging.getLogger().setLevel(_restore_root_level)
+
+del _logging, _restore_root_level, _restore_root_handlers, _cur_handlers
 
 
 def doc2md_convert(source, **kwargs):

--- a/tests/unit/test_logging_restore.py
+++ b/tests/unit/test_logging_restore.py
@@ -1,0 +1,70 @@
+"""Tests for root logger state preservation during paddleocr imports."""
+
+import logging
+import io
+
+
+def _simulate_import_chain(restore_root_level, restore_root_handlers):
+    """Simulate the save/restore logic used in paddleocr/__init__.py."""
+    cur_handlers = list(logging.getLogger().handlers)
+    if len(cur_handlers) != len(restore_root_handlers) or any(
+        a is not b for a, b in zip(cur_handlers, restore_root_handlers)
+    ):
+        logging.getLogger().handlers[:] = restore_root_handlers
+    logging.getLogger().setLevel(restore_root_level)
+
+
+def test_root_logger_level_is_restored_after_simulated_imports():
+    root_logger = logging.getLogger()
+    orig_level = root_logger.level
+
+    saved_level = root_logger.level
+    saved_handlers = list(root_logger.handlers)
+
+    root_logger.setLevel(logging.WARNING)
+
+    _simulate_import_chain(saved_level, saved_handlers)
+
+    assert root_logger.level == orig_level
+
+
+def test_root_logger_handlers_are_restored_after_simulated_addition():
+    root_logger = logging.getLogger()
+
+    orig_len = len(root_logger.handlers)
+    saved_level = root_logger.level
+    saved_handlers = list(root_logger.handlers)
+
+    extra = logging.StreamHandler(io.StringIO())
+    root_logger.addHandler(extra)
+
+    _simulate_import_chain(saved_level, saved_handlers)
+
+    assert len(root_logger.handlers) == orig_len
+    assert extra not in root_logger.handlers
+
+
+def test_root_logger_handlers_are_restored_after_simulated_removal():
+    root_logger = logging.getLogger()
+
+    orig_len = len(root_logger.handlers)
+    saved_level = root_logger.level
+    saved_handlers = list(root_logger.handlers)
+
+    root_logger.handlers[:] = []
+
+    _simulate_import_chain(saved_level, saved_handlers)
+
+    assert len(root_logger.handlers) == orig_len
+
+
+def test_no_op_when_root_logger_state_unchanged():
+    root_logger = logging.getLogger()
+
+    saved_level = root_logger.level
+    saved_handlers = list(root_logger.handlers)
+
+    _simulate_import_chain(saved_level, saved_handlers)
+
+    assert root_logger.level == saved_level
+    assert list(root_logger.handlers) == saved_handlers


### PR DESCRIPTION
## Motivation
Importing `paddleocr` triggers dependency imports (e.g., `paddlex`, `paddle`) that may modify the root logger's level or handlers. This causes issues where users who configure logging \*before\* importing PaddleOCR find their log output silenced after the import.

## Modifications
- `paddleocr/__init__.py`: Save the root logger's level and handler list before module imports, then restore them after all imports complete. This ensures PaddleOCR does not interfere with the calling application's logging configuration.
- `tests/unit/test_logging_restore.py`: Added unit tests validating the save/restore mechanism handles level changes, handler additions, handler removals, and the no-op case.

## Usage or Command
N/A

## Accuracy Tests
N/A - logging change only, no model accuracy impact.

## Checklist
- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `main` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

Closes #14955