### PR TITLE
fix: map JSONL result HTTP errors to SDK errors

### DIFF
--- a/paddleocr/_api_client/_http.py
+++ b/paddleocr/_api_client/_http.py
@@ -191,7 +191,7 @@ class HTTPClient:
         except requests.ConnectionError as e:
             raise NetworkError(f"Connection failed: {e}") from e
         try:
-            resp.raise_for_status()
+            _raise_for_response(resp)
             lines = resp.text.strip().split("\n")
             results = []
             for line in lines:

--- a/tests/api_client/test_http.py
+++ b/tests/api_client/test_http.py
@@ -214,6 +214,19 @@ def test_error_mapping_500(mock_server):
         client.submit_url("PP-OCRv5", "https://example.test/file.pdf", {})
 
 
+def test_fetch_jsonl_maps_http_errors(mock_server):
+    base_url, handler = mock_server
+    handler.response_status = 404
+    handler.response_body = {"message": "Result expired"}
+    client = HTTPClient("token", base_url, timeout=5.0)
+
+    with pytest.raises(APIError) as exc_info:
+        client.fetch_jsonl(f"{base_url}/result.jsonl")
+
+    assert exc_info.value.status_code == 404
+    assert "Result expired" in str(exc_info.value)
+
+
 def test_paddleocr_client_requires_token(monkeypatch):
     monkeypatch.delenv("PADDLEOCR_ACCESS_TOKEN", raising=False)
     with pytest.raises(AuthError):


### PR DESCRIPTION
### Problem

The Python SDK documents that its errors inherit from `PaddleOCRAPIError`. Most synchronous HTTP paths enforce that contract through the shared response mapper, but `HTTPClient.fetch_jsonl()` calls `requests.Response.raise_for_status()` directly.

When a completed job's result URL is expired or object storage returns another non-2xx response, the method therefore leaks a raw `requests.HTTPError`. Callers catching `PaddleOCRAPIError` cannot handle that result-download failure consistently, and the behavior also differs from the asynchronous JSONL path.

### Fix

Route JSONL result response statuses through the existing `_raise_for_response()` helper before parsing. This preserves the HTTP status and API message in the SDK's typed `APIError`, without changing successful JSONL parsing.

The regression test serves a local 404 response with a `Result expired` message and verifies that `fetch_jsonl()` raises `APIError` with both the 404 status and response message.

### Validation

- `python -m pytest -q tests/api_client` — 27 passed
- `pre-commit run --files paddleocr/_api_client/_http.py tests/api_client/test_http.py` — all hooks passed
