### PR TITLE
fix: replace bare except with specific exception types

### DIFF
--- a/benchmark/PaddleOCR_DBNet/post_processing/__init__.py
+++ b/benchmark/PaddleOCR_DBNet/post_processing/__init__.py
@@ -9,5 +9,5 @@ def get_post_processing(config):
     try:
         cls = eval(config["type"])(**config["args"])
         return cls
-    except:
+    except (KeyError, TypeError, NameError):
         return None

--- a/ppstructure/table/table_master_match.py
+++ b/ppstructure/table/table_master_match.py
@@ -528,7 +528,7 @@ def merge_span_token(master_token_list):
             else:
                 new_master_token_list.append(master_token_list[pointer])
                 pointer += 1
-        except:
+        except IndexError:
             print("Break in merge...")
             break
     new_master_token_list.append("</tbody>")

--- a/ppstructure/table/tablepyxl/style.py
+++ b/ppstructure/table/tablepyxl/style.py
@@ -15,7 +15,7 @@ try:
     from openpyxl.styles.fills import FILL_SOLID
     from openpyxl.styles.numbers import FORMAT_CURRENCY_USD_SIMPLE, FORMAT_PERCENTAGE
     from openpyxl.styles.colors import BLACK
-except:
+except ImportError:
     import warnings
 
     warnings.warn(

--- a/tools/program.py
+++ b/tools/program.py
@@ -295,7 +295,7 @@ def train(
         extra_input = config["Architecture"]["algorithm"] in extra_input_models
     try:
         model_type = config["Architecture"]["model_type"]
-    except:
+    except KeyError:
         model_type = None
 
     algorithm = config["Architecture"]["algorithm"]

--- a/tools/train.py
+++ b/tools/train.py
@@ -185,7 +185,7 @@ def main(config, device, logger, vdl_writer):
             os.remove(
                 os.path.join(config["Global"]["save_model_dir"], "train_result.json")
             )
-        except:
+        except OSError:
             pass
     if use_amp:
         AMP_RELATED_FLAGS_SETTING = {}


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with specific exception types to improve code quality and follow Python best practices.

## Changes

- `tools/train.py`: `except:` → `except OSError:` (file removal)
- `tools/program.py`: `except:` → `except KeyError:` (dict access)
- `ppstructure/table/table_master_match.py`: `except:` → `except IndexError:` (list access)
- `benchmark/PaddleOCR_DBNet/post_processing/__init__.py`: `except:` → `except (KeyError, TypeError, NameError):` (eval operation)
- `ppstructure/table/tablepyxl/style.py`: `except:` → `except ImportError:` (optional dependency)

## Impact

- Improves exception handling specificity
- Prevents catching unintended exceptions (SystemExit, KeyboardInterrupt)
- Follows Python best practices for exception handling
- No functional changes, only error handling improvements

## Testing

- Local environment limitations - relying on CI/CD automated testing
- All changes are exception handling improvements with no logic changes