### PR TITLE
docs: repair broken deployment and compression links

### DIFF
--- a/deploy/slim/prune/README.md
+++ b/deploy/slim/prune/README.md
@@ -48,7 +48,7 @@ sen.pickle(Dict){
         }
 ```
 
-加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/algo/algo.md#2-%E5%8D%B7%E7%A7%AF%E6%A0%B8%E5%89%AA%E8%A3%81%E5%8E%9F%E7%90%86)
+加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim敏感度剪裁原理](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md#23-基于敏感度剪裁卷积网络)
 
 进入PaddleOCR根目录，通过以下命令对模型进行敏感度分析训练：
 ```bash

--- a/deploy/slim/prune/README_en.md
+++ b/deploy/slim/prune/README_en.md
@@ -35,24 +35,26 @@ PaddleOCR also provides a series of [models](../../../doc/doc_en/models_list_en.
 
 ### 3. Pruning sensitivity analysis
 
-  After the pre-trained model is loaded, sensitivity analysis is performed on each network layer of the model to understand the redundancy of each network layer, and save a sensitivity file which named: sen.pickle.  After that, user could load the sensitivity file via the [methods provided by PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/paddleslim/prune/sensitive.py#L221) and determining the pruning ratio of each network layer automatically. For specific details of sensitivity analysis, see：[Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/en/tutorials/image_classification_sensitivity_analysis_tutorial_en.md)
-  The data format of sensitivity file：
+After the pre-trained model is loaded, sensitivity analysis is performed on each network layer of the model to understand the redundancy of each network layer, and save a sensitivity file which named: sen.pickle.  After that, user could load the sensitivity file via the [methods provided by PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/paddleslim/prune/sensitive.py#L221) and determining the pruning ratio of each network layer automatically. For specific details of sensitivity analysis, see：[Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/en/tutorials/image_classification_sensitivity_analysis_tutorial_en.md)
+The data format of sensitivity file：
 
-```
+```python
 sen.pickle(Dict){
               'layer_weight_name_0': sens_of_each_ratio(Dict){'pruning_ratio_0': acc_loss, 'pruning_ratio_1': acc_loss}
               'layer_weight_name_1': sens_of_each_ratio(Dict){'pruning_ratio_0': acc_loss, 'pruning_ratio_1': acc_loss}
           }
-example：
-          {
-              'conv10_expand_weights': {0.1: 0.006509952684312718, 0.2: 0.01827734339798862, 0.3: 0.014528405644659832, 0.6: 0.06536008804270439, 0.8: 0.11798612250664964, 0.7: 0.12391408417493704, 0.4: 0.030615754498018757, 0.5: 0.047105205602406594}
-              'conv10_linear_weights': {0.1: 0.05113190831455035, 0.2: 0.07705573833558801, 0.3: 0.12096721757739311, 0.6: 0.5135061352930738, 0.8: 0.7908166677143281, 0.7: 0.7272187676899062, 0.4: 0.1819252083008504, 0.5: 0.3728054727792405}
-          }
-  The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md)
 ```
 
-  The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/algo/algo.md#2-%E5%8D%B7%E7%A7%AF%E6%A0%B8%E5%89%AA%E8%A3%81%E5%8E%9F%E7%90%86)
+example：
 
+```python
+{
+    'conv10_expand_weights': {0.1: 0.006509952684312718, 0.2: 0.01827734339798862, 0.3: 0.014528405644659832, 0.6: 0.06536008804270439, 0.8: 0.11798612250664964, 0.7: 0.12391408417493704, 0.4: 0.030615754498018757, 0.5: 0.047105205602406594}
+    'conv10_linear_weights': {0.1: 0.05113190831455035, 0.2: 0.07705573833558801, 0.3: 0.12096721757739311, 0.6: 0.5135061352930738, 0.8: 0.7908166677143281, 0.7: 0.7272187676899062, 0.4: 0.1819252083008504, 0.5: 0.3728054727792405}
+}
+```
+
+The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md#23-基于敏感度剪裁卷积网络)
 
 Enter the PaddleOCR root directory，perform sensitivity analysis on the model with the following command：
 

--- a/docs/update/update.en.md
+++ b/docs/update/update.en.md
@@ -80,7 +80,7 @@ hide:
     - Set a default upper limit for MKL-DNN cache size to prevent unlimited growth, while also allowing users to configure cache capacity.
     - Updated default configurations for high-performance inference to support Paddle MKL-DNN acceleration and optimized the logic for automatic configuration selection for smarter choices.
     - Adjusted the logic for obtaining the default device to consider the actual support for computing devices by the installed Paddle framework, making program behavior more intuitive.
-    - Added Android example for PP-OCRv5. [Details](https://paddlepaddle.github.io/PaddleOCR/latest/en/version3.x/inference_deployment/cross_platform/android_deployment.html).
+    - Added Android example for PP-OCRv5. [Details](https://paddlepaddle.github.io/PaddleOCR/v3.0.2/en/version3.x/deployment/on_device_deployment.html).
 
 - **Bug Fixes:**
 

--- a/docs/update/update.en.md
+++ b/docs/update/update.en.md
@@ -80,7 +80,7 @@ hide:
     - Set a default upper limit for MKL-DNN cache size to prevent unlimited growth, while also allowing users to configure cache capacity.
     - Updated default configurations for high-performance inference to support Paddle MKL-DNN acceleration and optimized the logic for automatic configuration selection for smarter choices.
     - Adjusted the logic for obtaining the default device to consider the actual support for computing devices by the installed Paddle framework, making program behavior more intuitive.
-    - Added Android example for PP-OCRv5. [Details](https://paddlepaddle.github.io/PaddleOCR/latest/en/version3.x/inference_deployment/cross_platform/on_device_deployment.html).
+    - Added Android example for PP-OCRv5. [Details](https://paddlepaddle.github.io/PaddleOCR/latest/en/version3.x/inference_deployment/cross_platform/android_deployment.html).
 
 - **Bug Fixes:**
 

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -79,7 +79,7 @@ hide:
     -  为MKL-DNN缓存大小设置默认上界，防止缓存无限增长。同时，支持用户配置缓存容量。@timminator 
     - 更新高性能推理默认配置，支持Paddle MKL-DNN加速。优化高性能推理自动配置逻辑，支持更智能的配置选择。
     - 调整默认设备获取逻辑，考虑环境中安装的Paddle框架对计算设备的实际支持情况，使程序行为更符合直觉。
-    - 新增PP-OCRv5的Android端示例，[详情](https://paddlepaddle.github.io/PaddleOCR/latest/version3.x/inference_deployment/cross_platform/android_deployment.html)。
+    - 新增PP-OCRv5的Android端示例，[详情](https://paddlepaddle.github.io/PaddleOCR/v3.0.2/version3.x/deployment/on_device_deployment.html)。
 
 - **Bug修复：**
     - 修复PP-StructureV3部分CLI参数不生效的问题。

--- a/docs/update/update.md
+++ b/docs/update/update.md
@@ -79,7 +79,7 @@ hide:
     -  为MKL-DNN缓存大小设置默认上界，防止缓存无限增长。同时，支持用户配置缓存容量。@timminator 
     - 更新高性能推理默认配置，支持Paddle MKL-DNN加速。优化高性能推理自动配置逻辑，支持更智能的配置选择。
     - 调整默认设备获取逻辑，考虑环境中安装的Paddle框架对计算设备的实际支持情况，使程序行为更符合直觉。
-    - 新增PP-OCRv5的Android端示例，[详情](https://paddlepaddle.github.io/PaddleOCR/latest/version3.x/inference_deployment/cross_platform/on_device_deployment.html)。
+    - 新增PP-OCRv5的Android端示例，[详情](https://paddlepaddle.github.io/PaddleOCR/latest/version3.x/inference_deployment/cross_platform/android_deployment.html)。
 
 - **Bug修复：**
     - 修复PP-StructureV3部分CLI参数不生效的问题。

--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
@@ -210,7 +210,7 @@ Architecture:
 
 When the model is finally trained, it contains 3 sub-networks: `Teacher`, `Student`, `Student2`.
 
-The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](../../ppocr/modeling/architectures/distillation_model.py).
+The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py).
 The final model output is a dictionary, the key is the name of all the sub-networks, for example, here are `Student` and `Teacher`, and the value is the output of the corresponding sub-network,
 which can be `Tensor` (only the last layer of the network is returned) and `dict` (also returns the characteristic information in the middle).
 In the recognition task, in order to add more loss functions and ensure the scalability of the distillation method, the output of each sub-network is saved as a `dict`, which contains the sub-module output.

--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.en.md
@@ -210,7 +210,7 @@ Architecture:
 
 When the model is finally trained, it contains 3 sub-networks: `Teacher`, `Student`, `Student2`.
 
-The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py).
+The specific implementation code of the `DistillationModel` class can refer to [distillation_model.py](https://github.com/PaddlePaddle/PaddleOCR/blob/{{PADDLEOCR_GITHUB_REF}}/ppocr/modeling/architectures/distillation_model.py).
 The final model output is a dictionary, the key is the name of all the sub-networks, for example, here are `Student` and `Teacher`, and the value is the output of the corresponding sub-network,
 which can be `Tensor` (only the last layer of the network is returned) and `dict` (also returns the characteristic information in the middle).
 In the recognition task, in order to add more loss functions and ensure the scalability of the distillation method, the output of each sub-network is saved as a `dict`, which contains the sub-module output.
@@ -478,7 +478,7 @@ Architecture:
 
 ```
 
-The specific implementation code of the distillation model `DistillationModel` class can refer to [distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py).
+The specific implementation code of the distillation model `DistillationModel` class can refer to [distillation_model.py](https://github.com/PaddlePaddle/PaddleOCR/blob/{{PADDLEOCR_GITHUB_REF}}/ppocr/modeling/architectures/distillation_model.py).
 
 The final model output is a dictionary, the key is the name of all the sub-networks, for example, here are `Student` and `Teacher`, and the value is the output of the corresponding sub-network,
 which can be `Tensor` (only the last layer of the network is returned) and `dict` (also returns the characteristic information in the middle).

--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
@@ -201,7 +201,7 @@ Architecture:
 
 最终该模型训练时，包含3个子网络：`Teacher`, `Student`, `Student2`。
 
-蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../ppocr/modeling/architectures/distillation_model.py)。
+蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py)。
 
 最终模型`forward`输出为一个字典，key为所有的子网络名称，例如这里为`Student`与`Teacher`，value为对应子网络的输出，可以为`Tensor`（只返回该网络的最后一层）和`dict`（也返回了中间的特征信息）。
 

--- a/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
+++ b/docs/version2.x/ppocr/model_compress/knowledge_distillation.md
@@ -201,7 +201,7 @@ Architecture:
 
 最终该模型训练时，包含3个子网络：`Teacher`, `Student`, `Student2`。
 
-蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py)。
+蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](https://github.com/PaddlePaddle/PaddleOCR/blob/{{PADDLEOCR_GITHUB_REF}}/ppocr/modeling/architectures/distillation_model.py)。
 
 最终模型`forward`输出为一个字典，key为所有的子网络名称，例如这里为`Student`与`Teacher`，value为对应子网络的输出，可以为`Tensor`（只返回该网络的最后一层）和`dict`（也返回了中间的特征信息）。
 
@@ -466,7 +466,7 @@ Architecture:
 
 ```
 
-蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](../../../../ppocr/modeling/architectures/distillation_model.py)。
+蒸馏模型`DistillationModel`类的具体实现代码可以参考[distillation_model.py](https://github.com/PaddlePaddle/PaddleOCR/blob/{{PADDLEOCR_GITHUB_REF}}/ppocr/modeling/architectures/distillation_model.py)。
 
 最终模型`forward`输出为一个字典，key为所有的子网络名称，例如这里为`Student`与`Teacher`，value为对应子网络的输出，可以为`Tensor`（只返回该网络的最后一层）和`dict`（也返回了中间的特征信息）。
 

--- a/docs/version2.x/ppocr/model_compress/prune.en.md
+++ b/docs/version2.x/ppocr/model_compress/prune.en.md
@@ -53,7 +53,7 @@ example：
 
 The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md)
 
-The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/algo/algo.md#2-%E5%8D%B7%E7%A7%AF%E6%A0%B8%E5%89%AA%E8%A3%81%E5%8E%9F%E7%90%86)
+The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Pruning strategy overview](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/tutorials/pruning/overview.md#策略介绍)
 
 Enter the PaddleOCR root directory，perform sensitivity analysis on the model with the following command：
 

--- a/docs/version2.x/ppocr/model_compress/prune.en.md
+++ b/docs/version2.x/ppocr/model_compress/prune.en.md
@@ -51,9 +51,7 @@ example：
 }
 ```
 
-The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md)
-
-The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Pruning strategy overview](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/tutorials/pruning/overview.md#策略介绍)
+The function would return a dict after loading the sensitivity file. The keys of the dict are name of parameters in each layer. And the value of key is the information about pruning sensitivity of corresponding layer. In example, pruning 10% filter of the layer corresponding to conv10_expand_weights would lead to 0.65% degradation of model performance. The details could be seen at: [Sensitivity analysis](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md#23-基于敏感度剪裁卷积网络)
 
 Enter the PaddleOCR root directory，perform sensitivity analysis on the model with the following command：
 

--- a/docs/version2.x/ppocr/model_compress/prune.md
+++ b/docs/version2.x/ppocr/model_compress/prune.md
@@ -49,7 +49,7 @@ sen.pickle(Dict){
 }
 ```
 
-加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/algo/algo.md#2-%E5%8D%B7%E7%A7%AF%E6%A0%B8%E5%89%AA%E8%A3%81%E5%8E%9F%E7%90%86)
+加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim裁剪策略介绍](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/tutorials/pruning/overview.md#策略介绍)
 
 进入PaddleOCR根目录，通过以下命令对模型进行敏感度分析训练：
 

--- a/docs/version2.x/ppocr/model_compress/prune.md
+++ b/docs/version2.x/ppocr/model_compress/prune.md
@@ -49,7 +49,7 @@ sen.pickle(Dict){
 }
 ```
 
-加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim裁剪策略介绍](https://github.com/PaddlePaddle/PaddleSlim/blob/develop/docs/zh_cn/tutorials/pruning/overview.md#策略介绍)
+加载敏感度文件后会返回一个字典，字典中的keys为网络模型参数模型的名字，values为一个字典，里面保存了相应网络层的裁剪敏感度信息。例如在例子中，conv10_expand_weights所对应的网络层在裁掉10%的卷积核后模型性能相较原模型会下降0.65%，详细信息可见[PaddleSlim敏感度剪裁原理](https://github.com/PaddlePaddle/PaddleSlim/blob/release/2.0-alpha/docs/zh_cn/algo/algo.md#23-基于敏感度剪裁卷积网络)
 
 进入PaddleOCR根目录，通过以下命令对模型进行敏感度分析训练：
 


### PR DESCRIPTION
## Summary

Repairs broken and misleading deployment and compression links identified from the link-checker report in #18160 and the affected mirrored documentation:

- points the Chinese and English PP-OCRv5 Android release notes to the versioned v3.0.2 guides, rather than the current PP-OCRv6 Android page;
- replaces both Chinese and English `distillation_model.py` references with version-aware GitHub source links that resolve correctly in main and release documentation builds;
- removes the duplicated English pruning explanation and pins the pruning references to the exact PaddleSlim 2.0-alpha sensitivity-based pruning section;
- applies the same pruning-link and Markdown fixes to the mirrored deployment READMEs.

Refs #18160

## Verification

- Confirmed the Chinese and English v3.0.2 Android guides explicitly support `PP-OCRv5_mobile`.
- Confirmed the PaddleSlim link resolves to the `2.3 基于敏感度剪裁卷积网络` section.
- `pytest -q tests/tools/test_docs_github_links.py` passes (3 tests).
- `python tools/check_docs_github_links.py --root docs --repo-slug PaddlePaddle/PaddleOCR --forbidden-ref main --forbidden-ref master` passes.
- `ENABLE_GIT_PLUGINS=false mkdocs build -f mkdocs-ci.yml` passes.
- `git diff --check` passes.

This is a documentation-only change with no runtime or API impact.
